### PR TITLE
Switching to HTML base extraction

### DIFF
--- a/extract/extract/extractors/zalando.py
+++ b/extract/extract/extractors/zalando.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional
 
 from bs4 import BeautifulSoup
 from pydantic import ValidationError
+
 from core.domain import LabelIDType, Product
 
 from ..parse import JSON_LD, ParsedPage

--- a/extract/extract/extractors/zalando.py
+++ b/extract/extract/extractors/zalando.py
@@ -122,7 +122,7 @@ def __get_sustainability_info(
     beautiful_soup: BeautifulSoup,
     title_attr: str,
     description_attr: str,
-    certificate_attr: str = "cluster-certificates",
+    certificate_attr: str,
 ) -> Dict[str, str]:
     """
     Helper function to extract sustainability information.
@@ -131,18 +131,15 @@ def __get_sustainability_info(
         beautiful_soup (BeautifulSoup): Parsed HTML
         title_attr (str): HTML attr of title
         description_attr (str): HTML attr of description
-        certificate_attr (str, optional): HTML attr of certificate. Defaults to
-            "cluster-certificates".
+        certificate_attr (str, optional): HTML attr of certificate.
 
     Returns:
         Dict[str, str]: `dict` with name and description of found sustainability information
     """
 
     # this area is hidden by default, so we need to find the right one
-    hidden_area = beautiful_soup.find("div", attrs={"data-testid": certificate_attr})
-
-    if hidden_area:
-        sustainability_info_parsed = hidden_area
+    if sustainability_info_parsed := beautiful_soup.find("div",
+                                                         attrs={"data-testid": certificate_attr}):
 
         titles = sustainability_info_parsed.find_all(attrs={"data-testid": title_attr})
         descriptions = sustainability_info_parsed.find_all(attrs={"data-testid": description_attr})
