### PR TITLE
Misc changes to speedup scraping

### DIFF
--- a/scraping/scraping/settings.py
+++ b/scraping/scraping/settings.py
@@ -26,7 +26,8 @@ ROBOTSTXT_OBEY = True
 # Configure a delay for requests for the same website (default: 0)
 # See https://docs.scrapy.org/en/latest/topics/settings.html#download-delay
 # See also autothrottle settings and docs
-DOWNLOAD_DELAY = 15
+DOWNLOAD_DELAY = 5
+
 # The download delay setting will honor only one of:
 # CONCURRENT_REQUESTS_PER_DOMAIN = 16
 # CONCURRENT_REQUESTS_PER_IP = 16
@@ -39,7 +40,7 @@ DOWNLOAD_DELAY = 15
 
 # Override the default request headers:
 DEFAULT_REQUEST_HEADERS = {
-    "Accept-Language": "de",  # We are interested in getting german sites
+    "Accept-Language": "*",
 }
 
 # Enable or disable spider middlewares

--- a/scraping/scraping/spiders/asos.py
+++ b/scraping/scraping/spiders/asos.py
@@ -36,7 +36,6 @@ class AsosSpider(BaseSpider):
 
     custom_settings = {
         "DEFAULT_REQUEST_HEADERS": headers,
-        "DOWNLOAD_DELAY": 15,  # decrease this to increase speed
     }
 
     def start_requests(self) -> Iterator[ScrapyHttpRequest]:

--- a/scraping/scrapy.cfg
+++ b/scraping/scrapy.cfg
@@ -10,6 +10,6 @@ default = scraping.settings
 url = http://localhost:6800
 project = scraping
 
-[deploy:local]
+[deploy:in-cluster]
 url = http://scrapyd:6800
-project = local_scraping
+project = scraping

--- a/start-job/scripts/entrypoint.sh
+++ b/start-job/scripts/entrypoint.sh
@@ -1,12 +1,17 @@
 #!/bin/sh
 
+# clone green-db repositore
 cd /
 git clone https://github.com/calgo-lab/green-db.git
