### PR TITLE
Fix finding product urls for otto.

### DIFF
--- a/scraping/scraping/spiders/otto.py
+++ b/scraping/scraping/spiders/otto.py
@@ -22,6 +22,7 @@ class OttoSpider(BaseSpider):
 
         # Get all unique links
         all_links = list(set(response.css("[href]::attr(href)").getall()))
+
         # Filter for product links
         all_product_links = [
             response.urljoin(link)
@@ -29,7 +30,6 @@ class OttoSpider(BaseSpider):
             if "/#variationId=" in link and "/p/" in link
         ]
 
-        # If set a subset of the products are scraped
         if self.products_per_page:
             all_product_links = all_product_links[: self.products_per_page]
 

--- a/scraping/scraping/spiders/otto.py
+++ b/scraping/scraping/spiders/otto.py
@@ -23,7 +23,11 @@ class OttoSpider(BaseSpider):
         # Get all unique links
         all_links = list(set(response.css("[href]::attr(href)").getall()))
         # Filter for product links
-        all_product_links = [response.urljoin(link) for link in all_links if "#variation" in link]
+        all_product_links = [
+            response.urljoin(link)
+            for link in all_links
+            if "/#variationId=" in link and "/p/" in link
+        ]
 
         # If set a subset of the products are scraped
         if self.products_per_page:

--- a/scraping/scraping/spiders/otto.py
+++ b/scraping/scraping/spiders/otto.py
@@ -20,12 +20,10 @@ class OttoSpider(BaseSpider):
         # Save HTML to database
         self._save_SERP(response)
 
-        # most links are lazy loaded
-        all_product_links = response.css('[class*="productLink"]::attr(href)').getall()
-        all_product_links = list(set(all_product_links))
-
-        # Scrape products on page to database
-        all_product_links = [response.urljoin(link) for link in all_product_links]
+        # Get all unique links
+        all_links = list(set(response.css("[href]::attr(href)").getall()))
+        # Filter for product links
+        all_product_links = [response.urljoin(link) for link in all_links if "#variation" in link]
 
         # If set a subset of the products are scraped
         if self.products_per_page:


### PR DESCRIPTION
The HTML of otto changed, breaking our method to retrieve product urls. This one fixes it with a method, which is independent of the html structure, but relying on a specific format of the product url.