### PR TITLE
fix url on splash responses

### DIFF
--- a/scraping/scraping/splash.py
+++ b/scraping/scraping/splash.py
@@ -21,6 +21,9 @@ function main(splash, args)
         splash:wait(args.wait)
     end
     splash:wait(args.wait)
-    return splash:html()
+    return {
+        url = splash:url(),
+        html = splash:html(),
+    }
 end
 """


### PR DESCRIPTION
if splash gets redirected while rendering a page, response.url will not be updated.
this breaks the zalando scrapers which use response.url do detect redirection.
to fix this the splash lua script needs to return the updated URL.