### PR TITLE
set Accept-Language to all

### DIFF
--- a/scraping/scraping/settings.py
+++ b/scraping/scraping/settings.py
@@ -39,7 +39,7 @@ DOWNLOAD_DELAY = 15
 
 # Override the default request headers:
 DEFAULT_REQUEST_HEADERS = {
-    "Accept-Language": "de",  # We are interested in getting german sites
+    "Accept-Language": "*",  # We are interested in getting all sites
 }
 
 # Enable or disable spider middlewares


### PR DESCRIPTION
Accept-Language was set to german. this may cause non german sites to redirect to a german version.
setting Accept-Language to * should prevent this.
#51 