+
+# install necessary dependencies
 cd /green-db/core
 poetry build -f wheel && pip install --no-deps dist/*.whl 
 
+# deploy to scrapyd
+cd /green-db/scraping
 scrapyd-client deploy in-cluster
 
-# finally start all scraping jobs
+# and finally start all scraping jobs
 cd /workdir/scripts
 python main.py

--- a/start-job/scripts/entrypoint.sh
+++ b/start-job/scripts/entrypoint.sh
@@ -5,16 +5,6 @@ git clone https://github.com/calgo-lab/green-db.git
 cd /green-db/core
 poetry build -f wheel && pip install --no-deps dist/*.whl 
 
-# Add a ne Scrapy target that works in the cluster.
-# Important: url need to be `scrapy`, which is the service name and project name is scraping
-cd /green-db/scraping
-cat <<EOF >> scrapy.cfg
-
-[deploy:in-cluster]
-url = http://scrapyd:6800
-project = scraping
-EOF
-
 scrapyd-client deploy in-cluster
 
 # finally start all scraping jobs

--- a/start-job/scripts/main.py
+++ b/start-job/scripts/main.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 import subprocess
+from collections import deque
 from configparser import ConfigParser
 from datetime import datetime
+from typing import Any, List
 
 from asos import get_settings as get_asos_settings
 from otto import get_settings as get_otto_settings
@@ -15,12 +19,12 @@ from core.constants import (
 )
 
 START_TIMESTAMP = datetime.utcnow()
-SETTINGS = {
-    TABLE_NAME_SCRAPING_OTTO: get_otto_settings(),
-    TABLE_NAME_SCRAPING_ZALANDO: get_zalando_settings(),
-    TABLE_NAME_SCRAPING_ASOS: get_asos_settings(),
-    TABLE_NAME_SCRAPING_ZALANDO_FR: get_zalando_fr_settings(),
-}
+SETTINGS = (
+    [(TABLE_NAME_SCRAPING_ASOS, x) for x in get_asos_settings()],
+    [(TABLE_NAME_SCRAPING_OTTO, x) for x in get_otto_settings()],
+    [(TABLE_NAME_SCRAPING_ZALANDO, x) for x in get_zalando_settings()],
+    [(TABLE_NAME_SCRAPING_ZALANDO_FR, x) for x in get_zalando_fr_settings()],
+)
 
 # Read scrapy config and get target URL for local
 scrapy_config_parser = ConfigParser()
@@ -28,17 +32,44 @@ scrapy_config_parser.read("/green-db/scraping/scrapy.cfg")  # Repo get cloned
 SCRAPYD_CLUSTER_TARGET = scrapy_config_parser.get("deploy:in-cluster", "url")
 
 
+class RoundRobinIterator(object):
+    """
+    `RoundRobinIterator` iterates over the given `lists` in a round robin fashion.
+    First elements of `lists`, second elements of `lists`, ...
+
+    Args:
+        lists (List[Any]): `RoundRobinIterator` will output elements of `lists`
+            one after another.
+    """
+
+    def __init__(self, *lists: List[Any]) -> None:
+        self._lists = [x for x in lists if type(x) == list and len(x) > 0]
+        self._deque = deque([[i, 0] for i in range(len(self._lists))])
+
+    def __iter__(self) -> RoundRobinIterator:
+        return self
+
+    def __next__(self) -> Any:
+        if bool(self._deque):
+            current_list, current_index = self._deque.popleft()
+            if current_index + 1 != len(self._lists[current_list]):
+                self._deque.append([current_list, current_index + 1])
+            return self._lists[current_list][current_index]
+        else:
+            raise StopIteration
+
+
 if __name__ == "__main__":
 
-    for merchant, settings in SETTINGS.items():
-        for setting in settings:
-            url = setting["start_urls"]
-            category = setting["category"]
-            meta_data = setting["meta_data"]
+    # Using `RoundRobinIterator` helps to mix the shops and increases scraping speed
+    # since we can request them in parallel but throttle for same domain.
+    for merchant, setting in RoundRobinIterator(*SETTINGS):
+        url = setting["start_urls"]
+        category = setting["category"]
+        meta_data = setting["meta_data"]
 
-            # -t in-cluster gets pachted by entrypoint.sh...
-            command = f"scrapyd-client -t {SCRAPYD_CLUSTER_TARGET} schedule -p scraping --arg start_urls='{url}' \
-            --arg category='{category}' --arg timestamp='{START_TIMESTAMP}' \
-            --arg meta_data='{meta_data}' {merchant}"
-            output = subprocess.run(command, shell=True, capture_output=True)
-            print(output.stdout.decode("utf-8"))
+        command = f"scrapyd-client -t {SCRAPYD_CLUSTER_TARGET} schedule -p scraping --arg start_urls='{url}' \
+        --arg category='{category}' --arg timestamp='{START_TIMESTAMP}' \
+        --arg meta_data='{meta_data}' {merchant}"
+        output = subprocess.run(command, shell=True, capture_output=True)
+        print(output.stdout.decode("utf-8"))

--- a/start-job/scripts/zalando.py
+++ b/start-job/scripts/zalando.py
@@ -17,16 +17,13 @@ def combine_results(
     results = []
     for path, info in path_2_category.items():
         category, meta_data = info if type(info) == tuple else (info, {})
-        for filter in filters:
-            results.append(
-                {
-                    "start_urls": f"https://www.zalando.de/{path}/?cause={filter}",
-                    "category": category,
-                    "meta_data": json.dumps(
-                        {"family": "FASHION", "sustainability": filter, "sex": sex, **meta_data}
-                    ),
-                }
-            )
+        results.append(
+            {
+                "start_urls": f"https://www.zalando.de/{path}/?cause={'.'.join(filters)}",
+                "category": category,
+                "meta_data": json.dumps({"family": "FASHION", "sex": sex, **meta_data}),
+            }
+        )
     return results
 
 

--- a/start-job/scripts/zalando_fr.py
+++ b/start-job/scripts/zalando_fr.py
@@ -17,16 +17,13 @@ def combine_results(
     results = []
     for path, info in path_2_category.items():
         category, meta_data = info if type(info) == tuple else (info, {})
-        for filter in filters:
-            results.append(
-                {
-                    "start_urls": f"https://www.zalando.fr/{path}/?cause={filter}",
-                    "category": category,
-                    "meta_data": json.dumps(
-                        {"family": "FASHION", "sustainability": filter, "sex": sex, **meta_data}
-                    ),
-                }
-            )
+        results.append(
+            {
+                "start_urls": f"https://www.zalando.fr/{path}/?cause={'.'.join(filters)}",
+                "category": category,
+                "meta_data": json.dumps({"family": "FASHION", "sex": sex, **meta_data}),
+            }
+        )
     return results
 
 


### PR DESCRIPTION
I recognized that the scraping took very long. This PR bundles some speedup ideas:
- decrease waiting time (for the same domain)
- make sure we start different spiders because scrapy can parallelize more if it has to scrape different domains.