@@ -150,8 +147,8 @@ def __get_sustainability_info(
         return {
             title.string: description.string for title, description in zip(titles, descriptions)
         }
-
-    return {}
+    else:
+        return {}
 
 
 def _get_sustainability(

--- a/extract/extract/extractors/zalando.py
+++ b/extract/extract/extractors/zalando.py
@@ -142,13 +142,10 @@ def __get_sustainability_info(
     """
 
     # this area is hidden by default, so we need to find the right one
-    hidden_areas = [
-        div
-        for div in beautiful_soup.find_all("div", attrs={"data-testid": certificate_attr})
-    ]
+    hidden_area = beautiful_soup.find("div", attrs={"data-testid": certificate_attr})
 
-    if hidden_areas:
-        sustainability_info_parsed = hidden_areas[0]
+    if hidden_area:
+        sustainability_info_parsed = hidden_area
 
         titles = sustainability_info_parsed.find_all(attrs={"data-testid": title_attr})
         descriptions = sustainability_info_parsed.find_all(attrs={"data-testid": description_attr})
@@ -157,8 +154,7 @@ def __get_sustainability_info(
             title.string: description.string for title, description in zip(titles, descriptions)
         }
 
-    else:
-        return {}
+    return {}
 
 
 def _get_sustainability(

--- a/extract/extract/extractors/zalando.py
+++ b/extract/extract/extractors/zalando.py
@@ -138,8 +138,9 @@ def __get_sustainability_info(
     """
 
     # this area is hidden by default, so we need to find the right one
-    if sustainability_info_parsed := beautiful_soup.find("div",
-                                                         attrs={"data-testid": certificate_attr}):
+    if sustainability_info_parsed := beautiful_soup.find(
+        "div", attrs={"data-testid": certificate_attr}
+    ):
 
         titles = sustainability_info_parsed.find_all(attrs={"data-testid": title_attr})
         descriptions = sustainability_info_parsed.find_all(attrs={"data-testid": description_attr})

--- a/extract/extract/extractors/zalando.py
+++ b/extract/extract/extractors/zalando.py
@@ -110,7 +110,8 @@ _LABEL_MAPPING = {
     "OCS - Organic Content Standard": LabelIDType.OCS_100,
     "Hergestellt aus mindestens 50% nachhaltigerer Baumwolle": LabelIDType.OTHER,
     "Zum Wohl der Tierwelt": LabelIDType.OTHER,
-    "Hergestellt aus mindestens 20% innovativen ökologischen Alternativen zu fossilen Brennstoffen": LabelIDType.OTHER,  # noqa
+    "Hergestellt aus mindestens 20% innovativen ökologischen Alternativen zu fossilen Brennstoffen": LabelIDType.OTHER,
+    # noqa
     "Natürlich": LabelIDType.OTHER,
     "Hergestellt aus recyceltem Gummi": LabelIDType.OTHER,
     "Hergestellt aus LENZING™ TENCEL™, einem Eco-Material": LabelIDType.OTHER,
@@ -122,7 +123,7 @@ def __get_sustainability_info(
     beautiful_soup: BeautifulSoup,
     title_attr: str,
     description_attr: str,
-    headline: str = "Dieser Artikel erfüllt die folgenden Nachhaltigkeits-Kriterien:",
+    certificate_attr: str = "cluster-certificates",
 ) -> Dict[str, str]:
     """
     Helper function to extract sustainability information.
@@ -131,8 +132,8 @@ def __get_sustainability_info(
         beautiful_soup (BeautifulSoup): Parsed HTML
         title_attr (str): HTML attr of title
         description_attr (str): HTML attr of description
-        headline (str, optional): Headline on webpage. Defaults to
-            "Dieser Artikel erfüllt die folgenden Nachhaltigkeits-Kriterien:".
+        certificate_attr (str, optional): HTML attr of certificate. Defaults to
+            "cluster-certificates".
 
     Returns:
         Dict[str, str]: `dict` with name and description of found sustainability information
@@ -141,8 +142,7 @@ def __get_sustainability_info(
     # this area is hidden by default, so we need to find the right one
     hidden_areas = [
         div
-        for div in beautiful_soup.find_all("div", attrs={"style": "max-height:0"})
-        if headline in div.text
+        for div in beautiful_soup.find_all("div", attrs={"data-testid": certificate_attr})
     ]
 
     if hidden_areas:
@@ -160,16 +160,16 @@ def __get_sustainability_info(
 
 
 def _get_sustainability(
-    beautiful_soup: BeautifulSoup,
-    headline: str = "Dieser Artikel erfüllt die folgenden Nachhaltigkeits-Kriterien:",
+        beautiful_soup: BeautifulSoup,
+        certificate_attr: str = "cluster-certificates",
 ) -> List[str]:
     """
     Extracts the sustainability information from HTML.
 
     Args:
         beautiful_soup (BeautifulSoup): Parsed HTML
-        headline (str, optional): Headline on webpage. Defaults to
-            "Dieser Artikel erfüllt die folgenden Nachhaltigkeits-Kriterien:".
+        certificate_attr (str, optional): HTML attr of certificate. Defaults to
+            "cluster-certificates".
 
     Returns:
         List[str]: Ordered `list` of found sustainability labels
@@ -180,19 +180,19 @@ def _get_sustainability(
             beautiful_soup=beautiful_soup,
             title_attr="certificate__title",
             description_attr="certificate__description",
-            headline=headline,
+            certificate_attr=certificate_attr,
         ),
         "impact": __get_sustainability_info(
             beautiful_soup=beautiful_soup,
             title_attr="cluster-causes__title",
             description_attr="cluster-causes__intro-statement",
-            headline=headline,
+            certificate_attr=certificate_attr,
         ),
         "aspects": __get_sustainability_info(
             beautiful_soup=beautiful_soup,
             title_attr="cause__title",
             description_attr="cause__description",
-            headline=headline,
+            certificate_attr=certificate_attr,
         ),
     }
 

--- a/extract/extract/extractors/zalando.py
+++ b/extract/extract/extractors/zalando.py
@@ -2,9 +2,8 @@ from logging import getLogger
 from typing import Dict, List, Optional
 
 from bs4 import BeautifulSoup
-from pydantic import ValidationError
-
 from core.domain import LabelIDType, Product
+from pydantic import ValidationError
 
 from ..parse import JSON_LD, ParsedPage
 from ..utils import safely_return_first_element
@@ -82,8 +81,7 @@ _LABEL_MAPPING = {
     "Weniger Verpackung": LabelIDType.OTHER,
     "Better Cotton Initiative": LabelIDType.BCI,
     "Hergestellt aus 50-70% recycelten Materialien": LabelIDType.OTHER,
-    "Hergestellt aus mindestens 50% verantwortungsbewussten forstbasierten Materialien":
-        LabelIDType.OTHER, # noqa
+    "Hergestellt aus mindestens 50% verantwortungsbewussten forstbasierten Materialien": LabelIDType.OTHER,  # noqa
     "Hergestellt aus 30-50% recycelten Materialien": LabelIDType.OTHER,
     "Sustainable Textile Production (STeP) by OEKO-TEX®": LabelIDType.STEP_OEKO_TEX,
     "Global Recycled Standard": LabelIDType.GRS,
@@ -107,13 +105,11 @@ _LABEL_MAPPING = {
     "Leather Working Group": LabelIDType.LWG,
     "Hergestellt aus mindestens 20% innovativen Leder-Alternativen": LabelIDType.OTHER,
     "Hergestellt aus mindestens 50% Polyurethanen auf Wasserbasis": LabelIDType.OTHER,
-    "Hergestellt aus mindestens 20% innovativen Materialien aus recyceltem Müll":
-        LabelIDType.OTHER,  # noqa
+    "Hergestellt aus mindestens 20% innovativen Materialien aus recyceltem Müll": LabelIDType.OTHER,  # noqa
     "OCS - Organic Content Standard": LabelIDType.OCS_100,
     "Hergestellt aus mindestens 50% nachhaltigerer Baumwolle": LabelIDType.OTHER,
     "Zum Wohl der Tierwelt": LabelIDType.OTHER,
-    "Hergestellt aus mindestens 20% innovativen ökologischen Alternativen zu fossilen Brennstoffen":
-        LabelIDType.OTHER,  # noqa
+    "Hergestellt aus mindestens 20% innovativen ökologischen Alternativen zu fossilen Brennstoffen": LabelIDType.OTHER,  # noqa
     "Natürlich": LabelIDType.OTHER,
     "Hergestellt aus recyceltem Gummi": LabelIDType.OTHER,
     "Hergestellt aus LENZING™ TENCEL™, einem Eco-Material": LabelIDType.OTHER,

--- a/extract/extract/extractors/zalando.py
+++ b/extract/extract/extractors/zalando.py
@@ -2,8 +2,8 @@ from logging import getLogger
 from typing import Dict, List, Optional
 
 from bs4 import BeautifulSoup
-from core.domain import LabelIDType, Product
 from pydantic import ValidationError
+from core.domain import LabelIDType, Product
 
 from ..parse import JSON_LD, ParsedPage
 from ..utils import safely_return_first_element

--- a/extract/extract/extractors/zalando.py
+++ b/extract/extract/extractors/zalando.py
@@ -160,8 +160,8 @@ def __get_sustainability_info(
 
 
 def _get_sustainability(
-        beautiful_soup: BeautifulSoup,
-        certificate_attr: str = "cluster-certificates",
+    beautiful_soup: BeautifulSoup,
+    certificate_attr: str = "cluster-certificates",
 ) -> List[str]:
     """
     Extracts the sustainability information from HTML.

--- a/extract/extract/extractors/zalando.py
+++ b/extract/extract/extractors/zalando.py
@@ -82,7 +82,8 @@ _LABEL_MAPPING = {
     "Weniger Verpackung": LabelIDType.OTHER,
     "Better Cotton Initiative": LabelIDType.BCI,
     "Hergestellt aus 50-70% recycelten Materialien": LabelIDType.OTHER,
-    "Hergestellt aus mindestens 50% verantwortungsbewussten forstbasierten Materialien": LabelIDType.OTHER,  # noqa
+    "Hergestellt aus mindestens 50% verantwortungsbewussten forstbasierten Materialien":
+        LabelIDType.OTHER, # noqa
     "Hergestellt aus 30-50% recycelten Materialien": LabelIDType.OTHER,
     "Sustainable Textile Production (STeP) by OEKO-TEX®": LabelIDType.STEP_OEKO_TEX,
     "Global Recycled Standard": LabelIDType.GRS,
@@ -106,12 +107,13 @@ _LABEL_MAPPING = {
     "Leather Working Group": LabelIDType.LWG,
     "Hergestellt aus mindestens 20% innovativen Leder-Alternativen": LabelIDType.OTHER,
     "Hergestellt aus mindestens 50% Polyurethanen auf Wasserbasis": LabelIDType.OTHER,
-    "Hergestellt aus mindestens 20% innovativen Materialien aus recyceltem Müll": LabelIDType.OTHER,  # noqa
+    "Hergestellt aus mindestens 20% innovativen Materialien aus recyceltem Müll":
+        LabelIDType.OTHER,  # noqa
     "OCS - Organic Content Standard": LabelIDType.OCS_100,
     "Hergestellt aus mindestens 50% nachhaltigerer Baumwolle": LabelIDType.OTHER,
     "Zum Wohl der Tierwelt": LabelIDType.OTHER,
-    "Hergestellt aus mindestens 20% innovativen ökologischen Alternativen zu fossilen Brennstoffen": LabelIDType.OTHER,
-    # noqa
+    "Hergestellt aus mindestens 20% innovativen ökologischen Alternativen zu fossilen Brennstoffen":
+        LabelIDType.OTHER,  # noqa
     "Natürlich": LabelIDType.OTHER,
     "Hergestellt aus recyceltem Gummi": LabelIDType.OTHER,
     "Hergestellt aus LENZING™ TENCEL™, einem Eco-Material": LabelIDType.OTHER,


### PR DESCRIPTION
Before, we used displayed strings to find the area of interest. For other languages, this won't work.
This one improves the Zalando extractor by using HTML tags that are, hopefully, also available in other languages.