### PR TITLE
add otto EU_ENERGY_LABEL extraction for electronics

### DIFF
--- a/extract/extract/extractors/otto.py
+++ b/extract/extract/extractors/otto.py
@@ -266,6 +266,8 @@ def _get_energy_labels(product_data: dict) -> List[str]:
             case [*json_array]:
                 json_values += json_array
 
+    # Adding the prefix "EU Energy label" to allow automated mapping,
+    # see file: core.sustainability_labels.sustainability_labels.json
     return [f"EU Energy label {letter}" for letter in energy_labels]
 
 

--- a/extract/extract/extractors/otto.py
+++ b/extract/extract/extractors/otto.py
@@ -240,7 +240,7 @@ def _get_sustainability_info(beautiful_soup: BeautifulSoup) -> dict:
     return_value = dict()
 
     for label_html in beautiful_soup.find_all(
-            "div", attrs={"class": "prd_sustainabilityLayer__label"}
+        "div", attrs={"class": "prd_sustainabilityLayer__label"}
     ):
         name = label_html.find("div", attrs={"class": "prd_sustainabilityLayer__caption"})
         description = label_html.find(
@@ -277,10 +277,9 @@ def _get_energy_labels(product_data: dict) -> List[str]:
 
     for json_value in json_values:
         match json_value:
-            case {"showNewEnergyLabelInfoLayer": True,
-                  "energyEfficiencyClasses": [*attributes]}:
+            case {"showNewEnergyLabelInfoLayer": True, "energyEfficiencyClasses": [*attributes]}:
                 for attribute in attributes:
-                    energy_labels.append(attribute.get('energyLabel', {}).get('letter'))
+                    energy_labels.append(attribute.get("energyLabel", {}).get("letter"))
             case {**json_object}:
                 json_values += json_object.values()
             case [*json_array]:
@@ -312,5 +311,7 @@ def _get_sustainability(product_data: dict, parsed_url: ParseResult) -> List[str
         sustainable_soup = BeautifulSoup(sustainability_information_html, "html.parser")
         labels.update(_get_sustainability_info(sustainable_soup))
 
-    return sorted({_LABEL_MAPPING.get(label, CertificateType.UNKNOWN) for label in labels.keys()} |
-                  {_LABEL_MAPPING_ENERGY.get(label) for label in energy_labels})
+    return sorted(
+        {_LABEL_MAPPING.get(label, CertificateType.UNKNOWN) for label in labels.keys()}
+        | {_LABEL_MAPPING_ENERGY.get(label) for label in energy_labels}
+    )

--- a/extract/extract/extractors/otto.py
+++ b/extract/extract/extractors/otto.py
@@ -119,6 +119,7 @@ _LABEL_MAPPING = {
     "Bio-Siegel": CertificateType.OTHER,
     "bioRe® Sustainable Textiles Standard": CertificateType.BIORE,
     "[REE]GROW": CertificateType.OTHER,
+    "Energieeffizientes Gerät": CertificateType.OTHER,
     "Birla Viscose": CertificateType.OTHER,
     "": CertificateType.OTHER,
 }

--- a/extract/extract/extractors/otto.py
+++ b/extract/extract/extractors/otto.py
@@ -119,7 +119,6 @@ _LABEL_MAPPING = {
     "Bio-Siegel": CertificateType.OTHER,
     "bioRe® Sustainable Textiles Standard": CertificateType.BIORE,
     "[REE]GROW": CertificateType.OTHER,
-    "Energieeffizientes Gerät": CertificateType.OTHER,
     "Birla Viscose": CertificateType.OTHER,
     "": CertificateType.OTHER,
 }

--- a/extract/extract/extractors/otto.py
+++ b/extract/extract/extractors/otto.py
@@ -295,4 +295,3 @@ def _get_sustainability(product_data: dict, parsed_url: ParseResult) -> List[str
     return sorted(
         sustainability_labels_to_certificates(list(labels.keys()) + energy_labels, _LABEL_MAPPING)
     )
-

--- a/extract/extract/extractors/otto.py
+++ b/extract/extract/extractors/otto.py
@@ -124,16 +124,6 @@ _LABEL_MAPPING = {
     "": CertificateType.OTHER,
 }
 
-_LABEL_MAPPING_ENERGY = {
-    "A": CertificateType.EU_ENERGY_LABEL_A,
-    "B": CertificateType.EU_ENERGY_LABEL_B,
-    "C": CertificateType.EU_ENERGY_LABEL_C,
-    "D": CertificateType.EU_ENERGY_LABEL_D,
-    "E": CertificateType.EU_ENERGY_LABEL_E,
-    "F": CertificateType.EU_ENERGY_LABEL_F,
-    "G": CertificateType.EU_ENERGY_LABEL_G,
-}
-
 
 def _get_product_data(beautiful_soup: BeautifulSoup) -> dict:
     """
@@ -276,7 +266,7 @@ def _get_energy_labels(product_data: dict) -> List[str]:
             case [*json_array]:
                 json_values += json_array
 
-    return energy_labels
+    return [f"EU Energy label {letter}" for letter in energy_labels]
 
 
 def _get_sustainability(product_data: dict, parsed_url: ParseResult) -> List[str]:
@@ -303,6 +293,6 @@ def _get_sustainability(product_data: dict, parsed_url: ParseResult) -> List[str
         labels.update(_get_sustainability_info(sustainable_soup))
 
     return sorted(
-        sustainability_labels_to_certificates(labels.keys(), _LABEL_MAPPING)
-        + list({_LABEL_MAPPING_ENERGY.get(label) for label in energy_labels})
+        sustainability_labels_to_certificates(list(labels.keys()) + energy_labels, _LABEL_MAPPING)
     )
+

--- a/extract/extract/extractors/otto.py
+++ b/extract/extract/extractors/otto.py
@@ -14,7 +14,7 @@ from pydantic import ValidationError
 from core.domain import CertificateType, Product
 
 from ..parse import DUBLINCORE, JSON_LD, MICRODATA, ParsedPage
-from ..utils import safely_return_first_element
+from ..utils import safely_return_first_element, sustainability_labels_to_certificates
 
 logger = getLogger(__name__)
 
@@ -95,20 +95,15 @@ _LABEL_MAPPING = {
     "Vegetabil gegerbtes Leder": CertificateType.OTHER,
     "[REE]CYCLED": CertificateType.OTHER,
     "Recyceltes Material": CertificateType.OTHER,
-    "bluesign® APPROVED": CertificateType.BLUESIGN_APPROVED,
     "Primegreen": CertificateType.OTHER,
     "bluesign® PRODUCT": CertificateType.BLUESIGN_PRODUCT,
-    "Grüner Knopf": CertificateType.GREEN_BUTTON,
     "Organic Content Standard 100": CertificateType.ORGANIC_CONTENT_STANDARD_100,
     "Organic Content Standard blended": CertificateType.ORGANIC_CONTENT_STANDARD_BLENDED,
     "Bio-Baumwolle": CertificateType.OTHER,
     "Unterstützt Cotton made in Africa": CertificateType.COTTON_MADE_IN_AFRICA,
     "Primeblue": CertificateType.OTHER,
     "Fairtrade Cotton": CertificateType.FAIRTRADE_COTTON,
-    "Fairtrade Textile Production": CertificateType.FAIRTRADE_TEXTILE_PRODUCTION,
-    "Responsible Down Standard": CertificateType.RESPONSIBLE_DOWN_STANDARD,
     "BIONIC-FINISH®ECO (Rudolf Chemie)": CertificateType.OTHER,
-    "GOTS organic": CertificateType.GOTS_ORGANIC,
     "GOTS made with organic materials": CertificateType.GOTS_MADE_WITH_ORGANIC_MATERIALS,
     "Umweltfreundlicher Färbeprozess": CertificateType.OTHER,
     "TENCEL™ Lyocell": CertificateType.OTHER,
@@ -118,16 +113,12 @@ _LABEL_MAPPING = {
     "REPREVE®": CertificateType.OTHER,
     "Nachhaltige Viskose": CertificateType.OTHER,
     "ECONYL©": CertificateType.OTHER,
-    "Blauer Engel": CertificateType.GREEN_BUTTON,
     "Recycled Claim Standard blended": CertificateType.RECYCLED_CLAIM_STANDARD_BLENDED,
     "Recycled Claim Standard 100": CertificateType.RECYCLED_CLAIM_STANDARD_100,
     "Recycelter Kunststoff (Hartwaren)": CertificateType.OTHER,
     "Bio-Siegel": CertificateType.OTHER,
     "bioRe® Sustainable Textiles Standard": CertificateType.BIORE,
     "[REE]GROW": CertificateType.OTHER,
-    "ECOCERT": CertificateType.ECOCERT,
-    "EU Ecolabel": CertificateType.EU_ECOLABEL_TEXTILES,
-    "The Good Cashmere Standard®": CertificateType.GOOD_CASHMERE_STANDARD,
     "Energieeffizientes Gerät": CertificateType.OTHER,
     "Birla Viscose": CertificateType.OTHER,
     "": CertificateType.OTHER,
@@ -312,6 +303,6 @@ def _get_sustainability(product_data: dict, parsed_url: ParseResult) -> List[str
         labels.update(_get_sustainability_info(sustainable_soup))
 
     return sorted(
-        {_LABEL_MAPPING.get(label, CertificateType.UNKNOWN) for label in labels.keys()}
-        | {_LABEL_MAPPING_ENERGY.get(label) for label in energy_labels}
+        sustainability_labels_to_certificates(labels.keys(), _LABEL_MAPPING)
+        + list({_LABEL_MAPPING_ENERGY.get(label) for label in energy_labels})
     )

--- a/extract/extract/utils.py
+++ b/extract/extract/utils.py
@@ -55,7 +55,7 @@ def sustainability_labels_to_certificates(
         if certificate_string in certificate_strings:
             result.append(certificate)
 
-    return sorted(result) or [CertificateType.UNKNOWN]  # type: ignore[attr-defined]
+    return sorted(set(result)) or [CertificateType.UNKNOWN]  # type: ignore[attr-defined]
 
 
 def _get_certificate_for_any_language(

--- a/extract/tests/otto/data/electronics-fridge-old-energy-label.html
+++ b/extract/tests/otto/data/electronics-fridge-old-energy-label.html
@@ -1,0 +1,2794 @@
+
+    <!DOCTYPE html>
+    <html data-pagecluster="Artikeldetailseite">
+    <head>
+        <title>Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie online kaufen | OTTO</title>
+        <meta charset="utf-8"/>
+        <script>
+"use strict";
+
+var o_global = o_global || {};
+
+o_global.toggles = Object.freeze({
+    "EMR_PXC": true,
+    "RUM_PageCluster": true,
+    "RUM_Viewport": true,
+    "EMR_MPATHY": true,
+    "tr_add_mini_actions": true,
+    "RUM_CustomEvents": true,
+    "IAB_FEATURE_ACTIVE": true,
+    "FTFIND_REMOVE_UNFILTERED_ON_BROWSER_BACK": false,
+    "FTFIND_JS_ERRORS": true,
+    "FT9_USE_SLIDESHOWLEVER_API": true,
+    "SCALE_SendUserTimings": true,
+    "RUM_SendErrorsWithoutStack": false,
+    "ENABLE_NEW_MAIN_LEVER_TRACKING": true,
+    "FEATURE_TRACKING_BENEFITS": true,
+    "RUM_Visibility": false,
+    "LHAS_2048_TRACK_COOKIES": false,
+    "quality_use_pass_proxy": true,
+    "RUM_RoundTripTime": true,
+    "FTFIND_ENABLE_SCROLL_RESTORE": true,
+    "FT6_EASTEREGGS": false,
+    "FT9_UP_TEASER_LAYER_TRACKING": true,
+    "RUM_DetailedPerformance": true,
+    "RUM_BasicInformation": true,
+    "nitro_js_enabled": true,
+    "ASSETS_POLYFILL_SERVICE_ENABLED": true,
+    "RUM_AssetX": false,
+    "FTFIND_JS_ERROR_COLORTHUMB": false,
+    "FTFIND_LATER_SCROLLTO_ON_ADS_BACK": true,
+    "RUM_DeviceInformation": true,
+    "DEBUG_TEST_TOGGLE_SERVICE": false,
+    "FT9_UP_TEASER_SHEET_SIGNUP_TRACKING": false,
+    "FT6_BEAT_FEATURE_TRACKING_CLICK": false,
+    "RUM_JavascriptErrors": true,
+    "EMR_PRELOAD_POLYFILL_DISABLE_FETCH": true,
+    "ENABLE_NEW_MAIN_LEVER_COPY": true,
+    "RUM_ScreenSize": false,
+    "USE_MOVE_TRACKING": false,
+    "tr_use_pass_proxy": false,
+    "EMR_RUM": true,
+    "RUM_Connection": false,
+    "RUM_ImportantPerformance": true,
+    "FTFIND46_ENABLE_INTERVAL_TRACKING": false,
+    "tr_disable_bct_requests": false,
+    "SCALE_SendRumData": true
+});
+</script>
+<script src="/assets-polyfills/assets.polyfills.head.js" crossorigin="anonymous"></script>
+
+<script>!function(){"use strict";function e(e){var t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:"success";"success"===t&&e.hasAttribute("noinvoke")?(e.removeAttribute("noinvoke"),window.invokePreload.setLifecycleData(e,"data-preloaded","noinvoke")):window.invokePreload.setLifecycleData(e,"data-preloaded",t),e.removeEventListener("load",window.invokePreload.onLoad),e.onload=null}function t(e){e.setAttribute("rel","stylesheet"),e.setAttribute("type","text/css"),e.setAttribute("media","all"),e.removeAttribute("as")}function o(e){var t=document.createElement("script"),o="\n  window.invokePreload.browserSupport.typemodule=".concat(e,';\n  window.invokePreload.browserSupport.detectionComplete=true;\n  document.dispatchEvent(new CustomEvent("PreloadFeatureDetectionComplete"));\n  ');e?t.type="module":t.setAttribute("nomodule","true");try{t.appendChild(document.createTextNode(o)),document.head.appendChild(t)}catch(e){t.text=o,document.head.appendChild(t)}}window.invokePreload=window.invokePreload||{},function(){var e,t={preload:!1,modulepreload:!1,typemodule:!1,dynamicimport:!1,detectionComplete:!1};window.invokePreload.browserSupport=t;try{var n=(e=document.createElement("link").relList)?{preload:e.supports("preload"),modulepreload:e.supports("modulepreload")}:{preload:!1,modulepreload:!1},r=n.modulepreload,d=n.preload;if(t.modulepreload=r,t.preload=d,t.modulepreload)return t.typemodule=!0,t.dynamicimport=!0,t.detectionComplete=!0,t;if(t.dynamicimport=function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"return import('data:text/javascript;base64,Cg==')";try{return new Function(e)(),!0}catch(e){return!1}}(),t.dynamicimport)return t.typemodule=!0,t.detectionComplete=!0,t;if(t.typemodule="noModule"in document.createElement("script")||([!1,!0].forEach(o),!1),t.typemodule)return t.detectionComplete=!0,t}catch(e){t.detectionComplete=!0}}(),window.invokePreload.setLifecycleData=function(e,t,o){e.setAttribute(t,o)},window.invokePreload.getLifeCycleData=function(e,t){return e.getAttribute(t)},window.invokePreload.onLoad=e,window.invokePreload.onScriptLoad=e,window.invokePreload.onScriptError=function(e){return window.invokePreload.onScriptLoad(e,"try-with-error")},window.invokePreload.onStyleLoad=function(e){return-1===[].map.call(document.styleSheets,(function(e){try{return"all"===e.media.mediaText?e.href:null}catch(e){return null}})).indexOf(e.href)&&(window.requestAnimationFrame?window.requestAnimationFrame((function(){return t(e)})):t(e)),e.removeAttribute("onload"),e};var n=document.createElement("script");!("noModule"in n)&&"onbeforeload"in n&&document.addEventListener("beforeload",(function(e){e.target.hasAttribute("nomodule")&&window.invokePreload.browserSupport.typemodule&&e.preventDefault()}),!0)}();
+
+//# sourceMappingURL=/assets-static/global-resources/assets.global-resources.preflight.nomodule.31c1a5d6.js.map
+</script><script src="/assets-static/global-resources/assets.global-resources.legacy.nomodule.1e7abb4b.js" crossorigin="anonymous" integrity="sha256-X8ODH/E+ZwlwrYijRDSIs6p7sEYkbVOGAZXDbreqsIQ=" nomodule=""></script>
+<link rel="stylesheet" href="/assets-static/global-resources/assets.global-resources.head.4127e24b.css" crossorigin="anonymous" integrity="sha256-JZfiz9BFZsALPa3u1Bg+HCP3N6ZjCIc6M8gEHGUl74c=">
+
+<script src="/assets-static/global-resources/assets.global-resources.head.nomodule.0a475768.js" crossorigin="anonymous" integrity="sha256-lFCvZpv5IsvPDr71CJ5RTFVzHpJOy0LCUWsdfVh9Bgc="></script>
+<link rel="preload" href="/assets-static/global-resources/assets.global-resources.fonts.607dafe6.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/assets-static/global-resources/assets.global-resources.fonts.607dafe6.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="preload" name="OttoSans" as="font" weight="400" crossorigin="anonymous" type="font/woff2" href="/assets-static/global-resources/assets/otto-sans_fb84ead3.woff2"/>
+<link rel="preload" name="OttoSans" as="font" weight="700" crossorigin="anonymous" type="font/woff2" href="/assets-static/global-resources/assets/otto-sans-bold_b7bb08ce.woff2"/>
+<link rel="preload" name="OttoSansThin" as="font" weight="400" crossorigin="anonymous" type="font/woff2" href="/assets-static/global-resources/assets/otto-sans-thin_f4c271f3.woff2"/>
+<link rel="preload" name="OttoIconFonts" as="font" weight="400" crossorigin="anonymous" type="font/woff2" href="/assets-static/global-resources/assets/OTTO-Icons_8a586867.woff2"/>
+<link rel="preload" name="OttoIcons" as="font" weight="400" crossorigin="anonymous" type="font/woff2" href="/assets-static/global-resources/assets/OTTO-Icons_8a586867.woff2"/>
+<link rel="preload" crossorigin="anonymous" href="/scale-shop-assets/scale.shop-assets.scale_beacon.8cbe987d.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link
+        rel="stylesheet"
+        href="/assets-static/global-pattern/assets.global-pattern.main.38488765.css"
+          crossorigin="anonymous"
+          integrity="sha256-qfGQ+aBCianJzswRGx8q/JslUBSt14GqvgiFWKy6zjM="
+      />
+    <script
+      src="/assets-static/global-pattern/assets.global-pattern.main.nomodule.fbe4b581.js"
+        crossorigin="anonymous"
+        integrity="sha256-8Kp8Xshu5bvf6+mdyoxU9R9i5wJ7RzGvmHqz2yMN2jo="
+></script>
+<link rel="shortcut icon" type="image/x-icon" href="/assets-static/global-favicons/favicon.ico">
+<link rel="icon" type="image/x-icon" href="/assets-static/global-favicons/favicon.ico">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon.png">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-57x57.png" sizes="57x57">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-60x60.png" sizes="60x60">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-72x72.png" sizes="72x72">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-76x76.png" sizes="76x76">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-114x114.png" sizes="114x114">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-120x120.png" sizes="120x120">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-128x128.png" sizes="128x128">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-144x144.png" sizes="144x144">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-152x152.png" sizes="152x152">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-180x180.png" sizes="180x180">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-precomposed.png">
+<link rel="icon" type="image/png" href="/assets-static/global-favicons/favicon-16x16.png" sizes="16x16">
+<link rel="icon" type="image/png" href="/assets-static/global-favicons/favicon-32x32.png" sizes="32x32">
+<link rel="icon" type="image/png" href="/assets-static/global-favicons/favicon-96x96.png" sizes="96x96">
+<link rel="icon" type="image/png" href="/assets-static/global-favicons/favicon-160x160.png" sizes="160x160">
+<link rel="icon" type="image/png" href="/assets-static/global-favicons/favicon-192x192.png" sizes="192x192">
+<link rel="icon" type="image/png" href="/assets-static/global-favicons/favicon-196x196.png" sizes="196x196">
+<link rel="manifest" href="/assets-static/global-favicons/manifest.json">
+<meta name="msapplication-TileImage" content="/assets-static/global-favicons/ms-icon-144x144.png">
+<meta name="msapplication-TileColor" content="#ffffff">
+<meta name="msapplication-navbutton-color" content="#d52b1e">
+<meta name="msapplication-square70x70logo" content="/assets-static/global-favicons/ms-icon-70x70.png">
+<meta name="msapplication-square144x144logo" content="/assets-static/global-favicons/ms-icon-144x144.png">
+<meta name="msapplication-square150x150logo" content="/assets-static/global-favicons/ms-icon-150x150.png">
+<meta name="msapplication-wide310x150logo" content="/assets-static/global-favicons/ms-icon-310x150.png">
+<meta name="msapplication-square310x310logo" content="/assets-static/global-favicons/ms-icon-310x310.png">
+<meta name="theme-color" content="#f0f0f0">
+
+<link rel="stylesheet" href="/product/static/assets/ft5.detailview.head.6b642614.css" integrity="sha256-y8+LfR/BP/GIRp+bSQw8pXB8QH0CLtbA5XFBczKuOiY=" crossorigin="anonymous"/><meta name="description" content="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie für 333,00€ bei OTTO"/>
+<meta name="robots" content="index,follow"/>
+<meta property="og:image" content="https://i.otto.de/i/otto/19651738/privileg-family-edition-pyrolyse-backofen-pbwr6-op8v2-in-mit-2-fach-teleskopauszug-pyrolyse-selbstreinigung-50-monate-herstellergarantie.jpg?$formatz$">
+<meta property="og:title" content="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie online kaufen | OTTO">
+<meta property="og:description" content="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie für 333,00€ bei OTTO">
+<meta property="og:url" content="https://www.otto.de/p/privileg-family-edition-pyrolyse-backofen-pbwr6-op8v2-in-mit-2-fach-teleskopauszug-pyrolyse-selbstreinigung-50-monate-herstellergarantie-682285688/">
+<meta property="og:site_name" content="OTTO">
+<meta property="og:type" content="product">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@otto_de">
+<meta name="twitter:description" content="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie für 333,00€ bei OTTO">
+<meta name="twitter:image" content="https://i.otto.de/i/otto/19651738/privileg-family-edition-pyrolyse-backofen-pbwr6-op8v2-in-mit-2-fach-teleskopauszug-pyrolyse-selbstreinigung-50-monate-herstellergarantie.jpg?$formatz$">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="canonical" href="https://www.otto.de/p/privileg-family-edition-pyrolyse-backofen-pbwr6-op8v2-in-mit-2-fach-teleskopauszug-pyrolyse-selbstreinigung-50-monate-herstellergarantie-682285688/"/>
+
+
+    <style>@charset "UTF-8";.cr_aggregation{display:inline-block;margin-top:8px}.cr_aggregation__starsWithAmount{cursor:pointer;text-decoration:none}.cr_aggregation__button{display:inline;margin-left:8px;width:auto}.cr_aggregation__amount,.cr_aggregation__label{text-decoration:underline}.cr_aggregation__label-icon{font-style:normal;vertical-align:bottom}.cr_aspectFilter{margin-top:32px}@media (min-width:48em){.cr_aspectFilter--old-{margin-top:16px}}.cr_aspectFilter__headline{font-size:14px;font-size:.875rem;line-height:1.4285714286em}.cr_aspectFilter__headline--old-design{font-weight:700}.cr_aspectFilter__buttons{overflow:hidden}.cr_aspectButton{-webkit-tap-highlight-color:transparent;background:#f3f1ec;background:-webkit-linear-gradient(180deg,#fefefe,#f3f1ec);background:linear-gradient(180deg,#fefefe,#f3f1ec);border:1px solid #c4c4c4;border-radius:3px;color:#333;cursor:pointer;float:left;font-size:12px;font-size:.75rem;height:31px;line-height:1.5em;margin:8px 8px 0 0;max-width:300px;outline:0 none;padding:5px 9px;text-align:center;text-decoration:none;vertical-align:baseline;white-space:nowrap}.cr_aspectButton:hover{background:#fefefe;color:#d5281e}.cr_aspectButton:last-of-type{margin:8px 16px 0 0}.cr_aspectButton--selected{border-color:#9e9e9e;cursor:auto}.cr_aspectButton--selected,.cr_aspectButton--selected:hover{background:#fff;background:-webkit-linear-gradient(180deg,#d7d5cf,#fff);background:linear-gradient(180deg,#d7d5cf,#fff);font-weight:700}.cr_aspectButton--selected:hover{color:inherit}.cr_aspectButton__text{display:inline-block;margin-right:4px;max-width:235px;overflow:hidden;text-overflow:ellipsis;vertical-align:bottom;white-space:nowrap}.cr_aspectDeselectLink{float:left;line-height:31px;margin-top:8px}.cr_histogram__row{display:table-row}.cr_histogram__row--clickable{cursor:pointer}.cr_histogram__row--clickable .cr_histogram__amount span{text-decoration:underline}.cr_histogram__row--selected .cr_histogram__amount,.cr_histogram__row--selected .cr_histogram__label{font-weight:700}.cr_histogram__row--selected .cr_bar{border:1px solid #777}.cr_histogram__row--selected .cr_bar__fill{background-color:#9e9e9e}.cr_histogram__row--selected .cr_histogram__amount span{text-decoration:none}@media (min-width:48em){.cr_histogram__row--selected .cr_histogram__deselect{display:table-cell}}.cr_histogram__amount,.cr_histogram__label,.cr_histogram__percent{display:table-cell;padding-top:12px;vertical-align:top}.cr_histogram__row:first-child .cr_histogram__amount,.cr_histogram__row:first-child .cr_histogram__deselect,.cr_histogram__row:first-child .cr_histogram__label,.cr_histogram__row:first-child .cr_histogram__percent{padding-top:0}.cr_histogram__amount,.cr_histogram__deselect,.cr_histogram__label{font-size:14px;font-size:.875rem;line-height:1.4285714286em;line-height:20px}.cr_histogram__amount,.cr_histogram__label,.cr_histogram__percent{padding-right:8px}.cr_bar{border:1px solid #c4c4c4;-moz-border-radius:2px;-webkit-border-radius:2px;border-radius:2px;height:20px;width:170px}.cr_bar__fill{background-color:#e6e6e6;height:100%}.cr_histogram__deselect{display:none;padding-top:12px;vertical-align:top}.cr_filterIndicator{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:16px 0 0}@media (min-width:48em){.cr_filterIndicator{display:inline-block;line-height:38px}}.cr_filterIndicator__deselect{white-space:nowrap}@media (min-width:48em){.cr_filterIndicator__deselect{display:none}}.cr_landingPage .cr_reviewHeadline__row--FEATURE_2065 .cr_reviewHeadline__starsWithAmount>*{display:inline-block;vertical-align:middle}@media (min-width:48em){.cr_landingPage .cr_histogram--old-design{float:left}.cr_landingPage .cr_aspectFilter--old-design{margin-left:480px}}.cr_landingPage .cr_filterWrapper{margin:16px 0 0;overflow:hidden}.cr_landingPage .cr_filterWrapper--old-design{margin:8px 0 0}.cr_landingPage .cr_priceAmount--reduced{color:#f00020}.cr_landingPage .cr_priceNote{display:block}.cr_landingPage .cr_productVariationImage{max-height:74px;max-width:74px}.cr_landingPage .cr_variationImage{display:inline;float:left;padding:0 0 0 8px}@media (min-width:28em){.cr_landingPage .cr_variationImage{padding:0 8px}}.cr_landingPage .cr_priceAndMoreVariationsLink{float:left}.cr_landingPage .cr_headLink{text-decoration:none}.cr_loadingSpinner{margin-bottom:8px;text-align:center}.cr_loadingSpinner__loader{display:inline-block}@media (min-width:48em){.cr_minimal .cr_histogram--old-design{float:left}.cr_minimal .cr_aspectFilter--old-design{margin-left:360px}}.cr_minimal .cr_reviewList{margin:32px 0 24px}.cr_minimal .cr_filterWrapper{margin:16px 0 0;overflow:hidden}.cr_minimal .cr_filterWrapper--old-design{margin:8px 0 0}.cr_moreReviewsButton{max-width:350px}.cr_paging{margin-bottom:8px;overflow:hidden;text-align:center}@media (min-width:48em){.cr_paging{float:right;width:310px}}.cr_paging__button{width:auto}.cr_paging__button--first,.cr_paging__button--prev{float:left;margin-left:8px}.cr_paging__button--last,.cr_paging__button--next{float:right;margin-right:8px}.cr_paging__currentPage{font-size:14px;font-size:.875rem;line-height:1.4285714286em;line-height:30px}.cr_reportReviewLayer{font-size:14px;font-size:.875rem;line-height:1.4285714286em;overflow:hidden}.cr_reportReviewLayer--success .cr_reportReviewLayer__surveyWrapper{display:none}.cr_reportReviewLayer--success .cr_reportReviewLayer__successWrapper{display:block}.cr_reportReviewLayer__error{display:none;margin-bottom:16px}.cr_reportReviewLayer__request{font-weight:700;margin:0}.cr_reportReviewLayer__survey{margin-top:10px}.cr_reportReviewLayer__textarea{margin-top:8px}.cr_reportReviewLayer__disclaimer,.cr_reportReviewLayer__feedbackIndication,.cr_reportReviewLayer__guidelines{font-size:12px;font-size:.75rem;line-height:1.5em}.cr_reportReviewLayer__feedbackIndication{margin:8px 0 0}.cr_reportReviewLayer__feedbackIndication--success{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:16px 0 0}.cr_reportReviewLayer__disclaimer,.cr_reportReviewLayer__guidelines{display:block;margin-top:8px}@media (min-width:48em){.cr_reportReviewLayer__disclaimer{float:left;line-height:40px;margin-top:16px}}.cr_reportReviewLayer__button{margin-top:16px}@media (min-width:48em){.cr_reportReviewLayer__button{float:right;max-width:160px}}.cr_reportReviewLayer__successWrapper{display:none}.cr_reviewHeadline{position:relative}.cr_reviewHeadline__headline{margin-top:16px}.cr_reviewHeadline__headline--FEATURE_2065{font-family:OttoSansThin,OTTOSans,Arial,Helvetica,sans-serif;font-size:22px;font-size:1.375rem;line-height:1.2727272727em;margin-top:24px}@media (min-width:48em){.cr_reviewHeadline__headline--FEATURE_2065{font-size:26px;font-size:1.625rem;line-height:1.2307692308em}}.cr_reviewHeadline__recommendation{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:8px 0 0}.cr_reviewHeadline__recommendation.cr_reviewHeadline__recommendation--FEATURE_2065{margin:12px 0 0}.cr_reviewHeadline__row{overflow:hidden}.cr_reviewHeadline__starsWithAmount{float:left;margin-top:19px;white-space:nowrap}.cr_reviewHeadline__row--FEATURE_2065 .cr_reviewHeadline__starsWithAmount{margin-top:16px}.cr_reviewHeadline__row--FEATURE_2065 a.cr_reviewHeadline__starsWithAmount{cursor:pointer;text-decoration:none}.cr_reviewHeadline__amount{margin:0 8px 0 4px;vertical-align:text-bottom}.cr_reviewHeadline__row--FEATURE_2065 .cr_reviewHeadline__amount{margin:4px}.cr_reviewHeadline__label{text-decoration:underline;vertical-align:text-bottom}.cr_reviewHeadline__label-icon{font-style:normal;vertical-align:baseline}.cr_reviewHeadline__amount--clickable{cursor:pointer;text-decoration:underline}.cr_reviewHeadline__submitReviewButton{margin-top:8px;width:auto}.cr_reviewHeadline__row--FEATURE_2065 .cr_reviewHeadline__submitReviewButton{margin-top:0}.cr_reviewHeadline__submitReviewButton--old{margin-top:16px}.cr_reviewHeadline__submitReviewButton--floating{margin:12px 0 0}@media (min-width:48em){.cr_reviewHeadline__submitReviewButton--floating{margin:0;position:absolute;right:0;top:0}}.cr_reviewHeadline__submitReviewStar{margin-right:2px}.cr_reviewHeadline__submitReview{display:inline-block;float:right;margin-top:16px}.cr_reviewHeadline__noReviews{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:8px 0 0}.cr_reviewHeadline__submitReview--noReviews{float:none;margin:8px 0}#cr_reviewErrorContainer{display:none;margin-bottom:8px}#cr_js_topReviews{overflow:hidden}.cr_reviewList{margin:16px 0 24px;position:relative}@media (min-width:48em){.cr_reviewList{margin:24px 0 32px}}.cr_review{font-size:14px;font-size:.875rem;line-height:1.4285714286em}.cr_review__stars{margin-right:8px}.cr_review__stars--error{color:#f00020}.cr_review__title{display:inline;font-size:14px;font-size:.875rem;font-weight:700;line-height:1.4285714286em}.cr_review__helpfulSummary{display:block;font-size:12px;font-size:.75rem;line-height:1.5em;margin-top:2px}@media (min-width:48em){.cr_review__helpfulSummary--SandM{display:none}}.cr_review__helpfulSummary--LandXL{display:none}@media (min-width:48em){.cr_review__helpfulSummary--LandXL{display:block}}.cr_review__text{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:12px 0 0}.cr_review__reviewer{display:block;font-size:12px;font-size:.75rem;line-height:1.5em;margin-top:12px}.cr_review__reviewerName{font-weight:700}.cr_review__partner{display:block;font-size:12px;font-size:.75rem;line-height:1.5em}.cr_review__partnerName{font-weight:700}.cr_review__dimensions{display:block}.cr_review__dimensions,.cr_review__helpfulSubmit{font-size:12px;font-size:.75rem;line-height:1.5em}.cr_review__helpfulSubmit{display:inline-block;margin:8px 0 0}.cr_review__verifiedPurchase{margin-top:2px}.cr_review__verifiedPurchaseText{color:#50cc7f;font-size:12px;font-size:.75rem;line-height:1.5em}.cr_review__verifiedPurchaseIcon{fill:#50cc7f;vertical-align:middle}.cr_review__verifiedPurchaseInfo{font-size:14px;font-size:.875rem;line-height:1.4285714286em}.cr_review__verifiedPurchaseInfoText{color:#50cc7f}.cr_review__verifiedPurchaseInfoIcon{fill:#50cc7f;height:14px;vertical-align:text-bottom;width:14px}.cr_helpfulSubmit{margin-left:4px;white-space:nowrap}.cr_helpfulSubmit__button{display:inline-block;width:auto}.cr_helpfulSubmit__button:first-child{margin-right:4px}.cr_reportReviewLink{display:inline-block;font-size:12px;font-size:.75rem;line-height:1.5em;margin-top:12px;white-space:nowrap}@media (min-width:28em){.cr_reportReviewLink{display:inline;margin-left:12px;margin-top:0}}.cr_review__line{margin:16px 0!important}@media (min-width:48em){.cr_review__line{margin:24px 0!important}}.cr_bi-review:before{display:inline-block;float:left;font-family:OttoIcons,Arial,Helvetica,sans-serif;font-size:20px;font-size:1.25rem}.cr_bi-review>*{margin-left:28px}.cr_bi-review .cr_reportReviewLink,.cr_bi-review .cr_review__helpfulSubmit{display:none}.cr_bi-review.cr_review--expanded .cr_reportReviewLink,.cr_bi-review.cr_review--expanded .cr_review__helpfulSubmit{display:inline-block}.cr_bi-review--positive:before{color:#417505;content:"↑"}.cr_bi-review--negative:before{color:#ba0019;content:"↓"}.cr_bi-review--neutral:before{content:"→"}.cr_review__text--afterOccurrence,.cr_review__text--beforeOccurrence{display:none}.cr_review--expanded .cr_review__text--afterOccurrence,.cr_review--expanded .cr_review__text--beforeOccurrence{display:inline}.cr_review__highlightedWord{font-weight:700}.cr_review__highlightedWord--negative{color:#ba0019}.cr_review__highlightedWord--positive{color:#417505}.cr_review__moreLink:after{content:"...Mehr"}.cr_review--expanded .cr_review__moreLink:after{content:"...Weniger"}.cr_aspectHeader{margin-top:24px;overflow:hidden}.cr_aspectHeader__name{display:inline-block;font-size:16px;font-size:1rem;font-weight:700;line-height:1.375em;margin-right:9px;vertical-align:middle}.cr_aspectTypeDistribution{cursor:default;display:inline-block;vertical-align:middle}.cr_aspectTypeDistribution__item{display:inline-block;font-size:16px;font-size:1rem;font-weight:700;line-height:1.375em;line-height:26px;vertical-align:middle}.cr_aspectTypeDistribution__item:not(:last-child){margin-right:10px}.cr_aspectTypeDistribution__icon{font-size:20px;font-style:normal;font-weight:400;margin-right:-3px;vertical-align:bottom}.cr_aspectTypeDistribution__icon--positive{color:#417505}.cr_aspectTypeDistribution__icon--negative{color:#ba0019}.cr_sortingForm{display:block;margin-top:16px}@media (min-width:28em){.cr_sortingForm--old-design{text-align:right}}@media (min-width:48em){.cr_sortingForm--old-design{display:inline-block;float:right}}.cr_sortingForm__label{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin-right:8px}.cr_sortingForm__select{display:inline-block;width:auto}.cr_filterIndicatorAndSortingWrapper{overflow:hidden}.reviewSubmitLayer a.overlay{color:#777;display:inline-block;margin-top:16px}.reviewSubmitLayer .label{margin-bottom:4px}.reviewSubmitLayer .reviewContent p{margin-top:15px}.reviewSubmitLayer .reviewContent .cr_reviewImage img{height:164px;width:164px}.reviewSubmitLayer .reviewContent .cr_reviewDimensions{flex:1;vertical-align:top}.reviewSubmitLayer .reviewContent .cr_reviewImageContainer{display:flex}.reviewSubmitLayer .reviewContent .cr_reviewTextContainer{margin-bottom:12px!important}.reviewSubmitLayer .reviewContent .recommended{margin:8px 0}.reviewSubmitLayer .reviewContent .radio-option{margin-right:40px}.reviewSubmitLayer .reviewContent .star-empty{background-image:url(/assets-static/icons/pl_icon_rating-empty.svg)}.reviewSubmitLayer .reviewContent .star-empty,.reviewSubmitLayer .reviewContent .star-filled{background-position:0;background-repeat:no-repeat;background-size:24px;cursor:pointer;padding:14px 38px 14px 0}.reviewSubmitLayer .reviewContent .star-filled{background-image:url(/assets-static/icons/pl_icon_rating-filled.svg)}.reviewSubmitLayer .reviewContent .left{float:left}.reviewSubmitLayer .reviewContent .right{float:right}.reviewSubmitLayer .reviewContent form{float:left;margin:0 0 15px}@media (min-width:48em){.reviewSubmitLayer .reviewContent .selectBoxWrapper{width:50%}.reviewSubmitLayer .reviewContent .selectBoxWrapper:nth-child(2n){padding-left:4px}.reviewSubmitLayer .reviewContent .selectBoxWrapper:nth-child(odd){padding-right:4px}.reviewSubmitLayer .reviewContent .footer button{width:auto}}</style>
+
+
+
+        <script type="application/ld+json">
+              {
+  "@context": "https://schema.org/",
+  "@type": "Product",
+  "gtin13": "8003437938573",
+  "sku": "64649515",
+  "name": "Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie",
+  "image": [
+    "https://i.otto.de/i/otto/19651738/privileg-family-edition-pyrolyse-backofen-pbwr6-op8v2-in-mit-2-fach-teleskopauszug-pyrolyse-selbstreinigung-50-monate-herstellergarantie.jpg?$formatz$",
+    "https://i.otto.de/i/otto/19651739/privileg-family-edition-pyrolyse-backofen-pbwr6-op8v2-in-mit-2-fach-teleskopauszug-pyrolyse-selbstreinigung-50-monate-herstellergarantie.jpg?$formatz$",
+    "https://i.otto.de/i/otto/19651740/privileg-family-edition-pyrolyse-backofen-pbwr6-op8v2-in-mit-2-fach-teleskopauszug-pyrolyse-selbstreinigung-50-monate-herstellergarantie.jpg?$formatz$"
+  ],
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "4.1111111111",
+    "reviewCount": "90"
+  },
+  "offers": {
+    "@type": "Offer",
+    "url": "/p/privileg-family-edition-pyrolyse-backofen-pbwr6-op8v2-in-mit-2-fach-teleskopauszug-pyrolyse-selbstreinigung-50-monate-herstellergarantie-682285688/",
+    "priceCurrency": "EUR",
+    "price": "333.00",
+    "itemCondition": "http://schema.org/NewCondition",
+    "availability": "https://schema.org/InStock"
+  },
+  "brand": {
+    "@type": "Brand",
+    "name": "Privileg Family Edition"
+  }
+}
+            </script>
+    </head>
+
+    <body class="product-system so_footerswitch" data-productjsloaded="true" itemscope itemtype="http://schema.org/Product">
+        <div class="javascriptUriTemplate" data-uritemplate="/product/static-assets/a8d974f65f1d57ddf6904353f1e13889/{type}/{ident}.{extension}"></div>
+        <div class="ts-bct" data-ts_sfid="ec0a7407e5a0d3a528d70ccbe1bdbe6a416628090"></div>
+        <div class="gridAndInfoContainer">
+            <div class="gridContainer reducedOuterPadding wrapper">
+                <header class="withSubMenu">
+    <link rel="stylesheet" href="/walkingstick/grasshopper/ftfind.grasshopper.head.8159bab4.css" integrity="sha256-kysGnuRNtRcl17A3YFrlEzsULc2QySHIUjDnQKQWQBs=" crossorigin="anonymous"/>
+    <link rel="preload" href="/walkingstick/locust/reptile.locust.head.bacc537a.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/walkingstick/locust/reptile.locust.head.bacc537a.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/walkingstick/locust/reptile.locust.head.module.86f7d709.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/walkingstick/locust/reptile.locust.head.nomodule.bcb4befb.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+    <div class="find_header js_find_header find_header--hideSearchIconOnTop">
+        <div class="find_headerContent">
+        <div class="find_mobileMenuWrapper">
+    <nav class="nav_menu-toggle-button" id="nav_menu-toggle-button"><p class="nav_menu-toggle-button__icon"></p><p class="nav_menu-toggle-button__title-closed">Sortiment</p><p class="nav_menu-toggle-button__title-open" style="display:none;">Schließen</p></nav>
+        </div>
+        <div class="find_ottoLogo" data-qa="ftfind-otto-logo-wrapper">
+            <a href="/" data-tracking="{&quot;san_Header&quot;:&quot;logo&quot;}" title="zur Homepage">
+                <svg class="san-svg" width="100%" height="100%" viewBox="0 0 140 52">
+                    <path d="M121.136,2.75c-6.876,0-12.469,2.12-16.42,6.508c0.562-1.523,0.858-3.381,0.897-5.569H81.517 c-5.258,0-8.263,2.315-10.329,8.262l1.065-8.262H47.905c-4.458,0-7.518,2.131-8.624,6.305C36.264,5.159,30.902,2.75,24.12,2.75 c-12.893,0-21.281,7.449-22.783,23.346L1.15,28.1c-1.314,14.209,6.134,21.219,17.712,21.219c12.895,0,21.282-7.513,22.784-23.41 l0.188-2.002c0.339-3.646,0.091-6.814-0.655-9.515h10.919l-3.129,26.79c-0.626,5.32,2.253,7.761,7.072,7.761 c2.942,0,3.943-0.188,5.07-0.375l3.881-34.176h12.707l-3.131,26.79c-0.625,5.32,2.254,7.761,7.073,7.761 c2.941,0,3.943-0.188,5.069-0.375l3.881-34.176h6.26c2.165,0,3.913-0.503,5.264-1.498c-1.97,3.473-3.257,7.858-3.763,13.203 L98.166,28.1c-1.314,14.209,6.133,21.219,17.712,21.219c12.896,0,21.281-7.513,22.783-23.41l0.188-2.002 C140.164,9.76,132.716,2.75,121.136,2.75z M28.94,23.03l-0.126,1.502c-0.875,10.765-4.381,14.083-8.699,14.083 c-3.881,0-6.634-2.628-6.071-9.638l0.124-1.565c0.877-10.704,4.382-14.083,8.701-14.083C26.687,13.328,29.503,16.02,28.94,23.03z M125.957,23.03l-0.126,1.502c-0.877,10.765-4.381,14.083-8.699,14.083c-3.882,0-6.637-2.628-6.072-9.638l0.125-1.565 c0.876-10.704,4.381-14.083,8.7-14.083C123.702,13.328,126.519,16.02,125.957,23.03z"/>
+                    <image class="san-svg" src="/san/resources/san/img/header/otto_logo_2015.png"/>
+                </svg>
+            </a>
+        </div>
+    <link rel="stylesheet" href="/stomachshop/squirrel.stomachshop.resources.8c5daae2.css" crossorigin="anonymous" integrity="sha256-rRwTqaseBG0rVHjrtzb9PxONRBkvVxWUjEnCGr6UIjY=">
+
+<script src="/stomachshop/squirrel.stomachshop.resources.nomodule.0bed790c.js" crossorigin="anonymous" integrity="sha256-BU5uEsq910WMRaJed8O+FAaEXBkfINJzZMv9lbRB19U="></script>
+
+<div class="squirrel_searchContainer js_squirrel_searchContainer js_squirrel_ignore_close_suggest">
+    <div class="squirrel_searchbarWrapper js_squirrel_ignore_close_suggest" data-qa-id="search-field-wrapper" data-qa="ftfind-search-wrapper">
+        <form class="js_squirrel_searchForm" action="/suche" data-article-number-search="/p/search/">
+            <div class="squirrel_searchline">
+                <div class="squirrel_searchbar js_squirrel_searchbar js_squirrel_ignore_close_suggest">
+                    <input class="squirrel_searchbar__input js_squirrel_searchbar__input js_squirrel_ignore_close_suggest"
+                           data-qa-id="search-field" data-qa="ftfind-search-field"
+                           type="text" placeholder="Wonach suchst du?"
+                           autocomplete="off"
+                           autocorrect="off" maxlength="50" disabled="disabled"/>
+                    <div class="squirrel_searchbar__delete js_squirrel_searchbar__delete" data-qa-id="search-field-reset">
+                        <svg class="pl_icon" data-qa="ftfind-search-reset" role="img">
+                            <use xlink:href="/assets-static/icons/pl_icon_close.svg#pl_icon_close"/>
+                        </svg>
+                    </div>
+                    <div class="squirrel_searchbar__submit js_squirrel_searchbar__submit" data-qa-id="search-field-submit">
+                        <svg class="pl_icon" data-qa="ftfind-search-submit" role="img">
+                            <use xlink:href="/assets-static/icons/pl_icon_search.svg#pl_icon_search"/>
+                        </svg>
+                    </div>
+                </div>
+                <span class="squirrel_searchline__abort js_squirrel_searchline__abort">Abbrechen</span>
+            </div>
+        </form>
+        <div class="squirrel_searchSuggestionsContainer js_squirrel_searchSuggestionsContainer js_squirrel_ignore_close_suggest"
+             data-qa-id="search-suggestions"
+             data-suggestserveruri="/san-squirrel-suggest-api/completion"
+             data-suggestscope="//catalog01/de_DE">
+            <!-- insert template searchSuggest.mustache -->
+        </div>
+    </div>
+    <div class="squirrel_searchCurtain js_squirrel_searchCurtain"></div>
+</div>
+<script type="text/javascript">
+  if (!!o_squirrel && !!o_squirrel.searchHandler) {
+    o_squirrel.searchHandler.init();
+  }
+</script>
+
+        <div class="find_headerIcons">
+            <div class="find_headerIcon find_searchIcon">
+    <div class="squirrel_searchIcon js_squirrel_searchIcon">
+    <span class="p_icons squirrel_searchIcon__icon">»</span>
+    <span class="squirrel_searchIcon__label">Suche</span>
+</div>
+<script type="text/javascript">
+  if (!!o_squirrel && !!o_squirrel.searchbar) {
+    o_squirrel.searchbar();
+  }
+</script>
+
+            </div>
+            <div class="find_headerIcon find_serviceIcon">
+                <a id="serviceLink" href="/shoppages/service/"
+                   data-tracking="{&quot;san_Header&quot;:&quot;service&quot;}">
+                    <span class="p_icons find_headerIcon__icon">s</span>
+                    <span class="find_headerIcon__label">Service</span>
+                </a>
+            </div>
+            <div class="find_headerIcon find_userIcon">
+
+<div id="us_js_id_loginAreaContainerWrapper" class="us_loginAreaContainerWrapper" style="visibility: hidden">
+    <div id="us_js_id_loginAreaContainerToReplace" class="us_loginAreaContainerBackground">
+        <a class="us_loginAreaFallbackLink" href="/user/accountOverview">
+            <span class="p_icons us_loginAreaContainerIcon">Θ</span>
+            <span class="us_iconSubtitle">Mein Konto</span>
+        </a>
+    </div>
+<link href="/user/assets/ft4.user.login-area.a5a182bf.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/user/assets/ft4.user.login-area.a5a182bf.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" crossorigin="anonymous" href="/user/assets/ft4.user.login-area.3b346b0d.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/></div>
+
+            </div>
+            <div class="find_headerIcon find_wishlistIcon">
+    <link rel="stylesheet" href="/wishlist-view/statics/ft1.wishlist-view.miniWishlist.6306a45b.css" crossorigin="anonymous" integrity="sha256-rTxcaUP2bC2z4qiavRGCDr/kM3DYsLwFH2PxIbJHYuw=">
+
+<link rel="modulepreload" href="/wishlist-view/statics/ft1.wishlist-view.miniWishlist.module.24299b32.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/wishlist-view/statics/ft1.wishlist-view.miniWishlist.nomodule.711da6fd.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+
+<span style="display: none" class="wl_toggleInfo"
+      data-toggles-active="REMOVE_UP_DELIVERY_FLAT_VARIATION">
+</span>
+<a href="/wishlist-view/" class="wl_mini__link">
+    <div class="wl_mini wl_js_mini_link "
+         title="Mein Merkzettel">
+        <span class="p_icons wl_mini__icon">&hearts;</span>
+        <span class="wl_mini__badge pl_badge--grey wl_mini__badge--empty wl_js_mini_amount"
+              data-qa="miniWishlistAmount"
+              data-amount-url="/wishlist-view/mini/amount.json">
+    </span>
+        <span class="wl_mini__text">Merkzettel</span>
+    </div>
+</a>
+
+            </div>
+            <div class="find_headerIcon find_basketIcon">
+
+<link rel="preload" critical="critical" crossorigin="anonymous" href="/order/statics/ft1.order-core.common-public.9b8d052b.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/><link rel="stylesheet" href="/order/statics/ft1.order-core.minibasket.32c2269d.css" integrity="sha256-R9uwmcwZ4eqo7cu5aHbpt5uIZa1YiAlunjUcLe0328w=" crossorigin="anonymous"/>
+<link rel="preload" crossorigin="anonymous" href="/order/statics/ft1.order-core.minibasket.95d21f5b.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/><div class="or_minis or_minibasket order_js_minibasket_link ub64e ts-link"
+     data-ub64e="L29yZGVyL2Jhc2tldA=="
+     data-ts-link='{"san_Header":"basket"}'
+     title="Zum Warenkorb">
+
+    <span class="p_icons or_minis__icon">+</span>
+    <span class="or_minis__badge or_minis__badge--empty p_badge100 order_js_minibasket_amount"
+          data-loadurl="/order/basket/amount.json"
+          data-qa="miniBasketAmount"></span>
+    <span class="or_minis__text">Warenkorb</span>
+</div>
+
+
+<div id="order_js_settings" data-settings="TEST_USERS_ARE_ALWAYS_VERIFIED_CUSTOMERS,FT1_ENABLE_FEATURE_TRACKING" ></div>
+            </div>
+        </div>
+        </div>
+    </div>
+
+    <div class="nav_menu nav_menu--invisible" id="nav_menu" style="display: none;"><div class="nav_level-container nav_level-container--level-1"><div class="nav_navi-panel nav_navi-panel--level-1 nav_navi-panel--full-screen nav_navi-panel--with-bottom-divider" data-nav-swipe-status="initial"><div class="nav_navi-panel__body"><ul class="nav_navi-list nav_navi-list--level-1 nav_navi-list--tiles-layout nav_navi-list--bottom-spacing"><li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-1" data-nav-down-link="/nav-chekov/menu-fragment/(und.(oder.(ist.thema.thmntag_neuheit).(ist.trend.pride)).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:1,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Inspiration&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;inspiration&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:1,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Inspiration&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;inspiration&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/inspiration/"><span class="nav_navi-elem__tile-title">Inspiration</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/001_2020_05_kamp_ir01_thementeaser_quadratisch_54247/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-1" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.accessoires.augenpflege.bademode.bartpflege.bekleidung.erotik.gepaeck.gesichtspflege.haarentfernung.haarpflege.haarstyling.hautpflege.make-up.manikuere-pedikuere.parfums.schmuck.sonnenpflege.taschen-rucksaecke.waesche.zahnpflege).(ist.zielgruppe.damen).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:2,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Damen&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;damen&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:2,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Damen&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;damen&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/damen/"><span class="nav_navi-elem__tile-title">Damen</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/cd05c6c6-8692-5b95-95c3-c221f3e2a99c/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-1" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.accessoires.augenpflege.bademode.bartpflege.bekleidung.erotik.gepaeck.gesichtspflege.haarentfernung.haarpflege.haarstyling.hautpflege.make-up.manikuere-pedikuere.parfums.schmuck.sonnenpflege.taschen-rucksaecke.waesche.zahnpflege).(ist.zielgruppe.herren).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:3,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Herren&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;herren&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:3,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Herren&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;herren&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/herren/"><span class="nav_navi-elem__tile-title">Herren</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/28397874/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-1" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.accessoires.bademode.bekleidung.gepaeck.schmuck.taschen-rucksaecke.waesche).(ist.zielgruppe.jungen.maedchen).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:4,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Kinder&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;kindermode&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:4,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Kinder&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;kindermode&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/?selektion=(und.(ist.sortiment.accessoires.bademode.bekleidung.gepaeck.schmuck.taschen-rucksaecke.waesche).(ist.zielgruppe.jungen.maedchen).(~.(v.1)))"><span class="nav_navi-elem__tile-title">Kinder</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/307b2380-0331-5b49-bfbb-6d606ff15bf6/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-1" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.bademode.waesche).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:5,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;W\u00e4sche\/Bademode&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;waesche-bademode&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:5,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;W\u00e4sche\/Bademode&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;waesche-bademode&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/mode/waesche-bademode/"><span class="nav_navi-elem__tile-title nav_navi-elem--wbr">Wäsche/<wbr />Bademode</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/e217dc5d-7741-579c-aa44-555000e3f458/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-1" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.thema.sport).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:6,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Sport&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;sport&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:6,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Sport&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;sport&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/sport/"><span class="nav_navi-elem__tile-title">Sport</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/18517368/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-1" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.bekleidung).(sind.kategorien.schuhe).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:7,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Schuhe&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;schuhe&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:7,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Schuhe&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;schuhe&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/mode/schuhe/"><span class="nav_navi-elem__tile-title">Schuhe</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/c8ae0890-fc5d-5ba6-8571-51eeb1fa082b/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-1" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.grossegroesse).(ist.zielgruppe.damen.herren).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:8,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Gro\u00dfe Gr\u00f6\u00dfen&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;grosse-groessen&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:8,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Gro\u00dfe Gr\u00f6\u00dfen&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;grosse-groessen&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/mode/?grossegroesse"><span class="nav_navi-elem__tile-title">Große Größen</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/2fbee55d-4d4e-574d-914f-11b50625be5f/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.buerotechnik.kommunikation.medien.navigation.optik.technik-zubehoer.unterhaltungselektronik).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:9,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Multimedia&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;multimedia&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:9,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Multimedia&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;multimedia&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/technik/multimedia/"><span class="nav_navi-elem__tile-title">Multimedia</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/34177157/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.augenpflege.bartpflege.erotik.gesichtspflege.gesundheitsprodukte.haarentfernung.haarstyling.haushaltsgeraete.haushaltswaren.hautpflege.lebensmittel.make-up.manikuere-pedikuere.parfums.pflegemittel.reinigungsgeraete.sonnenpflege.zahnpflege).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:10,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Haushalt&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;haushalt&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:10,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Haushalt&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;haushalt&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/haushalt/"><span class="nav_navi-elem__tile-title">Haushalt</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/20608712/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.raum.kueche).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:11,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;K\u00fcche&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;kueche&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:11,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;K\u00fcche&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;kueche&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/moebel/?ansicht=einstieg&amp;thema=kueche"><span class="nav_navi-elem__tile-title">Küche</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/35333038/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ansicht.variante).(oder.(ist.sortiment.heimtextilien).(und.(ist.sortiment.moebel).(sind.kategorien.lattenroste)).(und.(ist.sortiment.waesche).(sind.kategorien.bademaentel))).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:12,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Heimtextilien&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;heimtextilien&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:12,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Heimtextilien&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;heimtextilien&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/heimtextilien/?ansicht=einstieg"><span class="nav_navi-elem__tile-title">Heimtextilien</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/18763571/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ansicht.variante).(ist.sortiment.aufbewahrung.beleuchtung.dekoration.haushaltswaren.heimtextilien.moebel).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:13,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;M\u00f6bel&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;moebel&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:13,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;M\u00f6bel&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;moebel&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/moebel/?ansicht=einstieg"><span class="nav_navi-elem__tile-title">Möbel</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/19992267/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(oder.(ist.sortiment.autozubehoer.bauelemente.baumaschinen.baumaterialien.bewaesserung.bodenbelaege.eisenwaren.elektroinstallation.fahrzeuge.farben-lacke.gartengeraete.gartengestaltung.gebaeude.heizen-klima.insektenschutz.pflanzenpflege.pools.sanitaer.sicherheitstechnik.sonnenschutz.tierbedarf.werkzeug).(und.(ist.sortiment.heimtextilien).(oder.(sind.kategorien.auflagen.gartenliegenauflagen).(sind.kategorien.duschvorhaenge).(sind.kategorien.rollos).(sind.kategorien.tapeten))).(und.(ist.sortiment.reinigungsgeraete).(oder.(sind.kategorien.besen.akkubesen).(sind.kategorien.besen.dampfbesen).(sind.kategorien.dampfreiniger).(sind.kategorien.hochdruckreiniger).(sind.kategorien.kehrmaschinen).(sind.kategorien.sauger.dampfsauger).(sind.kategorien.sauger.nass-trockensauger)))).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:14,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Baumarkt&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;baumarkt&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:14,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Baumarkt&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;baumarkt&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/baumarkt/"><span class="nav_navi-elem__tile-title">Baumarkt</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/2e04cc29-0785-5cbf-ad7b-24c9bc19c946/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.accessoires.beauty.bekleidung.buerotechnik.moebel.sanitaer.schmuck.taschen-rucksaecke.uhren.unterhaltungselektronik).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:15,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Marken&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;marken&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:15,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Marken&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;marken&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/marken/"><span class="nav_navi-elem__tile-title">Marken</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/001_2020_28_kund_repraesentant_fuer_marken_kleine_shoppromotion_72615/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.spielzeug).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:16,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Spielzeug&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;spielzeug&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:16,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Spielzeug&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;spielzeug&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/spielzeug/"><span class="nav_navi-elem__tile-title">Spielzeug</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/14539649/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.reduziert).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:17,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;%Sale%&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;sale&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:17,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;%Sale%&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;sale&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/sale/"><span class="nav_navi-elem__tile-title">%Sale%</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/001_2019_09_sale_dauerhafteaktionen_flexpage_22966_shopteaser_3/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> </ul></div></div></div></div><link rel="preload" href="/nav-chekov/static/compiled/nav.chekov.kirk_bundle.1e2042c7.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/nav-chekov/static/compiled/nav.chekov.kirk_bundle.1e2042c7.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/nav-chekov/static/compiled/nav.chekov.kirk_bundle.module.197aeb7a.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/nav-chekov/static/compiled/nav.chekov.kirk_bundle.nomodule.ce16500b.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+</header>
+                <div class="content contentFullWidth">
+
+    <div class="nav_grimm-breadcrumb-container nav_grimm-breadcrumb-container--product-page" data-nav-testing="breadcrumb-container" style="visibility:hidden;"><script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"item":{"@id":"https:\/\/www.otto.de\/","name":"Startseite"}},{"@type":"ListItem","position":2,"item":{"@id":"https:\/\/www.otto.de\/haushalt\/","name":"Haushalt"}},{"@type":"ListItem","position":3,"item":{"@id":"https:\/\/www.otto.de\/haushalt\/herde-kochfelder\/","name":"Herde & Kochfelder"}},{"@type":"ListItem","position":4,"item":{"@id":"https:\/\/www.otto.de\/haushalt\/backoefen\/","name":"Back\u00f6fen"}},{"@type":"ListItem","position":5,"item":{"@id":"https:\/\/www.otto.de\/haushalt\/backoefen\/pyrolyse-backoefen\/?thema=herde-kochfelder,unser_tipp","name":"Pyrolyse Back\u00f6fen"}}]}</script><div class="nav_grimm-breadcrumb-container__breadcrumb"><ul class="nav_grimm-breadcrumb"><li class="nav_grimm-breadcrumb__icon-item" data-nav-testing="breadcrumb-list-refer-back" id="nav_breadcrumb-list-refer-back"><div class="nav_grimm-refer-back"><span class="p_icons"></span></div></li><li class="nav_grimm-breadcrumb__list-item nav_grimm-breadcrumb__ellipsis-item" data-nav-testing="breadcrumb-path-element"><a class="nav_grimm-breadcrumb__link ts-link" data-nav-testing="breadcrumb-path-element-link" data-ts-link="{&quot;san_Interaction&quot;:&quot;breadcrumb&quot;, &quot;san_Navigation&quot;:&quot;Breadcrumb&quot;}" href="/haushalt/herde-kochfelder/">…</a></li> <li class="nav_grimm-breadcrumb__list-item " data-nav-testing="breadcrumb-path-element"><a class="nav_grimm-breadcrumb__link ts-link" data-nav-testing="breadcrumb-path-element-link" data-ts-link="{&quot;san_Interaction&quot;:&quot;breadcrumb&quot;, &quot;san_Navigation&quot;:&quot;Breadcrumb&quot;}" href="/">Startseite</a></li> <li class="nav_grimm-breadcrumb__list-item " data-nav-testing="breadcrumb-path-element"><a class="nav_grimm-breadcrumb__link ts-link" data-nav-testing="breadcrumb-path-element-link" data-ts-link="{&quot;san_Interaction&quot;:&quot;breadcrumb&quot;, &quot;san_Navigation&quot;:&quot;Breadcrumb&quot;}" href="/haushalt/">Haushalt</a></li> <li class="nav_grimm-breadcrumb__list-item " data-nav-testing="breadcrumb-path-element"><a class="nav_grimm-breadcrumb__link ts-link" data-nav-testing="breadcrumb-path-element-link" data-ts-link="{&quot;san_Interaction&quot;:&quot;breadcrumb&quot;, &quot;san_Navigation&quot;:&quot;Breadcrumb&quot;}" href="/haushalt/herde-kochfelder/">Herde &amp; Kochfelder</a></li> <li class="nav_grimm-breadcrumb__list-item nav_grimm-breadcrumb__always-visible-list-item" data-nav-testing="breadcrumb-path-element"><a class="nav_grimm-breadcrumb__link ts-link" data-nav-testing="breadcrumb-path-element-link" data-ts-link="{&quot;san_Interaction&quot;:&quot;breadcrumb&quot;, &quot;san_Navigation&quot;:&quot;Breadcrumb&quot;}" href="/haushalt/backoefen/">Backöfen</a></li> <li class="nav_grimm-breadcrumb__list-item nav_grimm-breadcrumb__always-visible-list-item" data-nav-testing="breadcrumb-path-element"><a class="nav_grimm-breadcrumb__link ts-link" data-nav-testing="breadcrumb-path-element-link" data-ts-link="{&quot;san_Interaction&quot;:&quot;breadcrumb&quot;, &quot;san_Navigation&quot;:&quot;Breadcrumb&quot;}" href="/haushalt/backoefen/pyrolyse-backoefen/?thema=herde-kochfelder,unser_tipp">Pyrolyse Backöfen</a></li> </ul></div></div><link rel="preload" href="/nav-grimm/static/compiled/nav.grimm.main.a9b504b7.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/nav-grimm/static/compiled/nav.grimm.main.a9b504b7.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/nav-grimm/static/compiled/nav.grimm.main.module.5f513935.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/nav-grimm/static/compiled/nav.grimm.main.nomodule.04a4985d.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+<div class="prd_messageWrapper" id="js_messageWrapper"></div>
+
+    <div class="exactag js_exactag"
+        data-trigger="productDetailView"
+        data-detailviewtype="detailview"
+        data-variationId="682285928"
+        data-productId="682285688"
+        data-contextPathUrl="/product"
+        data-mainimage=""
+        data-pt="Artikeldetailseite"
+        data-mp="64649515"
+        data-pr="1">
+    </div>
+<meta itemprop="gtin13" content="8003437938573">
+<meta itemprop="sku" content="6464951530"/>
+<div class="js_metaVariationId" itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
+    <meta itemprop="name" content="variationId"/>
+    <meta itemprop="value" content="682285928"/>
+</div>
+<div id="detailviewWrapper" class="detailviewWrapper prd_detailviewWrapper js_prd_detailviewWrapper"
+         data-config-installments-config-b="false"
+         data-variationid="682285928" data-product-resource-id="682285688"
+         data-variation-rendered-on-server-side="true"
+         data-config-customer-review-user-data-url="/product-customerreview/reviews/getUserDataForReviewSubmitLayer/682285688"
+         data-config-shoppages-system-url="/shoppages">
+<section class="prd_section">
+    <div class="prd_module prd_module--noLine prd_shortInfo">
+    <h1 itemprop="name" class="js_shortInfo__variationName prd_shortInfo__variationName" data-qa="variationName">Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie</h1>
+            <div class="prd_shortInfo__gratisInformation">
+                <div class="p_label100 prd_shortInfo__gratisIcon">+ Gratis</div>
+                <div class="prd_shortInfo__gratisText text">50 Monate Herstellergarantie</div>
+            </div>
+        <div class="cr_aggregation">
+
+        <span class="cr_aggregation__starsWithAmount js_hasPaliTooltip cr_js_customerReviewPageLink" data-tooltip="Alle Kundenbewertungen anzeigen" data-tooltip-pos="mouse" data-tooltip-touch="false" data-qa="ratingStarsAggregated" data-tracking-information="top">
+            <div>
+
+    <span class="cr_aggregation__rating p_rating100">* * * * o</span>
+    <span class="pl_link100--primary">(90)</span>
+</div>
+
+        </span>
+
+
+</div>
+
+    <div class="prd_shortInfo__expertReviews js_prd_shortInfoExpertReviews"></div>
+</div>
+</section>
+<section id="detailview" class="detailview prd_section prd_section--flex" data-qa="detailview">
+    <div id="js_prd_colWithProductImages" class="prd_section__col prd_section__col--15Of24">
+
+<div class="prd_module prd_module--fullHeight prd_module--noPadding prd_productImages prd_productImages--dynamic js_prd_productImages">
+    <div class="prd_productImages__stickyContainer js_prd_productImagesStickyContainer">
+    <div class="prd_productImages__root js_prd_productImagesRoot" id="js_prd_productImagesRoot">
+<script class="js_prd_productImagesConfig" type="application/json">
+{"dynamicVerticalImages":true,"includeOutfitButton":true,"increaseHeight":true,"sticky":true}
+</script>
+        <script>
+            document.getElementById('js_prd_productImagesRoot').addEventListener('error', function(event) {
+                var target = event.target;
+                if (target.tagName === 'IMG') {
+                    var fallbackUrl = target.getAttribute('data-fallback-url');
+                    if (fallbackUrl && target.src != fallbackUrl) {
+                        target.src = fallbackUrl;
+                        target.alt = 'ohne Abbildung';
+                    }
+                }
+            }, true);
+        </script>
+        <div class="prd_mainImageWithSwiping prd_mainImageWithSwiping--increaseHeight js_prd_mainImageWithSwiping">
+<div class="prd_deal js_prd_deal"></div>            <div title="Jetzt günstiger!" class="reducedImage js_reducedImage prd_hidden">%</div>
+
+            <div class="prd_swiper-container js_prd_swiper-container" data-qa="swiper-slide-active">
+                <div class="prd_swiper-wrapper js_prd_swiper-wrapper">
+
+                                    <!--js_prd_zoomWrapper is a HTML API (see README.md), DO NOT REMOVE-->
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper">
+
+            <span class="prd_verticalAlignHelper">
+            </span><a href="https://i.otto.de/i/otto/19651738/privileg-family-edition-pyrolyse-backofen-pbwr6-op8v2-in-mit-2-fach-teleskopauszug-pyrolyse-selbstreinigung-50-monate-herstellergarantie.jpg?$formatz$" onclick="event.preventDefault()"><img id="prd_mainProductImage"
+                        class="js_prd_inPlaceZoomSrc"
+                        src="https://i.otto.de/i/otto/19651738?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+                        alt="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie"
+                        onload="this.setAttribute('data-loaded', 'true')"
+                        data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+                        data-index="0"/></a>
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/19651739?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+             data-image-text="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/19651740?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+             data-image-text="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/19651741?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+             data-image-text="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/19651742?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+             data-image-text="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/18463778?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+             data-image-text="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/32530018?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+             data-image-text="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/32530357?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+             data-image-text="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/25218326?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;481&amp;sm&#61;clamp"
+             data-image-text="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie">
+        </div>
+
+
+                </div>
+            </div>
+            <span class="js_prd_mainImageWithSwipingAspectRatioHelper prd_mainImageWithSwiping__aspectRatioHelper" style="padding-top: 143%;"></span>
+                <div class="prd_imageOverlays js_prd_imageOverlays"></div>
+        </div>
+        <div class="prd_productImages__verticalImageControlWrapper">
+            <div id="js_prd_verticalImageControl" class="prd_verticalImageControl prd_verticalImageControl--withVideo">
+                <ul id="js_prd_verticalImageControlThumbnailList" class="prd_verticalImageControl__thumbnailList">
+                        <li class="prd_verticalImageControl__thumbnailItem prd_verticalImageControl__thumbnailItem--selected" data-index="0"><img src="https://i.otto.de/i/otto/19651738?$001PICT36$" alt="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie, Bild 1" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="19651738"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="1"><img src="https://i.otto.de/i/otto/19651739?$001PICT36$" alt="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie, Bild 2" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="19651739"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="2"><img src="https://i.otto.de/i/otto/19651740?$001PICT36$" alt="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie, Bild 3" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="19651740"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="3"><img src="https://i.otto.de/i/otto/19651741?$001PICT36$" alt="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie, Bild 4" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="19651741"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="4"><img src="https://i.otto.de/i/otto/19651742?$001PICT36$" alt="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie, Bild 5" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="19651742"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="5"><img src="https://i.otto.de/i/otto/18463778?$001PICT36$" alt="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie, Bild 6" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="18463778"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="6"><img src="https://i.otto.de/i/otto/32530018?$001PICT36$" alt="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie, Bild 7" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="32530018"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="7"><img src="https://i.otto.de/i/otto/32530357?$001PICT36$" alt="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie, Bild 8" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="32530357"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="8"><img src="https://i.otto.de/i/otto/25218326?$001PICT36$" alt="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie, Bild 9" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="25218326"></li>
+                </ul>
+                <div id="js_prd_verticalImageControlBtnWrapperTop" class ="prd_verticalImageControl__btnWrapper prd_verticalImageControl__btnWrapper--top">
+                    <button id="js_prd_verticalImageControlBtnUp" class="p_symbolBtn100--4th prd_verticalImageControl__btn" type="button"><i>^</i></button>
+                </div>
+                <div id="js_prd_verticalImageControlBtnWrapperBottom" class="prd_verticalImageControl__btnWrapper prd_verticalImageControl__btnWrapper--bottom">
+                    <button id="js_prd_verticalImageControlBtnDown" class="p_symbolBtn100--4th prd_verticalImageControl__btn" type="button"><i>v</i></button>
+                        <div class="prd_videoLink js_prd_videoLink" data-msck="682285688">
+                            <div class="prd_videoLink__icon"></div>
+                            <div class="prd_videoLink__caption">Videos</div>
+                        </div>
+                </div>
+            </div>
+        </div>
+
+            <div class="videoLinkSAndMWrapper">
+                <div class="pl_link75--primary js_prd_videoLink videoLinkSAndM"
+                     data-msck="682285688">Produktvideo abspielen</div>
+            </div>
+            <div itemscope itemtype="http://schema.org/VideoObject" class="js_schemaOrg">
+                <meta itemprop="thumbnailUrl" content="https://edge.mycliplister.com/cls/content/thumb/86605/917231/privileg-family-edition-pyrolyse-backofen-pbwr6-op8v2-in-mit-2-fach-teleskopauszug-pyrolyse-selbstreinigung-50-monate-herstellergarantie.jpg"/>
+                <meta itemprop="contentURL" content="https://edge.mycliplister.com/cls/content/clip/86605/917231/privileg-family-edition-pyrolyse-backofen-pbwr6-op8v2-in-mit-2-fach-teleskopauszug-pyrolyse-selbstreinigung-50-monate-herstellergarantie.flv"/>
+                <meta itemprop="height" content="1080"/>
+                <meta itemprop="width" content="1920"/>
+                <meta itemprop="name" content="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie"/>
+                <meta itemprop="url" content="https://www.otto.de/p/privileg-family-edition-pyrolyse-backofen-pbwr6-op8v2-in-mit-2-fach-teleskopauszug-pyrolyse-selbstreinigung-50-monate-herstellergarantie-682285688/"/>
+                <meta itemprop="description" content="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie"/>
+                <meta itemprop="duration" content="PT55S"/>
+            </div>
+            <div class="prd_outfitButton"></div>
+    </div>
+    </div>
+</div>
+    </div>
+    <div class="prd_section__col prd_section__col--9Of24">
+<div class="prd_module prd_dimensions" id="js_prd_dimensionsSelection"
+     data-enableCoverColorCombo="true"
+     data-coverColorComboWide="false"></div><div class="prd_module prd_module--noLine prd_customDimensions js_customDimensions"></div><div class="prd_module prd_cashback js_prd_cashback"></div><div class="prd_module prd_deliveryInfo" data-qa="prd_ordering">
+    <div class="js_prd_availability prd_availability" data-aob-active="false" data-is-aob-stock-customer="false"></div>
+    <div class="js_deliveryServices prd_deliveryServices"></div>
+</div>
+
+                    <link rel="preload" crossorigin="anonymous" href="/product-articleoptions/static/js/ft5.articleoptions.891d2a2f.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-articleoptions/static/css/ft5.articleoptions.4f175868.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/product-articleoptions/static/css/ft5.articleoptions.4f175868.css" crossorigin="anonymous"/></noscript>
+<script id="articleoptionsJson" type="application/json">{"682285928":{"id":"682285928","options":[{"id":"9602abd7-363a-4f64-8aa8-ae156420279b","displayName":"Altgeräte-Rücknahme nach Gesetz","group":"DISPOSAL","mandatory":false,"selected":false,"retailPrice":0,"contentUrl":"/shoppages/altgeraete_ruecknahme_nach_gesetz_hes","iconUrl":"https://i.otto.de/i/otto/001_service_mitnahme-entsorgung_rgb_90px_checkout","variationOptionConstraints":{"value":{"maximumOrderQuantity":1,"deliveryForDesiredDate":true,"deliveryWithin24H":true}},"formattedRetailPrice":"0,00"},{"id":"bbcb9bb5-e430-41f0-a1df-9370e71a14e5","displayName":"Installationsservice für Elektro-Einbaugeräte","group":"INSTALLATION","mandatory":false,"selected":false,"retailPrice":6000,"contentUrl":"/shoppages/installation_devices","iconUrl":"https://i.otto.de/i/otto/001_service_aufbau-anschluss_rgb_90px_checkout","variationOptionConstraints":{"value":{"maximumOrderQuantity":1,"deliveryForDesiredDate":false,"deliveryWithin24H":false}},"formattedRetailPrice":"60,00"}],"noHeadline":true,"uuid":"54b8806a-101d-4f3b-847f-914aafe12ae4"}}</script>
+<div class="prd_module" id="articleoptions" data-variationId="682285928"><ul>
+        <li class="ao_item pl_copy100">
+            <input id="54b8806a-101d-4f3b-847f-914aafe12ae4" data-id="9602abd7-363a-4f64-8aa8-ae156420279b" name="Altgeräte-Rücknahme nach Gesetz" type="checkbox" class="js_ao_item__invisibleCheckbox ao_item__invisibleCheckbox" tabindex="5">
+            <label class="ao_item__choice" data-id="9602abd7-363a-4f64-8aa8-ae156420279b" for="54b8806a-101d-4f3b-847f-914aafe12ae4">Altgeräte-Rücknahme nach Gesetz</label>
+            <span class="ao_item__price"> €&nbsp;0,00</span>
+            <span class="js_openInPaliLayer ao_item__details pl_link100--primary" data-layer-href="/shoppages/shoppages/altgeraete_ruecknahme_nach_gesetz_hes">Details</span>
+        </li>
+        <li class="ao_item pl_copy100">
+            <input id="54b8806a-101d-4f3b-847f-914aafe12ae4" data-id="bbcb9bb5-e430-41f0-a1df-9370e71a14e5" name="Installationsservice für Elektro-Einbaugeräte" type="checkbox" class="js_ao_item__invisibleCheckbox ao_item__invisibleCheckbox" tabindex="5">
+            <label class="ao_item__choice" data-id="bbcb9bb5-e430-41f0-a1df-9370e71a14e5" for="54b8806a-101d-4f3b-847f-914aafe12ae4">Installationsservice für Elektro-Einbaugeräte</label>
+            <span class="ao_item__price"> €&nbsp;60,00</span>
+            <span class="js_openInPaliLayer ao_item__details pl_link100--primary" data-layer-href="/shoppages/shoppages/installation_devices">Details</span>
+        </li>
+</ul></div>
+
+
+
+<div class="prd_module prd_module--noLine prd_module--highlight prd_priceBox js_prd_priceBox">
+<script class="js_prd_priceBoxConfig" type="application/json">
+{"includeSale":true,"includeHighlight":true,"includeCampaigns":true,"includeInstallments":true,"includeOttoUp":true,"variationIsAvailable":true}
+</script>
+    <div class="prd_price js_prd_price" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+    <link itemprop="itemCondition" href="http://schema.org/NewCondition"/>
+        <link itemprop="availability" href="http://schema.org/InStock"/>
+    <meta itemprop="priceCurrency" content="EUR"/>
+    <div class="prd_price__sale"><span class="prd_price__label" id="priceAdvantageAmount">-73%</span><span id="suggestedRetailPrice" class="pl_mr25 js_hasPaliTooltip" data-tooltip="Unverbindliche Preisempfehlung des Herstellers">UVP</span><span class="prd_price__oldAmount" id="oldPriceAmountWithEuroSign">&euro; <span id="oldPriceAmount">1.219,00</span></span></div>
+           <div class="prd_price__highlight prd_price__highlight--reduced">nur diesen Monat</div>
+    <div class="prd_price__main js_prd_price__main">
+        <span class="prd_price__amount  pl_display100"> &euro;&nbsp;<span id="reducedPriceAmount" itemprop="price" content="333.00">333,00</span></span>
+        <div class="prd_price__note pl_copy75">inkl.&nbsp;MwSt. zzgl.&nbsp;Versandkosten</div>
+    </div>
+</div>
+    <div class="js_prd_benefitOttoUpTargetTop prd_benefitTarget"></div>
+    <div class="js_prd_benefitOttoUpTarget prd_benefitTarget"></div>
+
+</div>
+<div class="prd_module prd_module--noLine js_prd_partnerBenefitSlot prd_partnerBenefitSlot" data-cpgn-slot="partnerBenefit"></div><div class="prd_module prd_module--noLine prd_seller js_prd_seller">
+
+</div><div class="prd_module prd_module--noLine prd_module--gap75 prd_ordering js_prd_ordering"  data-qa="prd_ordering" data-aob-active="false">
+    <form class="p_form product_basket prd_ordering__form" method="POST" action="/order/addToBasket">
+        <div class="prd_ordering__row">
+                <input class="js_prd_orderingQuantity" data-qa="quantity" name="quantity" type="hidden" value="1">
+                <button data-qa="addToBasket" class=" prd_ordering__button pl_button100--primary js_product_addToBasket"
+                    autocomplete="off"
+                    disabled="disabled" type="submit">
+                    <i><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M17.8324 4.05c.641 0 1.1697.502 1.2029 1.1422l.7009 13.5442-.0042.127c-.0527.6166-.5699 1.1006-1.2001 1.1006H5.4645l-.1581-.0104c-.6136-.0805-1.0737-.619-1.0451-1.2486L4.8733 5.2c.029-.6434.5592-1.15 1.2032-1.15zm0 .949H6.0764a.2555.2555 0 00-.2551.244l-.612 13.505a.2555.2555 0 00.2437.2667l13.0789.0003a.2555.2555 0 00.2555-.2555l-.6999-13.5182a.2555.2555 0 00-.2551-.2423zm-2.7644 1.57c.242 0 .438.1958.438.438 0 1.2117-.3739 2.237-1.0805 2.9637-.6382.6561-1.4975 1.018-2.4197 1.018-1.7438 0-3.5091-1.3679-3.5091-3.9822 0-.2421.1959-.438.438-.438.242 0 .438.1959.438.438 0 2.134 1.3649 3.1058 2.6331 3.1058.6835 0 1.3196-.267 1.7914-.7524.5445-.56.8328-1.3739.8328-2.353 0-.242.1959-.438.438-.438z"></path>
+                    </svg></i>In den Warenkorb
+                </button>
+            <input class="js_prd_orderingVariationId" data-qa="product_variationId" type="hidden" name="variationId" value="682285928">
+        </div>
+    </form>
+</div><div class="prd_module prd_module--noLine prd_module--gap25 prd_wishlist2" data-qa="prd_wishlist">
+    <div class="prd_wishlist2__message js_prd_wishlist2__message" data-qa="add2WishlistSuccessMessage"></div>
+    <button type="button" class="pl_button100--secondary js_prd_wishlist2__button" disabled data-qa="wishlist">
+        <svg class="pl_icon" role="img">
+            <use xlink:href="/assets-static/icons/pl_icon_wishlist.svg#pl_icon_wishlist"></use>
+        </svg><span>Artikel merken</span>
+    </button>
+    <link rel="modulepreload" href="/wishlist-view/statics/ft1.wishlist-view.addToWishlistService.module.1ea5ea20.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/wishlist-view/statics/ft1.wishlist-view.addToWishlistService.nomodule.ecfcc1f4.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+
+<span style="display: none" class="wl_toggleInfo"
+      data-toggles-active="REMOVE_UP_DELIVERY_FLAT_VARIATION">
+</span>
+
+</div>
+<div class="prd_module prd_energyEfficiency prd_energyEfficiency--singleLine js_prd_energyEfficiency"></div>
+<link rel="preload" href="https://asset.live.coco.cloud.otto.de/static/coco.localoffers.searchWidget.390d88fe.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="https://asset.live.coco.cloud.otto.de/static/coco.localoffers.searchWidget.390d88fe.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="https://asset.live.coco.cloud.otto.de/static/coco.localoffers.searchWidget.module.c452d37d.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="https://asset.live.coco.cloud.otto.de/static/coco.localoffers.searchWidget.nomodule.350468d2.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+
+<div class="prd_module prd_localOffers js_prd_localOffers" data-product-ids="682285688"></div>
+        <div class="inPlaceZoom js_inPlaceZoom">
+            <div class="targetZoomImage js_targetZoomImage"></div>
+        </div>
+    </div>
+</section>
+<div id="pdp-frame" class="pdp_frame pl_grid-lane" data-block="pdp-frame" data-url="/dcs/pdp-frame/{variationId}">
+    <div class="pl_grid-container">
+        <!-- Bottom SECTION A -->
+        <div class="pl_grid-col-12">
+            <div class="pl_block pdp_platform-advantages js_pdp_platform-advantages"
+     data-ft5-view-tracking='{
+    "product_PlatformAdvantagesActivity":"view",
+    "product_PlatformAdvantagesType":"co2-neutraler versand|rechnung oder ratenzahlung|kostenlose rücksendung"}'>
+
+    <ul class="pdp_platform-advantages__list">
+            <li class="pdp_platform-advantages__item pdp_platform-advantages--co2 js_openInPaliSheet"
+                data-sheet-ub64e="L3Nob3BwYWdlcy9jbzJfbmV1dHJhbGVfbGllZmVydW5nX2Fkcw&#x3D;&#x3D;"
+                data-ft5-click-tracking='{"product_PlatformAdvantagesActivity": "open", "product_PlatformAdvantagesType": "co2-neutraler versand"}'>
+                <svg class="pl_icon pdp_platform-advantages__icon" role="img">
+                    <use xlink:href="/assets-static/icons/pl_icon_check.svg#pl_icon_check"/>
+                </svg>
+                <span class="pdp_platform-advantages__link pl_link75--secondary">
+                    <strong class="pdp_platform-advantages--green">CO<sub>2</sub>-neutraler Versand</strong> durch Kompensation
+                </span>
+            </li>
+            <li class="pdp_platform-advantages__item pdp_platform-advantages--invoice js_openInPaliSheet"
+                data-sheet-ub64e="L3Nob3BwYWdlcy9rYXVmX2F1Zl9yZWNobnVuZ19hZHM&#x3D;"
+                data-ft5-click-tracking='{"product_PlatformAdvantagesActivity": "open", "product_PlatformAdvantagesType": "rechnung oder ratenzahlung"}'>
+                <svg class="pl_icon pdp_platform-advantages__icon" role="img">
+                    <use xlink:href="/assets-static/icons/pl_icon_e-invoice.svg#pl_icon_e-invoice"/>
+                </svg>
+                <span class="pdp_platform-advantages__link pl_link75--secondary">
+                    Kauf auf Rechnung und Raten
+                </span>
+            </li>
+            <li class="pdp_platform-advantages__item pdp_platform-advantages--return js_openInPaliSheet"
+                data-sheet-ub64e="L3Nob3BwYWdlcy9rb3N0ZW5sb3NlX3J1ZWNrc2VuZHVuZ19hZHM&#x3D;"
+                data-ft5-click-tracking='{"product_PlatformAdvantagesActivity": "open", "product_PlatformAdvantagesType": "kostenlose rücksendung"}'>
+                <svg class="pl_icon pdp_platform-advantages__icon" role="img">
+                    <use xlink:href="/assets-static/icons/pl_icon_order-return.svg#pl_icon_order-return"/>
+                </svg>
+                <span class="pdp_platform-advantages__link pl_link75--secondary">
+                    Kostenlose Rücksendung
+                </span>
+            </li>
+    </ul>
+</div>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/platform-advantages-FPOOYKJH.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/platform-advantages-FPOOYKJH.css" crossorigin="anonymous"/></noscript>
+                <div class="pl_block pl_block--transparent pl_block--no-padding pdp_reco-productline pdp_reco-productline--e549-active js_pdp_reco-productline" data-variation-id="682285928"></div>
+
+  <link rel="preload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.3afc4579.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.3afc4579.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.module.46bea43c.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.nomodule.a87b68b8.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+
+<div style="display:none;" id="reco_cinema__toggle-state" data-toggle-state="{&quot;SHOW_DEALS&quot;:true,&quot;CSR&quot;:false,&quot;USE_OPAL_RELATIONSHIPS&quot;:true,&quot;TESLA_COLDSTART&quot;:false,&quot;USE_TESLA_ARTHURDENT&quot;:true,&quot;USE_TESLA_META&quot;:true,&quot;SHOW_DETAILVIEW_ONLY&quot;:false,&quot;DISPLAY_LAST_SEEN_ARTICLES&quot;:true,&quot;USE_TESLA_HITCHHIKER&quot;:true,&quot;WISHLIST_RECO_REDESIGN&quot;:true,&quot;RECO_REDESIGN&quot;:true}">
+</div>
+<script>
+  window.o_reco = window.o_reco || {};
+  window.o_reco.api = window.o_reco.api || {};
+  window.o_reco.private = window.o_reco.private || {};
+  window.o_reco.private.toggleState = JSON.parse(document.getElementById('reco_cinema__toggle-state').dataset.toggleState);
+
+  window.o_reco.private.delegate = function (originalFunction) {
+    return function () {
+      var passedArguments = arguments;
+      return new Promise(function (resolve, reject) {
+        o_global.eventLoader.onAllScriptsExecuted(10, function () {
+          window.o_reco.private[originalFunction].apply(null, passedArguments).then(resolve).catch(reject);
+        });
+      });
+    };
+  };
+
+  window.o_reco.private.delegateAndWrap = function (originalFunction) {
+    return function () {
+      var passedArguments = arguments;
+      return new Promise(function (resolve) {
+        o_global.eventLoader.onAllScriptsExecuted(10, function () {
+          var result = window.o_reco.private[originalFunction].apply(null, passedArguments);
+          resolve(result);
+        });
+      });
+    };
+  };
+
+  window.o_reco.api.initializeCinema = window.o_reco.private.delegateAndWrap('initializeCinema');
+  window.o_reco.api.initializeExpandableCinema = window.o_reco.private.delegateAndWrap('initializeExpandableCinema');
+  window.o_reco.api.loadRecommendationsForDetailView = window.o_reco.private.delegateAndWrap('asyncLoadRecommendationsForDetailView');
+
+  window.o_reco.api.loadRecommendationsForOrderOverview = window.o_reco.private.delegate('loadRecommendationsForOrderOverview');
+  window.o_reco.api.loadRecommendationsForWishlist = window.o_reco.private.delegate('loadRecommendationsForWishlist');
+  window.o_reco.api.loadRecommendationsForEntryPage =
+          window.o_reco.private.toggleState["CSR"] ?
+                  window.o_reco.private.delegateAndWrap('loadRecommendationsForEntryPageCsr') :
+                  window.o_reco.private.delegate('loadRecommendationsForEntryPage');
+  window.o_reco.api.loadBounceLayerCinema = window.o_reco.private.delegateAndWrap('loadBounceLayerCinema');
+
+  o_global.eventQBus.emit("ft6bcn.reco.init", ".reco.cinema.needsInitialization");
+</script>
+
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/reco-productline-FGYVZRSB.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/reco-productline-V53F2QXV.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/reco-productline-V53F2QXV.css" crossorigin="anonymous"/></noscript>
+        </div>
+        <!-- Bottom SECTION B -->
+        <div class="pl_grid-col-12 pl_grid-col-lg-8 pl_grid-col-lg--fill-remaining-space-with-block-color">
+            <div class="pl_block pdp_details-short-info">
+    <div class="pdp_details-short-info__wrapper">
+        <h2 class="pdp_details-short-info__title pl_headline200">Artikelbeschreibung</h2>
+        <div class="pdp_article-number pl_copy100" data-qa="articleNr" data-variation-id="682285928">
+    Artikel-Nr. <span itemprop="productID" class="pdp_article-number__number">6464951530</span>
+</div>
+
+    </div>
+        <div class="pdp_details-short-info__brand-image js_pdp_details-short-info__brand-image"
+             data-ft5-click-tracking='{"product_BrandLogo": "click"}'>
+            <a data-qa="brand"
+               href="/haushalt/?marke&#x3D;privileg-family-edition"
+               data-brand="Privileg Family Edition">
+                <span itemprop="brand">Privileg Family Edition</span>
+                <img src="https://i.otto.de/i/otto/b41aa7c26700144ac38f0ccee5baead9?$ov_brandlogo_retina$"
+                     alt="Privileg Family Edition" class="pdp_detail-short-info__logo">
+            </a>
+        </div>
+</div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/details-short-info-P6H74WEJ.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/details-short-info-P6H74WEJ.css" crossorigin="anonymous"/></noscript>
+            <link rel="preload" crossorigin="anonymous" href="/product-assets/quality-details-3FX75FTE.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/quality-details-GE3VIZPW.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/quality-details-GE3VIZPW.css" crossorigin="anonymous"/></noscript>
+            <div class="pl_block pl_block--no-gap pdp_selling-points">
+    <ul class="pl_list--unordered">
+            <li>Energieeffizienzklasse A+ (A+++ bis D)</li>
+            <li>8 Beheizungsarten</li>
+            <li>Pyrolyse-Selbstreinigung</li>
+            <li>Inkl. 2-fach Teleskopauszug</li>
+            <li>Turn&amp;Go - über 100 Rezepte mit nur einem Dreh</li>
+    </ul>
+</div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/selling-points-XTWGOXQG.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/selling-points-XTWGOXQG.css" crossorigin="anonymous"/></noscript>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/description-NOA62KQZ.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/description-OP6T3KIZ.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/description-OP6T3KIZ.css" crossorigin="anonymous"/></noscript>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/video-in-page-7DYG7U6Y.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+                <div class="js_pdp_manufacturer-content pl_block" data-variation-id="682285928">
+        <link rel="preload" crossorigin="anonymous" href="/product-richcontent/ft5-richcontent.css" as="style"
+              onload="invokePreload.onStyleLoad(this)"/>
+        <noscript>
+            <link rel="stylesheet" href="/product-richcontent/ft5-richcontent.css" crossorigin="anonymous"/>
+        </noscript>
+
+            <div class="pdp_manufacturer-content"
+                 data-provider-name="LOADBEE"
+                 data-qa="manufacturer-content-provider-container">
+                <div class="rc_component js_rc_component" data-provider="loadbee" data-ean="8003437938573"
+     data-other-providers="" data-provider-list-a2b="loadbee,displayed"
+     data-qa="rc_component">
+    <div class="rc_teaser rc_teaser--start js_rc_teaser">
+            <figure class="rc_teaser__figure">
+                <picture>
+                    <source media="(max-width: 767px)" srcset="/product-richcontent/images&#x2F;loadbee_8003437938573_mood_mobile.jpg"
+                            class="rc_teaser_img" data-qa="rc_mood-image-teaser-srcset">
+                    <source media="(min-width: 768px)" srcset="/product-richcontent/images&#x2F;loadbee_8003437938573_mood_desktop.jpg"
+                            class="rc_teaser_img" data-qa="rc_mood-image-teaser-srcset">
+                    <img src="/product-richcontent/images&#x2F;loadbee_8003437938573_mood_desktop.jpg" alt="Einbau-Backofen – PBWR6 OP8V2 IN"
+                         class="rc_teaser_img" data-qa="rc_mood-image-teaser-srcset">
+                </picture>
+            </figure>
+        <div class="rc_teaser__text">
+            <h1 class="rc_teaser__headline pl_headline100" data-qa="rc_teaser-headline">Einbau-Backofen – PBWR6 OP8V2 IN</h1>
+
+        </div>
+    </div>
+            <div class="rc_teaser rc_teaser--left js_rc_teaser" data-qa="rc_image-teaser-container">
+                <figure class="rc_teaser__figure">
+                    <picture>
+                        <source media="(max-width: 767px)" srcset="/product-richcontent/images&#x2F;loadbee_8003437938573_hl1_mobile.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <source media="(min-width: 768px)" srcset="/product-richcontent/images&#x2F;loadbee_8003437938573_hl1_desktop.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <img src="/product-richcontent/images&#x2F;loadbee_8003437938573_hl1_desktop.jpg" alt="Über 100 Rezepte mit nur einem Dreh"
+                             class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                    </picture>
+                </figure>
+                <div class="rc_teaser__container">
+                    <div class="rc_teaser__text">
+                        <h2 class="rc_teaser__headline pl_headline100" data-qa="rc_image-teaser-headline">Über 100 Rezepte mit nur einem Dreh</h2>
+                        <p class="pl_copy100" data-qa="rc_image-teaser-text">Profitieren Sie von der Turn&Go-Funktion, die Ihnen den Alltag leichter macht. Mit nur einem Dreh sind über 100 Gerichte in nur einer Stunde fertig. Die praktische Turn&Go Rezepte-App ist ab sofort im App-Store erhältlich.<br></p>
+                    </div>
+                </div>
+            </div>
+            <div class="rc_teaser rc_teaser--right js_rc_teaser" data-qa="rc_image-teaser-container">
+                <figure class="rc_teaser__figure">
+                    <picture>
+                        <source media="(max-width: 767px)" srcset="/product-richcontent/images&#x2F;loadbee_8003437938573_hl2_mobile.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <source media="(min-width: 768px)" srcset="/product-richcontent/images&#x2F;loadbee_8003437938573_hl2_desktop.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <img src="/product-richcontent/images&#x2F;loadbee_8003437938573_hl2_desktop.jpg" alt="Entdecken Sie die privileg Turn&Go App"
+                             class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                    </picture>
+                </figure>
+                <div class="rc_teaser__container">
+                    <div class="rc_teaser__text">
+                        <h2 class="rc_teaser__headline pl_headline100" data-qa="rc_image-teaser-headline">Entdecken Sie die privileg Turn&Go App</h2>
+                        <p class="pl_copy100" data-qa="rc_image-teaser-text">Die kostenlose Turn&Go-App ergänzt Ihren neuen Backofen ideal und bietet Ihnen über 100 Rezepte mit nur einem Dreh. Fotografieren Sie mit Ihrem Smartphone oder Tablet ein Lebensmittel, das Sie verwenden möchten. Die App erkennt das Lebensmittel und schlägt Ihnen passende Rezepte vor.<br></p>
+                    </div>
+                </div>
+            </div>
+            <div class="rc_teaser rc_teaser--left js_rc_teaser" data-qa="rc_image-teaser-container">
+                <figure class="rc_teaser__figure">
+                    <picture>
+                        <source media="(max-width: 767px)" srcset="/product-richcontent/images&#x2F;loadbee_8003437938573_hl3_mobile.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <source media="(min-width: 768px)" srcset="/product-richcontent/images&#x2F;loadbee_8003437938573_hl3_desktop.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <img src="/product-richcontent/images&#x2F;loadbee_8003437938573_hl3_desktop.jpg" alt="Saubere Backofentür in nur 2 Schritten"
+                             class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                    </picture>
+                </figure>
+                <div class="rc_teaser__container">
+                    <div class="rc_teaser__text">
+                        <h2 class="rc_teaser__headline pl_headline100" data-qa="rc_image-teaser-headline">Saubere Backofentür in nur 2 Schritten</h2>
+                        <p class="pl_copy100" data-qa="rc_image-teaser-text">Das patentierte Click&Clean-System ermöglicht die Reinigung der Backofentür in nur 2 Schritten. Entfernen Sie dazu einfach die Schiene am oberen Ende der Tür. So können Sie die Scheibe bequem entnehmen und mit minimalem Aufwand säubern.<br></p>
+                    </div>
+                </div>
+            </div>
+            <div class="rc_teaser rc_teaser--right js_rc_teaser" data-qa="rc_image-teaser-container">
+                <figure class="rc_teaser__figure">
+                    <picture>
+                        <source media="(max-width: 767px)" srcset="/product-richcontent/images&#x2F;loadbee_8003437938573_hl4_mobile.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <source media="(min-width: 768px)" srcset="/product-richcontent/images&#x2F;loadbee_8003437938573_hl4_desktop.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <img src="/product-richcontent/images&#x2F;loadbee_8003437938573_hl4_desktop.jpg" alt="Pyrolyse Selbstreinigungssystem"
+                             class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                    </picture>
+                </figure>
+                <div class="rc_teaser__container">
+                    <div class="rc_teaser__text">
+                        <h2 class="rc_teaser__headline pl_headline100" data-qa="rc_image-teaser-headline">Pyrolyse Selbstreinigungssystem</h2>
+                        <p class="pl_copy100" data-qa="rc_image-teaser-text">Die Premium-Funktion für eine mühelose Reinigung des Backofens. Dank der hohen Temperaturen während des Pyrolysezyklus werden Verschmutzungen wie Fett oder eingebrannte Verkrustungen in Asche verwandelt, die sich anschließend ganz einfach mit einem feuchten Schwamm entfernen lassen.<br><br></p>
+                    </div>
+                </div>
+            </div>
+            <div class="rc_teaser rc_teaser--left js_rc_teaser" data-qa="rc_image-teaser-container">
+                <figure class="rc_teaser__figure">
+                    <picture>
+                        <source media="(max-width: 767px)" srcset="/product-richcontent/images&#x2F;loadbee_8003437938573_hl5_mobile.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <source media="(min-width: 768px)" srcset="/product-richcontent/images&#x2F;loadbee_8003437938573_hl5_desktop.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <img src="/product-richcontent/images&#x2F;loadbee_8003437938573_hl5_desktop.jpg" alt="Backauszug 2-fach"
+                             class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                    </picture>
+                </figure>
+                <div class="rc_teaser__container">
+                    <div class="rc_teaser__text">
+                        <h2 class="rc_teaser__headline pl_headline100" data-qa="rc_image-teaser-headline">Backauszug 2-fach</h2>
+                        <p class="pl_copy100" data-qa="rc_image-teaser-text">Entnehmen Sie Ihre Backbleche durch den Backauszug auf 2 Ebenen kinderleicht und sicher.                                                  <br><br></p>
+                    </div>
+                </div>
+            </div>
+    <script class="js_prd_tracking_add2Basket" type="application/json" data-qa="rc_tracking-add2Basket">
+        {
+            "product_DetailInformation": "richcontent",
+            "product_RichContentProvider": "loadbee,displayed"
+        }
+    </script>
+</div>
+
+            </div>
+            <head><script defer="defer" src="/product-richcontent/ft5.richcontent-tracking.1ba9e5c71e4ac83f4b1f.min.js"></script></head>
+    </div>
+
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/manufacturer-content-SR4K6SHF.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/manufacturer-content-V2ACGY4U.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/manufacturer-content-V2ACGY4U.css" crossorigin="anonymous"/></noscript>
+                <div class="pl_block pdp_details js_pdp_details">
+        <h2 class="pl_headline200 pl_mb50">Details</h2>
+        <div class="pl_text-expander pl_copy100 pdp_details__text-expander js_pdp_details__text-expander" lang="de">
+                <div class="pdp_details__characteristics-html"><table class="dv_characteristicsTable"><caption>Top-Feature</caption><tr><td class="left"><span>Top-Features</span></td><td>Teleskopauszüge<br />Bedienung über Knebel<br />versenkbare Knebel<br />Turn&amp;Go: Profitieren Sie von der Turn&amp;Go-Funktion, die Ihnen den Alltag leichter macht. Mit nur einem Dreh sind über 100 Gerichte in nur einer Stunde fertig. Die praktische Turn&amp;Go Rezepte-App ist ab sofort im App-Store erhältlich.</td></tr><tr><td class="left"><span>Reinigungs-Funktion</span></td><td>Pyrolyse-Selbstreinigung: Dieser Backofen ist mit dem Pyroluxe®Plus Selbstreinigungssystem ausgestattet,das für Sauberkeit sorgt,die den höchsten professionellen Ansprüchen entspricht. Es erhitzt Ihren Backofen auf 500 °C und lässt dabei alle Speisereste zu Asche zerfallen,die nach dem Abkühlen einfach mit einem feuchten Tuch ausgewischt werden kann. Chemische Reinigungsmittel sind überflüssig.</td></tr></table> <table class="dv_characteristicsTable"><caption>Produktdetails</caption><tr><td class="left"><span>Farbe</span></td><td>edelstahlfarben</td></tr></table> <table class="dv_characteristicsTable"><caption>Leistung &amp; Verbrauch</caption><tr><td class="left"><span>Modellbezeichnung</span></td><td>PBWR6 OP8V2 IN</td></tr><tr><td class="left"><span>Energieeffizienzklasse (Skala)</span></td><td>A&#43; (A&#43;&#43;&#43; bis D)</td></tr><tr><td class="left"><span>Energieverbrauch konventioneller Betrieb in kWh</span></td><td>0,89 kWh</td></tr><tr><td class="left"><span>Energieverbrauch Heißluft oder Umluft in kWh</span></td><td>0,69 kWh</td></tr><tr><td class="left"><span>Anzahl Garräume</span></td><td>1</td></tr><tr><td class="left"><span>Wärmequelle pro Garraum</span></td><td>elektrisch</td></tr><tr><td class="left"><span>Backofenvolumen je Garraum</span></td><td>71 l</td></tr></table> <table class="dv_characteristicsTable"><caption>Ausstattung &amp; Funktionen</caption><tr><td class="left"><span>Standard Beheizungsarten</span></td><td>Ober- und Unterhitze<br />Grill<br />Heißluft</td></tr><tr><td class="left"><span>Zusätzliche Beheizungsarten</span></td><td>Pizzastufe<br />Heißluft-Eco</td></tr><tr><td class="left"><span>Bedienelemente</span></td><td>Drehknöpfe</td></tr><tr><td class="left"><span>Drehknöpfe</span></td><td>versenkbar</td></tr><tr><td class="left"><span>Display</span></td><td>Uhr</td></tr><tr><td class="left"><span>Auszugssystem</span></td><td>2-fach-Teleskopauszug</td></tr><tr><td class="left"><span>Art Tür</span></td><td>Glastür<br />3-fach-Verglasung</td></tr><tr><td class="left"><span>Selbstreinigung</span></td><td>Pyrolyse-Selbstreinigung</td></tr><tr><td class="left"><span>Mitgeliefertes Zubehör</span></td><td>1 Backblech emailliert<br />1 Grillrost<br />1 Fettpfanne</td></tr></table> <table class="dv_characteristicsTable"><caption>Maße &amp; Gewicht</caption><tr><td class="left"><span>Höhe</span></td><td>59,5 cm</td></tr><tr><td class="left"><span>Breite</span></td><td>59,5 cm</td></tr><tr><td class="left"><span>Tiefe</span></td><td>55,1 cm</td></tr><tr><td class="left"><span>Nischenhöhe minimal</span></td><td>60 cm</td></tr><tr><td class="left"><span>Nischenbreite minimal</span></td><td>56 cm</td></tr><tr><td class="left"><span>Nischentiefe</span></td><td>56 cm</td></tr></table> <table class="dv_characteristicsTable"><caption>Technische Daten</caption><tr><td class="left"><span>Spannung</span></td><td>220-240 V</td></tr><tr><td class="left"><span>Absicherung</span></td><td>16 A</td></tr><tr><td class="left"><span>Anschlusswert</span></td><td>3,3 kW</td></tr></table></div>
+                <div class="pdp_details__gratis-info pl_copy100">
+                    <span class="pl_tag50--red pl_mr50">+ Gratis</span>50 Monate Herstellergarantie
+                </div>
+            <div class="pl_text-expander__toggle">
+                <a class="pl_link100--primary pl_text-expander__link js_pl_text-expander__link"></a>
+            </div>
+        </div>
+    </div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/details-5SQY3X2Y.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/details-YT4QQ23U.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/details-YT4QQ23U.css" crossorigin="anonymous"/></noscript>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/care-details-GAFGMSSC.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/care-details-35N7QLPR.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/care-details-35N7QLPR.css" crossorigin="anonymous"/></noscript>
+                <div class="pl_block pdp_manufacturer-content-btn js_pdp_manufacturer-content-btn"
+         data-provider-name="LOADBEE"
+         data-brand-name="Privileg Family Edition"
+         data-ean="8003437938573"
+         data-ft5-view-tracking='{"product_BrandContent": "view"}'
+         >
+        <span class="pl_button100--secondary pdp_manufacturer-content-btn__inner"
+              data-ft5-click-tracking='{"product_BrandContent": "open"}'>
+                <img src="https://i.otto.de/i/otto/b41aa7c26700144ac38f0ccee5baead9?$ov_brandlogo$"
+                     srcset=" https://i.otto.de/i/otto/b41aa7c26700144ac38f0ccee5baead9?$ov_brandlogo_retina$ 2x"
+                     alt="Privileg Family Edition" class="pdp_manufacturer-content-btn__logo">
+            <span class="pdp_manufacturer-content-btn__text bold">Weitere Artikelinformationen <br>von Privileg Family Edition</span>
+        </span>
+    </div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/manufacturer-content-btn-3RJVSPTY.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/manufacturer-content-btn-TZKWPTRE.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/manufacturer-content-btn-TZKWPTRE.css" crossorigin="anonymous"/></noscript>
+                <div class="pdp_sustainability js_pdp_sustainability pl_block pl_copy100" data-variation-id="">
+        <h2 class="pl_headline100">Warum ist dieser Artikel nachhaltig?</h2>
+            <div class="pdp_sustainability__category pl_copy75 pl_mt150 js_pdp_sustainability__detail-link">
+                <svg class="pdp_sustainability__category-icon pdp_sustainability__category-icon--clickable pl_icon"
+                     role="img">
+                    <use xlink:href="/assets-static/icons/pl_icon_sustainable-energy-efficient.svg#pl_icon_sustainable-energy-efficient"/>
+                </svg>
+                <div class="pdp_sustainability__category-description pdp_sustainability__category-description--clickable pl_pl100">Energieeffiziente Nutzung</div>
+            </div>
+        <div class="pdp_sustainability__details-link pl_mt75">
+            <span class="pl_link100--primary js_pdp_sustainability__detail-link">Details</span>
+        </div>
+        <div class="pdp_sustainability__statement pl_mt100">
+            Nachhaltigkeit ist für uns kein Trend, sondern eine Selbstverständlichkeit.
+            Gehe den Weg mit uns und erfahre mehr über
+            <span class="pl_link100--primary ub64e" data-ub64e="L3Nob3BwYWdlcy9uYWNoaGFsdGlna2VpdA&#x3D;&#x3D;"><span>Nachhaltigkeit bei OTTO</span></span>.
+        </div>
+    </div>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/sustainability-TEGQHXDW.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/sustainability-AQLRH6ZY.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/sustainability-AQLRH6ZY.css" crossorigin="anonymous"/></noscript>
+        </div>
+        <div class="pl_grid-col-12 pl_grid-col-lg-4 pl_grid-col-lg--no-vertical-gap pl_grid-col-lg--fill-remaining-space-with-block-color">
+                <div class="pl_block pl_block--no-gap-lg pdp_article-services js_pdp_article-services pl_copy100">
+        <h3 class="pl_headline100 pl_mb150">Services zu diesem Artikel</h3>
+            <link href="/shoppages/static/assets/sho.shoppages.assets-public.c2691b52.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/shoppages/static/assets/sho.shoppages.assets-public.c2691b52.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" crossorigin="anonymous" href="/shoppages/static/assets/sho.shoppages.assets-public.21298cd5.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/><div id="55f02a35140b022b7ca31ec0"
+                   class="sp_js_contentElement ub64e js_contentElementClickTracking js_openInPaliLayer sp_prd_serviceElement"
+                   data-ub64e="L3Nob3BwYWdlcy9kZXRhaWx2aWV3X3NlcnZpY2VsYXllcl9jb25zdWx0YW50X2lk" data-layer-width="700px"
+                   data-tracking-key="CONSULTANT_ID"
+                   data-content-element-type="Artikeldetailseite-Service"
+                   data-content-element-name="Einbauger%C3%A4te-Beratung">
+    <img class="sp_prd_serviceImage" src="https://i.otto.de/i/otto/001_service_info_rgb_90px?$001ICON01$" alt="Einbaugeräte-Beratung"/>
+    <span class="sp_prd_serviceText">Einbaugeräte-Beratung</span>
+</div>
+
+
+
+    </div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/article-services-W5HQPYF4.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/article-services-HTRSTHT6.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/article-services-HTRSTHT6.css" crossorigin="anonymous"/></noscript>
+
+                <div class="pl_block pl_block--no-gap-lg dcs_important-information">
+        <h3 class="pl_headline100 pl_mb150">Wichtige Informationen:</h3>
+        <ul class="dcs_important-information__list">
+                <li class="dcs_important-information__list-item">
+                    <span class="pl_link100--primary dcs_important-information__link js_openInPaliLayer ub64e" data-ub64e="L3Nob3BwYWdlcy9jb25zdWx0aW5nZGV0YWlsX2Rpc3Bvc2FsX25vdGU&#x3D;">
+                        <span>
+                            <svg class="pl_icon dcs_important-information__icon" role="img"><use xlink:href="/assets-static/icons/pl_icon_disposal.svg#pl_icon_disposal" /></svg>
+                            Entsorgungshinweis
+                        </span>
+                    </span>
+                </li>
+                <li class="dcs_important-information__list-item">
+                    <a class="pl_link100--primary dcs_important-information__link" target="_blank" href="https://d.otto.de/files/25218135.pdf">
+                        <svg class="pl_icon dcs_important-information__icon" role="img"><use xlink:href="/assets-static/icons/pl_icon_pdf.svg#pl_icon_pdf" /></svg>
+                        Bedienungsanleitung (PDF)
+                    </a>
+                </li>
+        </ul>
+    </div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/important-information-U6H2HYV5.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/important-information-U6H2HYV5.css" crossorigin="anonymous"/></noscript>
+            <div class="pl_block pl_block--no-gap-lg js_pdp_share-btn pl_hidden" data-is-valid-variation="true">
+    <button class="pl_button100--secondary js_pdp_share-btn__button"
+            data-ft5-click-tracking='{ "social_Action": "share" }'
+    >
+        <svg class="pl_icon" role="img">
+            <use class="js_pdp_share-btn__icon-use" xlink:href="/assets-static/icons/pl_icon_share-ios.svg#pl_icon_share-ios"/>
+        </svg>
+        Teilen
+    </button>
+</div>
+
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/share-btn-SHU35MCQ.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+        </div>
+        <!-- Bottom SECTION C -->
+        <div class="pl_grid-col-12">
+                <div class="pl_block pl_block--full-bleed dcs_product-consulting">
+        <link href="/shoppages/static/assets/sho.shoppages.assets-public.c2691b52.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/shoppages/static/assets/sho.shoppages.assets-public.c2691b52.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" crossorigin="anonymous" href="/shoppages/static/assets/sho.shoppages.assets-public.21298cd5.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>    <div data-title="" data-callback="o_shoppages.layer.init">
+        <div class="shoppages shoppagesFragment">
+                <div id="6141e83f6a3bbf22834a8475" class="sp_js_contentElement sp_textBlock sp_plainText" data-qa="textBlock"
+                   data-content-element-type="Textblock" data-content-element-name="dcs_product_consulting_whitegoods">
+<div class="pl_grid-content100 pl_copy100">
+ <div class="pl_grid-container">
+  <div class="pl_grid-col-12 pl_grid-col-lg-4">
+   <div class="pl_headline100 pl_mb50">
+    Produktberatung
+   </div> Wir beraten dich gerne:
+  </div>
+  <div class="pl_grid-col-12 pl_grid-col-lg-4">
+   <div class="dcs_product-consulting__text">
+    <span class="dcs_product-consulting__icon">t</span> <span class="sp_hideWhenLarge pl_link100--primary ub64e" data-ub64e="dGVsOis0OTQwMzYwMzMzMzA=">040 - 3603 3330</span> <span class="sp_hideWhenNotLarge">040 - 3603 3330</span>
+    <br>oder <span class="js_openInPopup pl_link100--primary ub64e" data-ub64e="L3VzZXIvY2FsbGJhY2tQb3B1cD9zZWxlY3RlZFRvcGljPTIwMiZzb3VyY2U9c2l0ZQ==">kostenloser Rückruf in den nächsten 30 Minuten</span>
+    <br><span>(Mo.-Fr. 8-22 Uhr, Sa. 9-19 Uhr)</span>
+   </div>
+  </div>
+  <div class="pl_grid-col-12 pl_grid-col-lg-4">
+   <div class="dcs_product-consulting__text">
+    <span class="dcs_product-consulting__icon">B</span> <span class="js_openInPopup pl_link100--primary ub64e" data-ub64e="L2t1bmRlbmNoYXQvcG9wdXAuaHRtbD9jYXQ9T3R0b19DSEFUX0hhdXNoYWx0c2VsZWt0cm8=">Jetzt chatten</span>
+    <br><span>(Mo.-Fr. 8-22 Uhr, Sa. 9-19 Uhr)</span>
+   </div>
+   <div class="dcs_product-consulting__text">
+    <span class="dcs_product-consulting__icon">e</span> <span class="js_openInPopup pl_link100--primary ub64e" data-ub64e="L3VzZXIvY29udGFjdEZvcm0/c2VsZWN0ZWRUb3BpYz0yMDI=">haushaltselektro@otto.de</span>
+   </div>
+  </div>
+ </div>
+</div>
+</div>
+
+
+
+
+        </div>
+    </div>
+
+
+    </div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/product-consulting-62ZS3DP6.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/product-consulting-62ZS3DP6.css" crossorigin="anonymous"/></noscript>
+            <div class="pl_block pl_block--transparent pl_block--no-padding pdp_reco-sponsored pdp_reco-sponsored--e549-active js_pdp_reco-sponsored" data-variation-id="682285928"></div>
+<link rel="stylesheet" href="/spa-formicary/assets/ft7bcn.spa-formicary.spa_formicary_assets.7935b393.css" crossorigin="anonymous" integrity="sha256-IQzbUIGIxvC+RmQ1n3QFAF9eiKwlozE/v/tnQ5ByB8c=">
+
+<link rel="modulepreload" href="/spa-formicary/assets/ft7bcn.spa-formicary.spa_formicary_assets.module.18c96fd4.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/spa-formicary/assets/ft7bcn.spa-formicary.spa_formicary_assets.nomodule.22c7d8e1.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<script>
+    window.o_spa_formicary = window.o_spa_formicary || {};
+    window.o_spa_formicary.api = window.o_spa_formicary.api || {};
+    window.o_spa_formicary.private = window.o_spa_formicary.private || {};
+    window.o_spa_formicary.private.jlineup = window.o_spa_formicary.private.jlineup || {};
+
+    window.o_spa_formicary.private.delegate = function (originalFunction) {
+        return function () {
+            var passedArguments = arguments;
+            return new Promise(function (resolve, reject) {
+                o_global.eventLoader.onAllScriptsExecuted(10, function () {
+                    window.o_spa_formicary.private[originalFunction].apply(null, passedArguments).then(resolve).catch(reject);
+                });
+            });
+        };
+    };
+
+    window.o_spa_formicary.private.delegateAndWrap = function (originalFunction) {
+        return function () {
+            var passedArguments = arguments;
+            return new Promise(function (resolve) {
+                o_global.eventLoader.onAllScriptsExecuted(10, function () {
+                    var result = window.o_spa_formicary.private[originalFunction].apply(null, passedArguments);
+                    resolve(result);
+                });
+            });
+        };
+    };
+
+    window.o_spa_formicary.api.initializeCinema = window.o_spa_formicary.private.delegateAndWrap('initializeCinema');
+    window.o_spa_formicary.api.loadSponsoredArticlesForDetailView = window.o_spa_formicary.private.delegate('loadSponsoredArticlesForDetailView');
+</script>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/reco-sponsored-R3UBMRPW.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/reco-sponsored-HR556DNU.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/reco-sponsored-HR556DNU.css" crossorigin="anonymous"/></noscript>
+                    <div class="pl_block pl_block--transparent pl_block--no-padding pdp_reco-alternative pdp_reco-alternative--e549-active js_pdp_reco-alternative" data-variation-id="682285928"></div>
+
+  <link rel="preload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.3afc4579.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.3afc4579.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.module.46bea43c.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.nomodule.a87b68b8.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+
+<div style="display:none;" id="reco_cinema__toggle-state" data-toggle-state="{&quot;SHOW_DEALS&quot;:true,&quot;CSR&quot;:false,&quot;USE_OPAL_RELATIONSHIPS&quot;:true,&quot;TESLA_COLDSTART&quot;:false,&quot;USE_TESLA_ARTHURDENT&quot;:true,&quot;USE_TESLA_META&quot;:true,&quot;SHOW_DETAILVIEW_ONLY&quot;:false,&quot;DISPLAY_LAST_SEEN_ARTICLES&quot;:true,&quot;USE_TESLA_HITCHHIKER&quot;:true,&quot;WISHLIST_RECO_REDESIGN&quot;:true,&quot;RECO_REDESIGN&quot;:true}">
+</div>
+<script>
+  window.o_reco = window.o_reco || {};
+  window.o_reco.api = window.o_reco.api || {};
+  window.o_reco.private = window.o_reco.private || {};
+  window.o_reco.private.toggleState = JSON.parse(document.getElementById('reco_cinema__toggle-state').dataset.toggleState);
+
+  window.o_reco.private.delegate = function (originalFunction) {
+    return function () {
+      var passedArguments = arguments;
+      return new Promise(function (resolve, reject) {
+        o_global.eventLoader.onAllScriptsExecuted(10, function () {
+          window.o_reco.private[originalFunction].apply(null, passedArguments).then(resolve).catch(reject);
+        });
+      });
+    };
+  };
+
+  window.o_reco.private.delegateAndWrap = function (originalFunction) {
+    return function () {
+      var passedArguments = arguments;
+      return new Promise(function (resolve) {
+        o_global.eventLoader.onAllScriptsExecuted(10, function () {
+          var result = window.o_reco.private[originalFunction].apply(null, passedArguments);
+          resolve(result);
+        });
+      });
+    };
+  };
+
+  window.o_reco.api.initializeCinema = window.o_reco.private.delegateAndWrap('initializeCinema');
+  window.o_reco.api.initializeExpandableCinema = window.o_reco.private.delegateAndWrap('initializeExpandableCinema');
+  window.o_reco.api.loadRecommendationsForDetailView = window.o_reco.private.delegateAndWrap('asyncLoadRecommendationsForDetailView');
+
+  window.o_reco.api.loadRecommendationsForOrderOverview = window.o_reco.private.delegate('loadRecommendationsForOrderOverview');
+  window.o_reco.api.loadRecommendationsForWishlist = window.o_reco.private.delegate('loadRecommendationsForWishlist');
+  window.o_reco.api.loadRecommendationsForEntryPage =
+          window.o_reco.private.toggleState["CSR"] ?
+                  window.o_reco.private.delegateAndWrap('loadRecommendationsForEntryPageCsr') :
+                  window.o_reco.private.delegate('loadRecommendationsForEntryPage');
+  window.o_reco.api.loadBounceLayerCinema = window.o_reco.private.delegateAndWrap('loadBounceLayerCinema');
+
+  o_global.eventQBus.emit("ft6bcn.reco.init", ".reco.cinema.needsInitialization");
+</script>
+
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/reco-alternative-7BEZZ7LX.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/reco-alternative-KN75277F.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/reco-alternative-KN75277F.css" crossorigin="anonymous"/></noscript>
+
+    <style>@charset "UTF-8";.cr_aggregation{display:inline-block;margin-top:8px}.cr_aggregation__starsWithAmount{cursor:pointer;text-decoration:none}.cr_aggregation__button{display:inline;margin-left:8px;width:auto}.cr_aggregation__amount,.cr_aggregation__label{text-decoration:underline}.cr_aggregation__label-icon{font-style:normal;vertical-align:bottom}.cr_aspectFilter{margin-top:32px}@media (min-width:48em){.cr_aspectFilter--old-{margin-top:16px}}.cr_aspectFilter__headline{font-size:14px;font-size:.875rem;line-height:1.4285714286em}.cr_aspectFilter__headline--old-design{font-weight:700}.cr_aspectFilter__buttons{overflow:hidden}.cr_aspectButton{-webkit-tap-highlight-color:transparent;background:#f3f1ec;background:-webkit-linear-gradient(180deg,#fefefe,#f3f1ec);background:linear-gradient(180deg,#fefefe,#f3f1ec);border:1px solid #c4c4c4;border-radius:3px;color:#333;cursor:pointer;float:left;font-size:12px;font-size:.75rem;height:31px;line-height:1.5em;margin:8px 8px 0 0;max-width:300px;outline:0 none;padding:5px 9px;text-align:center;text-decoration:none;vertical-align:baseline;white-space:nowrap}.cr_aspectButton:hover{background:#fefefe;color:#d5281e}.cr_aspectButton:last-of-type{margin:8px 16px 0 0}.cr_aspectButton--selected{border-color:#9e9e9e;cursor:auto}.cr_aspectButton--selected,.cr_aspectButton--selected:hover{background:#fff;background:-webkit-linear-gradient(180deg,#d7d5cf,#fff);background:linear-gradient(180deg,#d7d5cf,#fff);font-weight:700}.cr_aspectButton--selected:hover{color:inherit}.cr_aspectButton__text{display:inline-block;margin-right:4px;max-width:235px;overflow:hidden;text-overflow:ellipsis;vertical-align:bottom;white-space:nowrap}.cr_aspectDeselectLink{float:left;line-height:31px;margin-top:8px}.cr_histogram__row{display:table-row}.cr_histogram__row--clickable{cursor:pointer}.cr_histogram__row--clickable .cr_histogram__amount span{text-decoration:underline}.cr_histogram__row--selected .cr_histogram__amount,.cr_histogram__row--selected .cr_histogram__label{font-weight:700}.cr_histogram__row--selected .cr_bar{border:1px solid #777}.cr_histogram__row--selected .cr_bar__fill{background-color:#9e9e9e}.cr_histogram__row--selected .cr_histogram__amount span{text-decoration:none}@media (min-width:48em){.cr_histogram__row--selected .cr_histogram__deselect{display:table-cell}}.cr_histogram__amount,.cr_histogram__label,.cr_histogram__percent{display:table-cell;padding-top:12px;vertical-align:top}.cr_histogram__row:first-child .cr_histogram__amount,.cr_histogram__row:first-child .cr_histogram__deselect,.cr_histogram__row:first-child .cr_histogram__label,.cr_histogram__row:first-child .cr_histogram__percent{padding-top:0}.cr_histogram__amount,.cr_histogram__deselect,.cr_histogram__label{font-size:14px;font-size:.875rem;line-height:1.4285714286em;line-height:20px}.cr_histogram__amount,.cr_histogram__label,.cr_histogram__percent{padding-right:8px}.cr_bar{border:1px solid #c4c4c4;-moz-border-radius:2px;-webkit-border-radius:2px;border-radius:2px;height:20px;width:170px}.cr_bar__fill{background-color:#e6e6e6;height:100%}.cr_histogram__deselect{display:none;padding-top:12px;vertical-align:top}.cr_filterIndicator{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:16px 0 0}@media (min-width:48em){.cr_filterIndicator{display:inline-block;line-height:38px}}.cr_filterIndicator__deselect{white-space:nowrap}@media (min-width:48em){.cr_filterIndicator__deselect{display:none}}.cr_landingPage .cr_reviewHeadline__row--FEATURE_2065 .cr_reviewHeadline__starsWithAmount>*{display:inline-block;vertical-align:middle}@media (min-width:48em){.cr_landingPage .cr_histogram--old-design{float:left}.cr_landingPage .cr_aspectFilter--old-design{margin-left:480px}}.cr_landingPage .cr_filterWrapper{margin:16px 0 0;overflow:hidden}.cr_landingPage .cr_filterWrapper--old-design{margin:8px 0 0}.cr_landingPage .cr_priceAmount--reduced{color:#f00020}.cr_landingPage .cr_priceNote{display:block}.cr_landingPage .cr_productVariationImage{max-height:74px;max-width:74px}.cr_landingPage .cr_variationImage{display:inline;float:left;padding:0 0 0 8px}@media (min-width:28em){.cr_landingPage .cr_variationImage{padding:0 8px}}.cr_landingPage .cr_priceAndMoreVariationsLink{float:left}.cr_landingPage .cr_headLink{text-decoration:none}.cr_loadingSpinner{margin-bottom:8px;text-align:center}.cr_loadingSpinner__loader{display:inline-block}@media (min-width:48em){.cr_minimal .cr_histogram--old-design{float:left}.cr_minimal .cr_aspectFilter--old-design{margin-left:360px}}.cr_minimal .cr_reviewList{margin:32px 0 24px}.cr_minimal .cr_filterWrapper{margin:16px 0 0;overflow:hidden}.cr_minimal .cr_filterWrapper--old-design{margin:8px 0 0}.cr_moreReviewsButton{max-width:350px}.cr_paging{margin-bottom:8px;overflow:hidden;text-align:center}@media (min-width:48em){.cr_paging{float:right;width:310px}}.cr_paging__button{width:auto}.cr_paging__button--first,.cr_paging__button--prev{float:left;margin-left:8px}.cr_paging__button--last,.cr_paging__button--next{float:right;margin-right:8px}.cr_paging__currentPage{font-size:14px;font-size:.875rem;line-height:1.4285714286em;line-height:30px}.cr_reportReviewLayer{font-size:14px;font-size:.875rem;line-height:1.4285714286em;overflow:hidden}.cr_reportReviewLayer--success .cr_reportReviewLayer__surveyWrapper{display:none}.cr_reportReviewLayer--success .cr_reportReviewLayer__successWrapper{display:block}.cr_reportReviewLayer__error{display:none;margin-bottom:16px}.cr_reportReviewLayer__request{font-weight:700;margin:0}.cr_reportReviewLayer__survey{margin-top:10px}.cr_reportReviewLayer__textarea{margin-top:8px}.cr_reportReviewLayer__disclaimer,.cr_reportReviewLayer__feedbackIndication,.cr_reportReviewLayer__guidelines{font-size:12px;font-size:.75rem;line-height:1.5em}.cr_reportReviewLayer__feedbackIndication{margin:8px 0 0}.cr_reportReviewLayer__feedbackIndication--success{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:16px 0 0}.cr_reportReviewLayer__disclaimer,.cr_reportReviewLayer__guidelines{display:block;margin-top:8px}@media (min-width:48em){.cr_reportReviewLayer__disclaimer{float:left;line-height:40px;margin-top:16px}}.cr_reportReviewLayer__button{margin-top:16px}@media (min-width:48em){.cr_reportReviewLayer__button{float:right;max-width:160px}}.cr_reportReviewLayer__successWrapper{display:none}.cr_reviewHeadline{position:relative}.cr_reviewHeadline__headline{margin-top:16px}.cr_reviewHeadline__headline--FEATURE_2065{font-family:OttoSansThin,OTTOSans,Arial,Helvetica,sans-serif;font-size:22px;font-size:1.375rem;line-height:1.2727272727em;margin-top:24px}@media (min-width:48em){.cr_reviewHeadline__headline--FEATURE_2065{font-size:26px;font-size:1.625rem;line-height:1.2307692308em}}.cr_reviewHeadline__recommendation{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:8px 0 0}.cr_reviewHeadline__recommendation.cr_reviewHeadline__recommendation--FEATURE_2065{margin:12px 0 0}.cr_reviewHeadline__row{overflow:hidden}.cr_reviewHeadline__starsWithAmount{float:left;margin-top:19px;white-space:nowrap}.cr_reviewHeadline__row--FEATURE_2065 .cr_reviewHeadline__starsWithAmount{margin-top:16px}.cr_reviewHeadline__row--FEATURE_2065 a.cr_reviewHeadline__starsWithAmount{cursor:pointer;text-decoration:none}.cr_reviewHeadline__amount{margin:0 8px 0 4px;vertical-align:text-bottom}.cr_reviewHeadline__row--FEATURE_2065 .cr_reviewHeadline__amount{margin:4px}.cr_reviewHeadline__label{text-decoration:underline;vertical-align:text-bottom}.cr_reviewHeadline__label-icon{font-style:normal;vertical-align:baseline}.cr_reviewHeadline__amount--clickable{cursor:pointer;text-decoration:underline}.cr_reviewHeadline__submitReviewButton{margin-top:8px;width:auto}.cr_reviewHeadline__row--FEATURE_2065 .cr_reviewHeadline__submitReviewButton{margin-top:0}.cr_reviewHeadline__submitReviewButton--old{margin-top:16px}.cr_reviewHeadline__submitReviewButton--floating{margin:12px 0 0}@media (min-width:48em){.cr_reviewHeadline__submitReviewButton--floating{margin:0;position:absolute;right:0;top:0}}.cr_reviewHeadline__submitReviewStar{margin-right:2px}.cr_reviewHeadline__submitReview{display:inline-block;float:right;margin-top:16px}.cr_reviewHeadline__noReviews{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:8px 0 0}.cr_reviewHeadline__submitReview--noReviews{float:none;margin:8px 0}#cr_reviewErrorContainer{display:none;margin-bottom:8px}#cr_js_topReviews{overflow:hidden}.cr_reviewList{margin:16px 0 24px;position:relative}@media (min-width:48em){.cr_reviewList{margin:24px 0 32px}}.cr_review{font-size:14px;font-size:.875rem;line-height:1.4285714286em}.cr_review__stars{margin-right:8px}.cr_review__stars--error{color:#f00020}.cr_review__title{display:inline;font-size:14px;font-size:.875rem;font-weight:700;line-height:1.4285714286em}.cr_review__helpfulSummary{display:block;font-size:12px;font-size:.75rem;line-height:1.5em;margin-top:2px}@media (min-width:48em){.cr_review__helpfulSummary--SandM{display:none}}.cr_review__helpfulSummary--LandXL{display:none}@media (min-width:48em){.cr_review__helpfulSummary--LandXL{display:block}}.cr_review__text{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:12px 0 0}.cr_review__reviewer{display:block;font-size:12px;font-size:.75rem;line-height:1.5em;margin-top:12px}.cr_review__reviewerName{font-weight:700}.cr_review__partner{display:block;font-size:12px;font-size:.75rem;line-height:1.5em}.cr_review__partnerName{font-weight:700}.cr_review__dimensions{display:block}.cr_review__dimensions,.cr_review__helpfulSubmit{font-size:12px;font-size:.75rem;line-height:1.5em}.cr_review__helpfulSubmit{display:inline-block;margin:8px 0 0}.cr_review__verifiedPurchase{margin-top:2px}.cr_review__verifiedPurchaseText{color:#50cc7f;font-size:12px;font-size:.75rem;line-height:1.5em}.cr_review__verifiedPurchaseIcon{fill:#50cc7f;vertical-align:middle}.cr_review__verifiedPurchaseInfo{font-size:14px;font-size:.875rem;line-height:1.4285714286em}.cr_review__verifiedPurchaseInfoText{color:#50cc7f}.cr_review__verifiedPurchaseInfoIcon{fill:#50cc7f;height:14px;vertical-align:text-bottom;width:14px}.cr_helpfulSubmit{margin-left:4px;white-space:nowrap}.cr_helpfulSubmit__button{display:inline-block;width:auto}.cr_helpfulSubmit__button:first-child{margin-right:4px}.cr_reportReviewLink{display:inline-block;font-size:12px;font-size:.75rem;line-height:1.5em;margin-top:12px;white-space:nowrap}@media (min-width:28em){.cr_reportReviewLink{display:inline;margin-left:12px;margin-top:0}}.cr_review__line{margin:16px 0!important}@media (min-width:48em){.cr_review__line{margin:24px 0!important}}.cr_bi-review:before{display:inline-block;float:left;font-family:OttoIcons,Arial,Helvetica,sans-serif;font-size:20px;font-size:1.25rem}.cr_bi-review>*{margin-left:28px}.cr_bi-review .cr_reportReviewLink,.cr_bi-review .cr_review__helpfulSubmit{display:none}.cr_bi-review.cr_review--expanded .cr_reportReviewLink,.cr_bi-review.cr_review--expanded .cr_review__helpfulSubmit{display:inline-block}.cr_bi-review--positive:before{color:#417505;content:"↑"}.cr_bi-review--negative:before{color:#ba0019;content:"↓"}.cr_bi-review--neutral:before{content:"→"}.cr_review__text--afterOccurrence,.cr_review__text--beforeOccurrence{display:none}.cr_review--expanded .cr_review__text--afterOccurrence,.cr_review--expanded .cr_review__text--beforeOccurrence{display:inline}.cr_review__highlightedWord{font-weight:700}.cr_review__highlightedWord--negative{color:#ba0019}.cr_review__highlightedWord--positive{color:#417505}.cr_review__moreLink:after{content:"...Mehr"}.cr_review--expanded .cr_review__moreLink:after{content:"...Weniger"}.cr_aspectHeader{margin-top:24px;overflow:hidden}.cr_aspectHeader__name{display:inline-block;font-size:16px;font-size:1rem;font-weight:700;line-height:1.375em;margin-right:9px;vertical-align:middle}.cr_aspectTypeDistribution{cursor:default;display:inline-block;vertical-align:middle}.cr_aspectTypeDistribution__item{display:inline-block;font-size:16px;font-size:1rem;font-weight:700;line-height:1.375em;line-height:26px;vertical-align:middle}.cr_aspectTypeDistribution__item:not(:last-child){margin-right:10px}.cr_aspectTypeDistribution__icon{font-size:20px;font-style:normal;font-weight:400;margin-right:-3px;vertical-align:bottom}.cr_aspectTypeDistribution__icon--positive{color:#417505}.cr_aspectTypeDistribution__icon--negative{color:#ba0019}.cr_sortingForm{display:block;margin-top:16px}@media (min-width:28em){.cr_sortingForm--old-design{text-align:right}}@media (min-width:48em){.cr_sortingForm--old-design{display:inline-block;float:right}}.cr_sortingForm__label{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin-right:8px}.cr_sortingForm__select{display:inline-block;width:auto}.cr_filterIndicatorAndSortingWrapper{overflow:hidden}.reviewSubmitLayer a.overlay{color:#777;display:inline-block;margin-top:16px}.reviewSubmitLayer .label{margin-bottom:4px}.reviewSubmitLayer .reviewContent p{margin-top:15px}.reviewSubmitLayer .reviewContent .cr_reviewImage img{height:164px;width:164px}.reviewSubmitLayer .reviewContent .cr_reviewDimensions{flex:1;vertical-align:top}.reviewSubmitLayer .reviewContent .cr_reviewImageContainer{display:flex}.reviewSubmitLayer .reviewContent .cr_reviewTextContainer{margin-bottom:12px!important}.reviewSubmitLayer .reviewContent .recommended{margin:8px 0}.reviewSubmitLayer .reviewContent .radio-option{margin-right:40px}.reviewSubmitLayer .reviewContent .star-empty{background-image:url(/assets-static/icons/pl_icon_rating-empty.svg)}.reviewSubmitLayer .reviewContent .star-empty,.reviewSubmitLayer .reviewContent .star-filled{background-position:0;background-repeat:no-repeat;background-size:24px;cursor:pointer;padding:14px 38px 14px 0}.reviewSubmitLayer .reviewContent .star-filled{background-image:url(/assets-static/icons/pl_icon_rating-filled.svg)}.reviewSubmitLayer .reviewContent .left{float:left}.reviewSubmitLayer .reviewContent .right{float:right}.reviewSubmitLayer .reviewContent form{float:left;margin:0 0 15px}@media (min-width:48em){.reviewSubmitLayer .reviewContent .selectBoxWrapper{width:50%}.reviewSubmitLayer .reviewContent .selectBoxWrapper:nth-child(2n){padding-left:4px}.reviewSubmitLayer .reviewContent .selectBoxWrapper:nth-child(odd){padding-right:4px}.reviewSubmitLayer .reviewContent .footer button{width:auto}}</style>
+
+
+<div class="pl_block pdp_product-reviews js_pdp_product-reviews" data-variation-id="682285928" data-product-id="682285688">
+    <!-- workaround with request parameter as long as old architecture is online -->
+    <section id="cr_js_topReviews"
+         class="cr_minimal" data-product-id="682285688" data-client-token="6295e3ad38e56128994bef6b" data-widget-type="minimal">
+
+
+
+
+
+
+
+    <div class="cr_reviewHeadline">
+
+
+
+
+    <h2 class="pl_headline200">Kundenbewertungen</h2>
+    <div class="cr_reviewHeadline__row cr_reviewHeadline__row--FEATURE_2065" itemprop="aggregateRating" itemscope="" itemtype="http://schema.org/AggregateRating">
+
+
+            <a class="cr_reviewHeadline__starsWithAmount cr_js_customerReviewPageLink js_hasPaliTooltip"
+               data-tracking-information="center"
+               data-tooltip="Alle Kundenbewertungen anzeigen"
+               data-tooltip-pos="mouse"
+               data-tooltip-touch="false"
+               data-qa="ratingStarsAggregated">
+                <span class="p_rating200" itemprop="ratingValue" content="4.0">* * * * o</span>
+                <span class="cr_reviewHeadline__amount">(<span class="js_cr_reviewHeadline__amount" data-target="allreviewscount" itemprop="reviewCount" content="90" >90</span>)</span>
+                <span class="cr_reviewHeadline__label">anzeigen</span>
+                <i class="p_icons cr_reviewHeadline__label-icon">&gt;</i>
+            </a>
+
+
+
+    </div>
+
+    <p class="cr_reviewHeadline__recommendation cr_reviewHeadline__recommendation--FEATURE_2065"><span class="p_copyBold">80%</span> aller Bewerter würden diesen Artikel weiterempfehlen.</p>
+
+    <div class="pl_mt150 p_copyBold">Du hast den Artikel erhalten?</div>
+    <button class="js_submitReview p_btn50--3rd cr_reviewHeadline__submitReviewButton"
+            data-href="/product/products/reviews/submitLayer" data-tracking-information="bottom_detailview">
+        <i class="cr_reviewHeadline__submitReviewStar">o</i>&nbsp;Artikel bewerten
+    </button>
+
+    <div class="cr_review__verifiedPurchaseInfo pl_mt150 pl_mb150">Wir setzen auf den&nbsp;
+        <svg class="cr_review__verifiedPurchaseInfoIcon pl_icon50" role="img"><use xlink:href="/assets-static/icons/pl_icon_check50.svg#pl_icon_check50"></use></svg>
+        <span class="cr_review__verifiedPurchaseInfoText">Verifizierten Kauf</span>:<br>Bewertungen können nur noch von Kunden veröffentlicht werden, die den Artikel <b>bestellt und erhalten</b> haben.
+    </div>
+
+        <div class="cr_filterWrapper">
+            <ul class="cr_histogram js_cr_histogram" id="cr_histogram">
+
+
+
+        <li class="cr_histogram__row js_cr_histogram__row cr_histogram__row--clickable "
+            data-filter="5" data-amount="49">
+            <span class="cr_histogram__label js_cr_histogram__clickTarget" data-target="stars">5 Sterne</span>
+            <div class="cr_histogram__percent js_cr_histogram__clickTarget" data-target="bars">
+                <div class="cr_bar">
+                    <div class="cr_bar__fill" style="width:54%"></div>
+                </div>
+            </div>
+            <span class="cr_histogram__amount js_cr_histogram__clickTarget" data-target="numbers">(<span>49</span>)</span>
+            <span class="cr_histogram__deselect p_link100--1st js_cr_deselectFilter" data-target="deselectlink">Auswahl aufheben</span>
+        </li>
+
+        <li class="cr_histogram__row js_cr_histogram__row cr_histogram__row--clickable "
+            data-filter="4" data-amount="22">
+            <span class="cr_histogram__label js_cr_histogram__clickTarget" data-target="stars">4 Sterne</span>
+            <div class="cr_histogram__percent js_cr_histogram__clickTarget" data-target="bars">
+                <div class="cr_bar">
+                    <div class="cr_bar__fill" style="width:24%"></div>
+                </div>
+            </div>
+            <span class="cr_histogram__amount js_cr_histogram__clickTarget" data-target="numbers">(<span>22</span>)</span>
+            <span class="cr_histogram__deselect p_link100--1st js_cr_deselectFilter" data-target="deselectlink">Auswahl aufheben</span>
+        </li>
+
+        <li class="cr_histogram__row js_cr_histogram__row cr_histogram__row--clickable "
+            data-filter="3" data-amount="7">
+            <span class="cr_histogram__label js_cr_histogram__clickTarget" data-target="stars">3 Sterne</span>
+            <div class="cr_histogram__percent js_cr_histogram__clickTarget" data-target="bars">
+                <div class="cr_bar">
+                    <div class="cr_bar__fill" style="width:8%"></div>
+                </div>
+            </div>
+            <span class="cr_histogram__amount js_cr_histogram__clickTarget" data-target="numbers">(<span>7</span>)</span>
+            <span class="cr_histogram__deselect p_link100--1st js_cr_deselectFilter" data-target="deselectlink">Auswahl aufheben</span>
+        </li>
+
+        <li class="cr_histogram__row js_cr_histogram__row cr_histogram__row--clickable "
+            data-filter="2" data-amount="4">
+            <span class="cr_histogram__label js_cr_histogram__clickTarget" data-target="stars">2 Sterne</span>
+            <div class="cr_histogram__percent js_cr_histogram__clickTarget" data-target="bars">
+                <div class="cr_bar">
+                    <div class="cr_bar__fill" style="width:4%"></div>
+                </div>
+            </div>
+            <span class="cr_histogram__amount js_cr_histogram__clickTarget" data-target="numbers">(<span>4</span>)</span>
+            <span class="cr_histogram__deselect p_link100--1st js_cr_deselectFilter" data-target="deselectlink">Auswahl aufheben</span>
+        </li>
+
+        <li class="cr_histogram__row js_cr_histogram__row cr_histogram__row--clickable "
+            data-filter="1" data-amount="8">
+            <span class="cr_histogram__label js_cr_histogram__clickTarget" data-target="stars">1 Stern</span>
+            <div class="cr_histogram__percent js_cr_histogram__clickTarget" data-target="bars">
+                <div class="cr_bar">
+                    <div class="cr_bar__fill" style="width:9%"></div>
+                </div>
+            </div>
+            <span class="cr_histogram__amount js_cr_histogram__clickTarget" data-target="numbers">(<span>8</span>)</span>
+            <span class="cr_histogram__deselect p_link100--1st js_cr_deselectFilter" data-target="deselectlink">Auswahl aufheben</span>
+        </li>
+
+</ul>
+
+            <div class="cr_aspectFilter"
+     id="cr_aspectFilter">
+
+    <div class="cr_aspectFilter__headline">Häufig genannt:</div>
+    <div class="cr_aspectFilter__buttons cr_js_aspectFilter__buttons">
+
+            <button class="cr_aspectButton cr_js_aspectButton" data-aspectname="Funktionen" data-occurrencescount="11">
+                <span class="cr_aspectButton__text">Funktionen</span>
+                <span class="cr_aspectButton__count">(11)</span>
+            </button>
+
+            <button class="cr_aspectButton cr_js_aspectButton" data-aspectname="Lieferung" data-occurrencescount="9">
+                <span class="cr_aspectButton__text">Lieferung</span>
+                <span class="cr_aspectButton__count">(9)</span>
+            </button>
+
+            <button class="cr_aspectButton cr_js_aspectButton" data-aspectname="Preis" data-occurrencescount="9">
+                <span class="cr_aspectButton__text">Preis</span>
+                <span class="cr_aspectButton__count">(9)</span>
+            </button>
+
+            <button class="cr_aspectButton cr_js_aspectButton" data-aspectname="bedienen" data-occurrencescount="9">
+                <span class="cr_aspectButton__text">bedienen</span>
+                <span class="cr_aspectButton__count">(9)</span>
+            </button>
+
+            <button class="cr_aspectButton cr_js_aspectButton" data-aspectname="Einbau" data-occurrencescount="5">
+                <span class="cr_aspectButton__text">Einbau</span>
+                <span class="cr_aspectButton__count">(5)</span>
+            </button>
+
+            <button class="cr_aspectButton cr_js_aspectButton" data-aspectname="Lautstärke" data-occurrencescount="5">
+                <span class="cr_aspectButton__text">Lautstärke</span>
+                <span class="cr_aspectButton__count">(5)</span>
+            </button>
+
+            <button class="cr_aspectButton cr_js_aspectButton" data-aspectname="optisch" data-occurrencescount="5">
+                <span class="cr_aspectButton__text">optisch</span>
+                <span class="cr_aspectButton__count">(5)</span>
+            </button>
+
+            <button class="cr_aspectButton cr_js_aspectButton" data-aspectname="Gebläse" data-occurrencescount="3">
+                <span class="cr_aspectButton__text">Gebläse</span>
+                <span class="cr_aspectButton__count">(3)</span>
+            </button>
+
+            <button class="cr_aspectButton cr_js_aspectButton" data-aspectname="Qualität" data-occurrencescount="3">
+                <span class="cr_aspectButton__text">Qualität</span>
+                <span class="cr_aspectButton__count">(3)</span>
+            </button>
+
+            <button class="cr_aspectButton cr_js_aspectButton" data-aspectname="Teleskopauszüge" data-occurrencescount="3">
+                <span class="cr_aspectButton__text">Teleskopauszüge</span>
+                <span class="cr_aspectButton__count">(3)</span>
+            </button>
+
+
+    </div>
+</div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="cr_js_reviewList cr_reviewList">
+
+            <div class="cr_review cr_js_review" data-review-rating="4" data-review-id="5d89038cc74039000761a1dd" data-review-creationDate="2019-09-23 19:40">
+                <span class="p_rating100 cr_review__stars">* * * * o</span>
+                <h3 class="cr_review__title">Super Ofen </h3>
+
+                    <span class="cr_review__helpfulSummary cr_review__helpfulSummary--SandM">Für <span class="cr_js_helpfulSummary__positive">5</span> von <span class="cr_js_helpfulSummary__all">5</span> Kunden hilfreich.</span>
+                    <span class="cr_review__helpfulSummary cr_review__helpfulSummary--LandXL"><span class="cr_js_helpfulSummary__positive">5</span> von <span class="cr_js_helpfulSummary__all">5</span> Kunden finden diese Bewertung hilfreich.</span>
+
+
+                <div class="cr_review__verifiedPurchase">
+                    <svg class="cr_review__verifiedPurchaseIcon pl_icon50" role="img"><use xlink:href="/assets-static/icons/pl_icon_check50.svg#pl_icon_check50" /></svg>
+                    <span class="cr_review__verifiedPurchaseText">Verifizierter Kauf</span>
+                </div>
+
+                <p class="cr_review__text">Der Backofen ist wirklich ein sehr schönes und gutes Gerät er bringt alles mit was man braucht. Bis jetzt bin ich begeistert habe ausser gebacken alles ausprobiert. Wirklich empfehlenswert. Ein Punkt Abzug muss ich geben erstens der Ton wenn die Zeit abgelaufen ist sehr sehr leise er zum Glück schaltet der Ofen sich selbst aus. Zweitens die Abkühlphase sehr lautes Gebläse man muss die Küchentüre schließen um weiter tv zu schauen trotzdem ein super Gerät.</p>
+                <span class="cr_review__reviewer">
+                    von <span class="cr_review__reviewerName">Elvira S.</span>
+
+                        aus Stolberg
+
+                    23.09.2019
+                </span>
+                <span class="cr_review__dimensions">
+                    Bewerteter Artikel:
+
+
+
+                            <span>Farbe: </span>
+
+                        <b>edelstahlfarben</b>
+
+                </span>
+
+
+
+                <span class="cr_review__helpfulSubmit cr_js_review__helpfulSubmit">
+                    Findest du diese Bewertung hilfreich?
+                    <span class="cr_helpfulSubmit">
+                        <button type="button" class="p_btn50--3rd cr_js_helpfulButton cr_helpfulSubmit__button" data-vote="+">Ja</button>
+                        <button type="button" class="p_btn50--3rd cr_js_helpfulButton cr_helpfulSubmit__button" data-vote="-">Nein</button>
+                    </span>
+                </span>
+
+                <span class="p_link--1st cr_reportReviewLink cr_js_reportReviewLink">
+                    Bewertung melden
+                </span>
+                <hr class="p_line100 cr_review__line" />
+            </div>
+
+            <div class="cr_review cr_js_review" data-review-rating="2" data-review-id="5c9c740054f3480006c4e45c" data-review-creationDate="2019-03-28 08:13">
+                <span class="p_rating100 cr_review__stars">* * o o o</span>
+                <h3 class="cr_review__title">Sehr lange und Laute Abkühlphase</h3>
+
+                    <span class="cr_review__helpfulSummary cr_review__helpfulSummary--SandM">Für <span class="cr_js_helpfulSummary__positive">3</span> von <span class="cr_js_helpfulSummary__all">3</span> Kunden hilfreich.</span>
+                    <span class="cr_review__helpfulSummary cr_review__helpfulSummary--LandXL"><span class="cr_js_helpfulSummary__positive">3</span> von <span class="cr_js_helpfulSummary__all">3</span> Kunden finden diese Bewertung hilfreich.</span>
+
+
+                <div class="cr_review__verifiedPurchase">
+                    <svg class="cr_review__verifiedPurchaseIcon pl_icon50" role="img"><use xlink:href="/assets-static/icons/pl_icon_check50.svg#pl_icon_check50" /></svg>
+                    <span class="cr_review__verifiedPurchaseText">Verifizierter Kauf</span>
+                </div>
+
+                <p class="cr_review__text">Dieser Backofen geht leider wieder zurück.<br />Trotts guter Backleistung gebe ich Ihn wieder zurück, da er eine sehr langen und sehr Laute Abkühlphase hat, des weiteren ist das Zeitsignal (Timer) sehr leise, so das man ihn sehr schnell überhört.<br />Ich habe mich nun für das Modell von Samsung entschieden, (Samsung Backofen NV70K3370RS/EG, Pyrolyse-Selbstreinigung) mal sehen wie dieser ist.</p>
+                <span class="cr_review__reviewer">
+                    von <span class="cr_review__reviewerName">einem Kunden</span>
+
+                        aus Hardegsen
+
+                    28.03.2019
+                </span>
+                <span class="cr_review__dimensions">
+                    Bewerteter Artikel:
+
+
+
+                            <span>Farbe: </span>
+
+                        <b>edelstahlfarben</b>
+
+                </span>
+
+
+
+                <span class="cr_review__helpfulSubmit cr_js_review__helpfulSubmit">
+                    Findest du diese Bewertung hilfreich?
+                    <span class="cr_helpfulSubmit">
+                        <button type="button" class="p_btn50--3rd cr_js_helpfulButton cr_helpfulSubmit__button" data-vote="+">Ja</button>
+                        <button type="button" class="p_btn50--3rd cr_js_helpfulButton cr_helpfulSubmit__button" data-vote="-">Nein</button>
+                    </span>
+                </span>
+
+                <span class="p_link--1st cr_reportReviewLink cr_js_reportReviewLink">
+                    Bewertung melden
+                </span>
+                <hr class="p_line100 cr_review__line" />
+            </div>
+
+            <div class="cr_review cr_js_review" data-review-rating="2" data-review-id="5c573a1538543d00066e6073" data-review-creationDate="2019-02-03 19:59">
+                <span class="p_rating100 cr_review__stars">* * o o o</span>
+                <h3 class="cr_review__title">Viel zu laut</h3>
+
+                    <span class="cr_review__helpfulSummary cr_review__helpfulSummary--SandM">Für <span class="cr_js_helpfulSummary__positive">16</span> von <span class="cr_js_helpfulSummary__all">17</span> Kunden hilfreich.</span>
+                    <span class="cr_review__helpfulSummary cr_review__helpfulSummary--LandXL"><span class="cr_js_helpfulSummary__positive">16</span> von <span class="cr_js_helpfulSummary__all">17</span> Kunden finden diese Bewertung hilfreich.</span>
+
+
+                <div class="cr_review__verifiedPurchase">
+                    <svg class="cr_review__verifiedPurchaseIcon pl_icon50" role="img"><use xlink:href="/assets-static/icons/pl_icon_check50.svg#pl_icon_check50" /></svg>
+                    <span class="cr_review__verifiedPurchaseText">Verifizierter Kauf</span>
+                </div>
+
+                <p class="cr_review__text">Eigentlich war ich bisher immer begeistert von privileg,  dieses Mal wohl nicht.  Das Gebläse nach dem Abschalten des Ofens ist extrem laut und nervtötend.  Wählt man den Timer schaltet sich der Ofen automatisch am Ende auf abkühlen, was sehr unpraktisch ist beim Kuchenbacken. <br />Wirklich schade! Der Einbau war ein Kinderspiel und während des normalen Backvorgangs ist der Ofen sehr leise. Warum ist das Gebläse nur so laut beim abkühlen?</p>
+                <span class="cr_review__reviewer">
+                    von <span class="cr_review__reviewerName">einer Kundin</span>
+
+                        aus Nittenau
+
+                    03.02.2019
+                </span>
+                <span class="cr_review__dimensions">
+                    Bewerteter Artikel:
+
+
+
+                            <span>Farbe: </span>
+
+                        <b>edelstahlfarben</b>
+
+                </span>
+
+
+
+                <span class="cr_review__helpfulSubmit cr_js_review__helpfulSubmit">
+                    Findest du diese Bewertung hilfreich?
+                    <span class="cr_helpfulSubmit">
+                        <button type="button" class="p_btn50--3rd cr_js_helpfulButton cr_helpfulSubmit__button" data-vote="+">Ja</button>
+                        <button type="button" class="p_btn50--3rd cr_js_helpfulButton cr_helpfulSubmit__button" data-vote="-">Nein</button>
+                    </span>
+                </span>
+
+                <span class="p_link--1st cr_reportReviewLink cr_js_reportReviewLink">
+                    Bewertung melden
+                </span>
+
+            </div>
+
+    </div>
+
+
+    <span data-tracking-information="bottom" class="cr_moreReviewsButton p_btn100--2nd cr_js_customerReviewPageLink">Alle Kundenbewertungen anzeigen<i>&nbsp;&gt;</i></span>
+
+
+        <script>/*<![CDATA[*/"use strict";function _slicedToArray(e,t){return _arrayWithHoles(e)||_iterableToArrayLimit(e,t)||_unsupportedIterableToArray(e,t)||_nonIterableRest()}function _nonIterableRest(){throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.")}function _unsupportedIterableToArray(e,t){if(e){if("string"==typeof e)return _arrayLikeToArray(e,t);var r=Object.prototype.toString.call(e).slice(8,-1);return"Map"===(r="Object"===r&&e.constructor?e.constructor.name:r)||"Set"===r?Array.from(e):"Arguments"===r||/^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(r)?_arrayLikeToArray(e,t):void 0}}function _arrayLikeToArray(e,t){(null==t||t>e.length)&&(t=e.length);for(var r=0,i=new Array(t);r<t;r++)i[r]=e[r];return i}function _iterableToArrayLimit(e,t){var r=null==e?null:"undefined"!=typeof Symbol&&e[Symbol.iterator]||e["@@iterator"];if(null!=r){var i,n,a=[],o=!0,s=!1;try{for(r=r.call(e);!(o=(i=r.next()).done)&&(a.push(i.value),!t||a.length!==t);o=!0);}catch(e){s=!0,n=e}finally{try{o||null==r.return||r.return()}finally{if(s)throw n}}return a}}function _arrayWithHoles(e){if(Array.isArray(e))return e}function ownKeys(t,e){var r,i=Object.keys(t);return Object.getOwnPropertySymbols&&(r=Object.getOwnPropertySymbols(t),e&&(r=r.filter(function(e){return Object.getOwnPropertyDescriptor(t,e).enumerable})),i.push.apply(i,r)),i}function _objectSpread(t){for(var e=1;e<arguments.length;e++){var r=null!=arguments[e]?arguments[e]:{};e%2?ownKeys(Object(r),!0).forEach(function(e){_defineProperty(t,e,r[e])}):Object.getOwnPropertyDescriptors?Object.defineProperties(t,Object.getOwnPropertyDescriptors(r)):ownKeys(Object(r)).forEach(function(e){Object.defineProperty(t,e,Object.getOwnPropertyDescriptor(r,e))})}return t}function _defineProperty(e,t,r){return t in e?Object.defineProperty(e,t,{value:r,enumerable:!0,configurable:!0,writable:!0}):e[t]=r,e}function _classCallCheck(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function _defineProperties(e,t){for(var r=0;r<t.length;r++){var i=t[r];i.enumerable=i.enumerable||!1,i.configurable=!0,"value"in i&&(i.writable=!0),Object.defineProperty(e,i.key,i)}}function _createClass(e,t,r){return t&&_defineProperties(e.prototype,t),r&&_defineProperties(e,r),Object.defineProperty(e,"prototype",{writable:!1}),e}var o_cr=window.o_cr||{};o_cr.data=o_cr.data||{},o_cr.data.ProductReviewsToReviewsModelConverter=function(){function o(){_classCallCheck(this,o)}return _createClass(o,null,[{key:"_convertDimensions",value:function(e){for(var t=e.length,r=0;r<t;r++)e[r].hasNext=r<t-1,"unknown"===e[r].displayName.toLowerCase()&&(e[r].displayName="Variante")}},{key:"_hasBeenRatedByUser",value:function(e,t,r){return!!e&&!!t&&e.getItem("cr_RatedReviews_".concat(t))&&0<=e.getItem("cr_RatedReviews_".concat(t)).indexOf(r)}},{key:"_convertSingleReview",value:function(e,t,r){var i=new o_cr.util.ToggleService;return e.ratingAsIconFont=o_cr.util.RatingConverter.ratingToIconFont(e.rating),e.creationDateGermanFormat=o_cr.util.DateUtil.getGermanDateFormat(e.creationDate),e.hasBeenRatedByUser=this._hasBeenRatedByUser(r,t,e.id),e.hasBeenRated=0<e.nrOfVotes,e.dimensions&&0<e.dimensions.length&&(e.hasDimensions=!0,this._convertDimensions(e.dimensions)),e.productData&&e.productData.dimensions&&0<e.productData.dimensions.length&&(e.hasDimensions=!0,this._convertDimensions(e.productData.dimensions)),e.text&&i.isEnabled("FEATURE_2024_DISPLAY_LINE_BREAKS_IN_REVIEW_TEXTS")&&e.text.replace(/(?:\r\n|\r|\n)/g,"<br />"),e}},{key:"convert",value:function(e,t,r){for(var i=[],n=0;n<e.length;n++){var a=o._convertSingleReview(e[n].data,t,r);n===e.length-1&&(a.isLast=!0),i.push(a)}return i}},{key:"convertBIReviews",value:function(e,t,r){var i=[];return e.forEach(function(e){e=e.data;o._convertSingleReview(e.productReview,t,r),i.push(e)}),i}}]),o}(),(o_cr=window.o_cr||{}).model=o_cr.model||{},o_cr.model.SUBMIT_LAYER_SOURCE_MAIL_LOWER_CASE="mail",o_cr.model.SUBMIT_LAYER_SOURCE_MYACCOUNT_LOWER_CASE="myaccount",o_cr.model.ReviewFormModel=function(){function i(){_classCallCheck(this,i)}return _createClass(i,null,[{key:"createUserViewModel",value:function(e){if(e&&e.userData){e=e.userData;return{firstName:e.firstName,lastNameAbbr:e.lastName?e.lastName[0]:null,anonymousSalutation:"MALE"===e.gender?"Ein Kunde":"Eine Kundin",city:e.city}}return null}},{key:"selectFirstOrderPosition",value:function(e){return e&&0!==e.length?e[0]:null}},{key:"selectOrderPosition",value:function(t,e,r){if(!e||e.toLowerCase()!==o_cr.model.SUBMIT_LAYER_SOURCE_MAIL_LOWER_CASE&&e.toLowerCase()!==o_cr.model.SUBMIT_LAYER_SOURCE_MYACCOUNT_LOWER_CASE)return i.selectFirstOrderPosition(r);e=r.filter(function(e){return e.product.variationId===t});return e&&0<e.length?e[0]:i.selectFirstOrderPosition(r)}},{key:"createProductViewModel",value:function(e,t,r){if(t&&r&&r.orderPositions){r=i.selectOrderPosition(e,t,r.orderPositions),r=r&&r.product;return{name:r&&r.name,imageUrl:r&&r.imageUrl,imageFallbackUrl:"https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT31$",dimensions:r&&r.dimensions.map(function(e){return _objectSpread({},e)})}}return null}},{key:"buildFormModel",value:function(e,t,r){return{user:i.createUserViewModel(r),product:i.createProductViewModel(e,t,r)}}}]),i}(),(o_cr=window.o_cr||{}).util=o_cr.util||{},o_cr.util.Api=function(){function t(e){_classCallCheck(this,t),this._customerReviewPageLinks=e}return _createClass(t,[{key:"updateLandingPageHref",value:function(){this._customerReviewPageLinks.updateHref()}}]),t}(),(o_cr=window.o_cr||{}).util=o_cr.util||{},o_cr.util.DateUtil=function(){function e(){_classCallCheck(this,e)}return _createClass(e,null,[{key:"getGermanDateFormat",value:function(e){var t=new Date(e),r=t.getFullYear(),e=t.getDate(),t=t.getMonth()+1;return t<10&&(t="0"+t),"".concat(e=e<10?"0"+e:e,".").concat(t,".").concat(r)}}]),e}(),(o_cr=window.o_cr||{}).util=o_cr.util||{},o_cr.util.Dom=function(){function e(){_classCallCheck(this,e)}return _createClass(e,null,[{key:"getClientTop",value:function(){return document.documentElement.clientTop}},{key:"getWindowPageYOffset",value:function(){return window.pageYOffset}},{key:"getYPositionOfElement",value:function(e){return e.getBoundingClientRect().top+this.getWindowPageYOffset()-this.getClientTop()}},{key:"getScrollTargetFromHash",value:function(){var e=window.location.hash.slice(1);if(e){var t=e.split("&");if(t.length)for(var r=0;r<t.length;r++){var i=t[r].split("=");if("scrollTarget"===i[0])return document.getElementById(i[1])}}return null}}]),e}(),(o_cr=window.o_cr||{}).util=o_cr.util||{},o_cr.util.MustacheRenderer=function(){function e(){_classCallCheck(this,e)}return _createClass(e,null,[{key:"render",value:function(e,t){e=document.getElementById(e).innerHTML;return Mustache.render(e,t)}}]),e}(),(o_cr=window.o_cr||{}).util=o_cr.util||{},o_cr.util.OnexInfoService=function(){function e(){_classCallCheck(this,e),this.json=JSON.parse(document.getElementById("cr_onexInfoJSON").innerHTML)}return _createClass(e,[{key:"isVariantActive",value:function(e,t){return!!this.json[e]&&this.json[e]===t}}]),e}(),(o_cr=window.o_cr||{}).util=o_cr.util||{},o_cr.util.PaliLayer=function(){function e(){_classCallCheck(this,e)}return _createClass(e,null,[{key:"openPaliLayer",value:function(e){var t=o_global.pali.layer.getActiveLayer();return t?t.switchLayerContent({content:e.content}):(t=new o_global.pali.layerBuilder(e)).open(),t}}]),e}(),(o_cr=window.o_cr||{}).util=o_cr.util||{},o_cr.util.RatingConverter=function(){function e(){_classCallCheck(this,e)}return _createClass(e,null,[{key:"ratingToIconFont",value:function(e){for(var t=Math.round(2*e)/2,r="",i=0;i<5;i++)i<t?t%1!=0&&i===Math.floor(t)?r+="/":r+="*":r+="o",i<4&&(r+=" ");return r}}]),e}(),(o_cr=window.o_cr||{}).util=o_cr.util||{},o_cr.util.StringUtil=function(){function a(){_classCallCheck(this,a)}return _createClass(a,null,[{key:"abbreviateString",value:function(e,t,r){return e.length>t&&(-1!==(t=(e=e.substring(0,t)).lastIndexOf(" "))&&(e=e.substring(0,t)),e+=r),e}},{key:"slugify",value:function(e){return String(e).toLowerCase().replace(/ä/g,"ae").replace(/ö/g,"oe").replace(/ü/g,"ue").replace(/ /g,"_")}},{key:"slugifyDataContainer",value:function(r,i){var n={};return Object.keys(r).forEach(function(e){var t;!r.hasOwnProperty(e)||null!=(t=r[e])&&(-1===i.indexOf(e)?n[e]=a.slugify(t):n[e]=String(t))}),n}}]),a}(),(o_cr=window.o_cr||{}).util=o_cr.util||{},o_cr.util.ToggleService=function(){function e(){_classCallCheck(this,e),this.json=JSON.parse(document.getElementById("cr_featuresJSON").innerHTML)}return _createClass(e,[{key:"isEnabled",value:function(e){return!!this.json[e]&&"true"===this.json[e]}},{key:"isDisabled",value:function(e){return!this.isEnabled(e)}}]),e}(),(o_cr=window.o_cr||{}).util=o_cr.util||{},o_cr.util.TokenService=function(){function t(e){_classCallCheck(this,t),this._token=e}return _createClass(t,[{key:"setToken",value:function(e){this._token=e}},{key:"getToken",value:function(){return this._token}}]),t}(),(o_cr=window.o_cr||{}).util=o_cr.util||{},o_cr.util.Tracking=function(){function e(){_classCallCheck(this,e)}return _createClass(e,null,[{key:"_extractVariationIdFromDom",value:function(){var e=null;return e=document.getElementsByClassName("js_metaVariationId").length?document.querySelector('.js_metaVariationId meta[itemprop="value"]').getAttribute("content"):e}},{key:"createContext",value:function(){var e=this._extractVariationIdFromDom(),t={};return e&&(t.product_VariationId=e),o_cr.isLandingPage&&(t.ot_PageCluster="Kundenbewertungsseite"),t}},{key:"sendEvent",value:function(e){var t=this._extractVariationIdFromDom();t&&(e.product_VariationId=t),o_cr.isLandingPage&&(e.ot_PageCluster="Kundenbewertungsseite");try{o_global.eventQBus.emit("tracking.bct.submitEvent",e)}catch(e){AS.RUM.sendCustomRequest("o_cr",{eventType:"sendEventToTrackingServer",errorType:e.name,errorMessage:e.message})}}},{key:"sendMerge",value:function(e){try{o_global.eventQBus.emit("tracking.bct.addToPageImpression",e)}catch(e){AS.RUM.sendCustomRequest("o_cr",{eventType:"sendMergeToTrackingServer",errorType:e.name,errorMessage:e.message})}}},{key:"trackOnNextPI",value:function(e){try{o_global.eventQBus.emit("tracking.bct.submitMove",e)}catch(e){AS.RUM.sendCustomRequest("o_cr",{eventType:"trackOnNextPageImpression",errorType:e.name,errorMessage:e.message})}}},{key:"sendMergeFeatures",value:function(e){try{o_global.eventQBus.emit("tracking.bct.addFeaturesToPageImpression",e)}catch(e){AS.RUM.sendCustomRequest("o_cr",{eventType:"sendMergeFeatures",errorType:e.name,errorMessage:e.message})}}},{key:"submitMoveAction",value:function(e,t){try{var r=o_cr.util.Tracking.createContext();o_global.eventQBus.emit("tracking.bct.submitMoveAction",r,{name:e,features:t})}catch(e){AS.RUM.sendCustomRequest("o_cr",{eventType:"submitMoveAction",errorType:e.name,errorMessage:e.message})}}}]),e}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.AspectFilter=function(){function r(e,t){_classCallCheck(this,r),this._rootElement=e,this._webPageLoader=t,this._aspectFilterElement=this._rootElement.querySelector(".cr_js_aspectFilter__buttons"),this._deselectLink=this._rootElement.querySelector(".cr_js_aspectDeselectLink")}return _createClass(r,[{key:"_aspectButtonClickHandler",value:function(e){e=o_util.dom.getParentByClassName(e.target,"cr_js_aspectButton"),e=encodeURIComponent(e.getAttribute("data-aspectName"));this._webPageLoader.filterByAspect(e)}},{key:"_deselectLinkClickHandler",value:function(){this._webPageLoader.filterByAspect(null)}},{key:"init",value:function(){var t=this;this._aspectFilterElement&&o_util.event.delegate(this._aspectFilterElement,"click",".cr_js_aspectButton",function(e){t._aspectButtonClickHandler(e)}),this._deselectLink&&this._deselectLink.addEventListener("click",function(){t._deselectLinkClickHandler()},!1)}}]),r}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.AspectSmileyTracking=function(){function t(e){_classCallCheck(this,t),this._rootElement=e}return _createClass(t,[{key:"init",value:function(){o_util.event.delegate(this._rootElement,"click",".cr_js_aspectTypeDistribution__item",o_cr.widgets.AspectSmileyTracking._smileyClickHandler)}}],[{key:"_smileyClickHandler",value:function(e){e=o_util.dom.getParentByClassName(e.target,"cr_js_aspectTypeDistribution__item");o_cr.util.Tracking.sendEvent({review_Smileys:e.getAttribute("data-type")})}}]),t}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.AspectTracking=function(){function t(e){_classCallCheck(this,t),this._rootElement=e,this._aspectData=this._parseAspectData()}return _createClass(t,[{key:"_shouldTrack",get:function(){return this._aspectData&&0!==this._aspectData.length}},{key:"deepCopyAspectData",get:function(){return this._aspectData&&0!==this._aspectData.length?this._aspectData.map(function(e){return _objectSpread({},e)}):[]}},{key:"_parseAspectData",value:function(){var e=[];if(this._rootElement){var t=this._rootElement.getElementsByClassName("cr_js_aspectButton");if(t&&t.length)for(var r=0;r<t.length;r++){var i=t[r],i={index:r,name:i.getAttribute("data-aspectname"),occurrencesCount:i.getAttribute("data-occurrencescount")};e.push(i)}}return e}},{key:"generateAspectTrackingData",value:function(i,n){var e=2<arguments.length&&void 0!==arguments[2]?arguments[2]:this.deepCopyAspectData,a=[];return a.push({id:i,name:"ReviewAspects",position:1,status:"visible",labels:{}}),e.forEach(function(e,t){var r={review_Name:[e.name],review_AspectCount:[e.occurrencesCount]};null!==e.overallRating&&void 0!==e.overallRating&&(r.review_AspectOverallRating=[e.overallRating]),a.push({id:"".concat(i,"-aspect").concat(t+1),name:"ReviewAspect",parentId:i,position:t+1,status:n&&n===e.name?"selected":"visible",labels:r})}),a}},{key:"trackAspectsView",value:function(){var e,t,r,i;!this._shouldTrack||void 0!==(i=(e=this._rootElement.querySelector(".js_cr_aspectHeader"))?(t=e.getAttribute("data-selected-aspect-name"),r=e.getAttribute("data-selected-positive-count-in-percent"),(i=this.deepCopyAspectData).forEach(function(e){e.name===t&&(e.overallRating="".concat(r/100))}),this.generateAspectTrackingData("kbw-pi-aspects",t,i)):this.generateAspectTrackingData("kbw-pi-aspects"))&&o_cr.util.Tracking.sendMergeFeatures(i)}},{key:"trackFilterByAspect",value:function(t){var e;t&&(e=this.deepCopyAspectData.filter(function(e){return e.name===t}),e=this.generateAspectTrackingData("kbw-pi-openaspects",t,e),o_cr.util.Tracking.submitMoveAction("select",e))}}]),t}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.BiReviewMoreLink=function(){function t(e){_classCallCheck(this,t),this._rootElement=e}return _createClass(t,[{key:"init",value:function(){o_util.event.delegate(this._rootElement,"click",".cr_js_review__moreLink",o_cr.widgets.BiReviewMoreLink._moreLinkClickHandler)}}],[{key:"_moreLinkClickHandler",value:function(e){e=o_util.dom.getParentByClassName(e.target,"cr_js_review");o_cr.widgets.BiReviewMoreLink._trackMoreLinkClick(e),e.classList.toggle("cr_review--expanded")}},{key:"_getTypeOfReviewFromClassList",value:function(e){var t;return e.classList.contains("cr_bi-review--positive")?t="positive":e.classList.contains("cr_bi-review--negative")?t="negative":e.classList.contains("cr_bi-review--neutral")&&(t="neutral"),t}},{key:"_trackMoreLinkClick",value:function(e){var t=e.classList.contains("cr_review--expanded")?"close":"open",e=this._getTypeOfReviewFromClassList(e);o_cr.util.Tracking.sendEvent({review_AspectExpand:t,review_AspectRating:e})}}]),t}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.CustomerReviewPageLinks=function(){function e(){_classCallCheck(this,e)}return _createClass(e,[{key:"_clickEventHandler",value:function(){o_cr.util.Tracking.trackOnNextPI({review_Navigation:this.getAttribute("data-tracking-information")})}},{key:"_convertSpanToLinkElement",value:function(e,t){for(var r=e.attributes,i=document.createElement("a"),n=r.length-1;0<=n;n--){var a=r[n];i.setAttribute(a.name,a.value)}return i.setAttribute("href",t),i.innerHTML=e.innerHTML,e.parentNode.replaceChild(i,e),i}},{key:"_initializeLinkElements",value:function(e){for(var t=document.getElementsByClassName("cr_js_customerReviewPageLink"),r=0;r<t.length;r++){var i=t[r];"SPAN"===i.tagName?i=this._convertSpanToLinkElement(i,e):i.setAttribute("href",e),i.addEventListener("click",this._clickEventHandler,!1)}}},{key:"_getLocation",value:function(){return window.location}},{key:"_createLandingPageHref",value:function(){var e=this._getLocation().pathname.replace(/\/$/,""),t=o_util.fragment.deserialize(!1);return t&&t.variationId?"".concat(e,"-kundenbewertungen/#variationId=").concat(t.variationId):"".concat(e,"-kundenbewertungen/")}},{key:"updateHref",value:function(){this._initializeLinkElements(this._createLandingPageHref())}}]),e}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.FeatureTracking=function(){function r(e){var t=this;_classCallCheck(this,r),this.rootElement=e,this.visibilityTracked=!1,this.relevantEvents=["scroll","resize"],this.trackContentVisibleCallback=function(){return t._trackContentIfVisible()},document.getElementById("cr_trackingInformation")&&(this.trackingInformation=JSON.parse(document.getElementById("cr_trackingInformation").innerHTML))}return _createClass(r,[{key:"init",value:function(){this.trackingInformation&&this.rootElement&&(o_cr.util.Tracking.sendMerge(_objectSpread({},this.trackingInformation)),this._registerVisibilityTrackingListeners())}},{key:"_registerVisibilityTrackingListeners",value:function(){var t=this;this.relevantEvents.forEach(function(e){document.addEventListener(e,t.trackContentVisibleCallback,!1)})}},{key:"_unregisterVisibilityTrackingListeners",value:function(){var t=this;this.relevantEvents.forEach(function(e){document.removeEventListener(e,t.trackContentVisibleCallback,!1)})}},{key:"_trackContentIfVisible",value:function(){!this.visibilityTracked&&this._isContentVisible()&&(this.visibilityTracked=!0,o_cr.util.Tracking.sendEvent(_objectSpread(_objectSpread({},this.trackingInformation),{},{review_RatingsSeen:!0})),this._unregisterVisibilityTrackingListeners())}},{key:"_isContentVisible",value:function(){var e=this.rootElement.getBoundingClientRect().top;return 0!==e&&100<document.documentElement.clientHeight-e}}]),r}(),(o_cr=window.o_cr||{}).widgets.LandingPage=function(){function t(e){_classCallCheck(this,t),this._landingPageTracking=new o_cr.widgets.LandingPageTracking(e)}return _createClass(t,[{key:"init",value:function(){this._determineInitialVariation(),this._landingPageTracking.init()}},{key:"_getVariationIdFromFragment",value:function(){return o_util.fragment.deserialize(!1).variationId}},{key:"_determineInitialVariation",value:function(){var e=this._getVariationIdFromFragment();void 0===e||void 0!==(e=o_cr.variationsMap[e])&&(this._setRetailPrice(e),this._setNormPrice(e),this._setHeadLine(e),this._setImage(e))}},{key:"_setNormPrice",value:function(e){var t=document.getElementsByClassName("cr_js_normPrice")[0];null===t||null!==(e=e.normPrice)&&(t.textContent="".concat(e.price," ").concat(e.normAmount,"/ ").concat(e.normUnit))}},{key:"_setRetailPrice",value:function(e){var t=document.getElementsByClassName("cr_js_retailPrice")[0];null!==t&&(t.textContent=e.retailPrice)}},{key:"_setHeadLine",value:function(e){document.getElementsByClassName("cr_js_productDetailHeadlineLink")[0].textContent=e.name}},{key:"_setImage",value:function(e){var t=document.getElementsByClassName("cr_js_imageLink")[0];null===e.imageUrl?(t.setAttribute("src",t.getAttribute("data-product-image-fallback-url")),t.setAttribute("alt",t.getAttribute("data-fallback-text")||"Kein Bild vorhanden")):t.setAttribute("src",e.imageUrl)}}]),t}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.LandingPageTracking=function(){function t(e){_classCallCheck(this,t),this._rootElement=e}return _createClass(t,[{key:"init",value:function(){this._trackClick(),this._trackVariation()}},{key:"_trackClick",value:function(){var t=this;o_util.event.delegate(this._rootElement,"click",".cr_js_productDetailButton",function(e){t._trackClickEvent(e.target)}),o_util.event.delegate(this._rootElement,"click",".cr_js_productDetailHeadlineLink",function(e){t._trackClickEvent(e.target)}),o_util.event.delegate(this._rootElement,"click",".cr_js_imageLink",function(e){t._trackClickEvent(e.target)}),o_util.event.delegate(this._rootElement,"click",".cr_js_variationLink",function(e){t._trackClickEvent(e.target)})}},{key:"_trackClickEvent",value:function(e){o_cr.util.Tracking.trackOnNextPI({product_Navigation:e.getAttribute("data-tracking-information")})}},{key:"_trackVariation",value:function(){var e;!this._rootElement||void 0!==(e=this._rootElement.getElementsByClassName("cr_js_availableVariationLink")[0])&&o_cr.util.Tracking.sendMerge({product_MoreVariations:e.getAttribute("data-tracking-information"),ot_PageCluster:"Kundenbewertungsseite"})}}]),t}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.MinimalProductReviewListWidget=function(){function t(e){_classCallCheck(this,t),this.rootElement=e,this._tokenService=new o_cr.util.TokenService(this.rootElement.getAttribute("data-client-token")),this._productId=this.rootElement.getAttribute("data-product-id"),this._reviewIds=null,this._ratingHelpful=new o_cr.widgets.RatingHelpful(this._productId,this._tokenService,this),this._webPageLoaderTracking=new o_cr.widgets.WebPageLoaderTracking(this.rootElement),this._webPageLoader=new o_cr.widgets.WebPageLoader(this._webPageLoaderTracking),this._aspectFilter=new o_cr.widgets.AspectFilter(this.rootElement,this._webPageLoader),this._starHistogram=new o_cr.widgets.StarHistogram(this.rootElement,this._webPageLoader),this._reportReview=new o_cr.widgets.ReportReview(this.rootElement,this,this._tokenService),this._featureTracking=new o_cr.widgets.FeatureTracking(this.rootElement)}return _createClass(t,[{key:"init",value:function(){this._reviewIds=this._extractReviewIds(),this._bindHelpfulRatingButtonHandler(),this._ratingHelpful.checkWhetherUserHasAlreadyRatedInitiallyRenderedReviews(),this._aspectFilter.init(),this._starHistogram.init(),this._webPageLoaderTracking.trackAspectsView(),this._reportReview.init(),this._featureTracking&&this._featureTracking.init()}},{key:"getPositionOfReviewById",value:function(e){return this._reviewIds.indexOf(e)+1}},{key:"_extractReviewIds",value:function(){for(var e=[],t=this.rootElement.getElementsByClassName("cr_js_review"),r=0;r<t.length;r++)e.push(t[r].getAttribute("data-review-id"));return e}},{key:"_bindHelpfulRatingButtonHandler",value:function(){var t=this;o_util.event.delegate(".cr_js_reviewList","click",".cr_js_helpfulButton",function(e){e=o_util.event.getTarget(e);t._ratingHelpful.helpfulRatingButtonHandler(e)})}}]),t}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.Paging=function(){function r(e,t){_classCallCheck(this,r),this._rootElement=e,this._pagingElement=this._rootElement.querySelector(".js_cr_paging"),this._buttonNext=this._pagingElement.querySelector(".cr_js_paging__button--next"),this._buttonLast=this._pagingElement.querySelector(".cr_js_paging__button--last"),this._pagingLabel=this._pagingElement.querySelector(".cr_js_paging__currentPage"),this._webPageLoader=t}return _createClass(r,[{key:"updatePaging",value:function(e,t,r){r=Math.ceil(r/t),t=e+1<=r?e+1:r;this._pagingLabel.innerHTML="Seite ".concat(e," / ").concat(r),this._buttonLast.setAttribute("data-target",r.toString()),this._buttonNext.setAttribute("data-target",t.toString()),e===r&&(this._buttonNext.setAttribute("disabled",""),this._buttonLast.setAttribute("disabled",""))}},{key:"_buttonClickHandler",value:function(e){var t=o_util.dom.getParentByClassName(e.target,"cr_js_paging__button");t.disabled||(e=parseInt(t.getAttribute("data-target"),10),t=t.getAttribute("data-action"),this._webPageLoader.changeReviewPage(e,"last"===t||"first"===t?t:null))}},{key:"init",value:function(){var t=this;o_util.event.delegate(this._rootElement,"click",".cr_js_paging__button",function(e){t._buttonClickHandler(e)})}}]),r}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.ProductReviewListWidget=function(){function t(e){_classCallCheck(this,t),this.rootElement=e,this._tokenService=new o_cr.util.TokenService(this.rootElement.getAttribute("data-client-token")),this._productId=this.rootElement.getAttribute("data-product-id"),this._reviewIds=null,this._ratingHelpful=new o_cr.widgets.RatingHelpful(this._productId,this._tokenService,this),this._webPageLoaderTracking=new o_cr.widgets.WebPageLoaderTracking(this.rootElement),this._webPageLoader=new o_cr.widgets.WebPageLoader(this._webPageLoaderTracking),this._starHistogram=new o_cr.widgets.StarHistogram(this.rootElement,this._webPageLoader),this._paging=new o_cr.widgets.Paging(this.rootElement,this._webPageLoader),this._sorting=new o_cr.widgets.Sorting(this.rootElement,this._webPageLoader),this._aspectFilter=new o_cr.widgets.AspectFilter(this.rootElement,this._webPageLoader),this._aspectSmileyTracking=new o_cr.widgets.AspectSmileyTracking(this.rootElement),this._biReviewMoreLink=new o_cr.widgets.BiReviewMoreLink(this.rootElement),this._reviewLoader=new o_cr.widgets.ReviewLoader(document.getElementById("cr_loadingSpinner")),this._scrollInteraction=new o_cr.widgets.ScrollInteraction(this.rootElement,this._reviewLoader,this._paging),this._reportReview=new o_cr.widgets.ReportReview(this.rootElement,this,this._tokenService)}return _createClass(t,[{key:"init",value:function(){this._reviewIds=this._extractReviewIds(),this._bindHelpfulRatingButtonHandler(),this._initStorage(),this._starHistogram.init(),this._sorting.init(),this._ratingHelpful.checkWhetherUserHasAlreadyRatedInitiallyRenderedReviews(),this._paging.init(),this._aspectFilter.init(),this._aspectSmileyTracking.init(),this._webPageLoaderTracking.trackAspectsView(),this._biReviewMoreLink.init(),this._reportReview.init(),"true"!==o_util.cookie.get("disableLoadReviewsOnScroll")&&this._scrollInteraction.init()}},{key:"_initStorage",value:function(){this.storage=new o_global.Storage(function(){return window.localStorage}),this.localStorageAvailable=this.storage.isStorageAvailable()}},{key:"getPositionOfReviewById",value:function(e){return-1===this._reviewIds.indexOf(e)&&(this._reviewIds=this._extractReviewIds()),this._reviewIds.indexOf(e)+1}},{key:"_extractReviewIds",value:function(){for(var e=[],t=this.rootElement.getElementsByClassName("cr_js_review"),r=0;r<t.length;r++)e.push(t[r].getAttribute("data-review-id"));return e}},{key:"_bindHelpfulRatingButtonHandler",value:function(){var t=this;o_util.event.delegate(".cr_js_reviewList","click",".cr_js_helpfulButton",function(e){e=o_util.event.getTarget(e);t._ratingHelpful.helpfulRatingButtonHandler(e)})}}]),t}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.RatingHelpful=function(){function n(e,t,r){_classCallCheck(this,n),this._productId=e,this._tokenService=t,this._productReviewListWidget=r,this._initStorage()}return _createClass(n,[{key:"_initStorage",value:function(){this.storage=new o_global.Storage(function(){return window.localStorage}),this.localStorageAvailable=this.storage.isStorageAvailable()}},{key:"helpfulRatingButtonHandler",value:function(e){var t="+"===e.getAttribute("data-vote"),r=o_util.dom.getParentByClassName(e,"cr_js_review"),i=r.getAttribute("data-review-id");this._frequencyAboveThreshold()?AS.RUM.sendCustomRequest("ft5.customerreview",{eventType:"_frequencyAboveThreshold",reviewId:i,productId:this._productId}):(this._sendHelpfulRating(i,this._productId,t,this._tokenService.getToken()),o_cr.util.Tracking.sendEvent({review_SingleReviewUseful:t,review_SingleReviewPosition:this._productReviewListWidget.getPositionOfReviewById(i),review_SingleReviewTextLength:e.parentNode.parentNode.previousElementSibling.previousElementSibling.innerHTML.length,review_SingleReviewStars:r.getAttribute("data-review-rating"),review_SingleReviewAge:n._getAgeOfReviewInDays(new Date(r.getAttribute("data-review-creationdate")))})),this._saveToLocalStorage(i),e.parentNode.parentNode.innerHTML="Vielen Dank für dein Feedback!",o_cr.widgets.RatingHelpful._increaseHelpfulCount(r,t)}},{key:"_saveToLocalStorage",value:function(e){var t,r;this.localStorageAvailable&&(t="cr_RatedReviews_".concat(this._productId),(r=this.storage.getItem(t))?r+=",".concat(e):r=e,this.storage.setItem(t,r))}},{key:"_frequencyAboveThreshold",value:function(){var e,t,r,i,n=!1;return this.localStorageAvailable&&(e="cr_helpfulRating_frequency",t=Date.now(),(r=this.storage.getItem(e))?(r=(i=_slicedToArray(r.split(","),2))[0],i=i[1],6e5<t-r?this.storage.setItem(e,"".concat(t,",1")):(this.storage.setItem(e,"".concat(t,",").concat(+i+1)),n=100<=+i)):this.storage.setItem(e,"".concat(t,",1"))),n}},{key:"_sendHelpfulRating",value:function(e,t,r,i){var n=this;o_util.ajax({method:"POST",url:"/product-customerreview/helpfulRatings",data:JSON.stringify({reviewId:e,productId:t,helpful:r,clientToken:i}),contentType:"application/json"}).then(function(e){try{n._tokenService.setToken(JSON.parse(e.response).token)}catch(e){AS.RUM.sendCustomRequest("o_cr",{eventType:"_sendHelpfulRating",errorType:e.name,errorMessage:e.message})}})}},{key:"checkWhetherUserHasAlreadyRatedInitiallyRenderedReviews",value:function(){for(var e=this._productReviewListWidget.rootElement.querySelectorAll(".cr_js_review"),t=this.storage.getItem("cr_RatedReviews_".concat(this._productId)),r=0;r<e.length;r++){var i=e[r].getAttribute("data-review-id");!(!!t&&0<=t.indexOf(i))||(i=e[r].getElementsByClassName("cr_js_review__helpfulSubmit")).length&&(i[0].innerHTML="Vielen Dank für dein Feedback!")}}}],[{key:"_getAgeOfReviewInDays",value:function(e){return Math.ceil((Date.now()-e.getTime())/864e5)}},{key:"_increaseElementsCount",value:function(e){if(0<e.length)for(var t=0;t<e.length;t++)e[t].innerHTML=+e[t].innerHTML+1}},{key:"_increaseHelpfulCount",value:function(e,t){this._increaseElementsCount(e.getElementsByClassName("cr_js_helpfulSummary__all")),t&&this._increaseElementsCount(e.getElementsByClassName("cr_js_helpfulSummary__positive"))}}]),n}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.ReportReview=function(){function i(e,t,r){_classCallCheck(this,i),this._rootElement=e,this._reviewId=null,this._layer=new o_global.pali.layerBuilder({modal:!0}),this._layerElement=null,this._productReviewListWidget=t,this._tokenService=r}return _createClass(i,[{key:"_radioButtonChangeHandler",value:function(e){null!==e.querySelector(".cr_js_reportReviewList__radio:checked")&&this._hideErrorMessage()}},{key:"_trackOpen",value:function(){o_cr.util.Tracking.sendEvent({review_ReportReview:"open",review_SingleReviewPosition:this._productReviewListWidget.getPositionOfReviewById(this._reviewId)})}},{key:"_showErrorMessage",value:function(){this._layerElement.querySelector(".cr_js_reportReviewLayer__error").style.display="block",this._layer.resetViewport()}},{key:"_hideErrorMessage",value:function(){this._layerElement.querySelector(".cr_js_reportReviewLayer__error").style.display="none"}},{key:"_showSuccessMessage",value:function(){this._layerElement.querySelector(".cr_js_reportReviewLayer__surveyWrapper").style.display="none",this._layerElement.querySelector(".cr_js_reportReviewLayer__successWrapper").style.display="block",this._layer.resetViewport()}},{key:"_trackSurvey",value:function(e){e={review_ReportReviewReason:e,review_ReportReview:"send"};e.review_SingleReviewPosition=this._productReviewListWidget.getPositionOfReviewById(this._reviewId),o_cr.util.Tracking.sendEvent(e)}},{key:"_getSelectedReportReason",value:function(){var e=this._layerElement.querySelector(".cr_js_reportReviewList__radio:checked");return e?e.value:null}},{key:"_submitButtonClickHandler",value:function(){var e=this._getSelectedReportReason();e?(this._trackSurvey(e),this._sendReportReview(this._reviewId,e,this._tokenService.getToken()),this._showSuccessMessage()):this._showErrorMessage()}},{key:"_addLayerHandlers",value:function(){var e=this;o_util.event.delegate(this._layerElement,"change",".cr_js_reportReviewList__radio",function(){e._radioButtonChangeHandler(e._layerElement)}),this._layerElement.querySelector(".cr_js_reportReviewLayer__button").addEventListener("click",function(){e._submitButtonClickHandler()})}},{key:"_reportReviewClickHandler",value:function(t){var r=this;o_util.ajax.get("/product-customerreview/reviews/report/reasons").then(function(e){e=e.response?JSON.parse(e.response):null;r._openReviewLayer(t,e)})}},{key:"_openReviewLayer",value:function(e,t){e=o_util.dom.getParentByClassName(e.target,"cr_js_review"),t=o_cr.util.MustacheRenderer.render("tmplReportReviewLayer",{reasons:t});this._layer.open(),this._layer.setContent(t),this._layerElement=this._layer.getContainerElement(),this._reviewId=e.getAttribute("data-review-id"),this._addLayerHandlers(),this._trackOpen()}},{key:"_sendReportReview",value:function(t,e,r){var i=this;o_util.ajax({method:"POST",url:"/product-customerreview/reportReview",data:JSON.stringify({reviewId:t,reason:e,clientToken:r}),contentType:"application/json"}).then(function(e){try{i._tokenService.setToken(JSON.parse(e.response).token)}catch(e){AS.RUM.sendCustomRequest("ft5.customerreview",{eventType:"_sendReportReview",reviewId:t,errorType:e.name,errorMessage:e.message})}})}},{key:"init",value:function(){var t=this;o_util.event.delegate(this._rootElement,"click",".cr_js_reportReviewLink",function(e){t._reportReviewClickHandler(e)})}}],[{key:"_removeElement",value:function(e){e&&e.parentNode&&e.parentNode.removeChild(e)}}]),i}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.CLASS_DIALOG_REVIEWS="reviewSubmitLayer",o_cr.widgets.JS_CLASS_DIALOG_REVIEWS="js_reviewSubmitLayer",o_cr.widgets.TEXTAREA_SELECTOR='textarea[id="cr_reviewText"]',o_cr.widgets.keysNotToBeSlugified=["ot_PageCluster","product_AdviceActivity","product_AdviceName","product_Dimension","product_VariationId"],o_cr.widgets.ReviewFormLayer=function(){function i(e){_classCallCheck(this,i),this._rootElement=e,this._dataSubmitted=!1,this._orderPositionCount=0,this._sourceToOpenSubmitLayer="",this._submitLayer=null,this._formData=null,this._productId=null,this._variationId=null}return _createClass(i,[{key:"initNewArch",value:function(e){this._initClickListener(),this._productId=e.productId,this._variationId=e.variationId,this._openFromFragment()}},{key:"initOldArch",value:function(){var t=this;this._initClickListener(),o_global.eventQBus.on("ft5.product-reviews.variationChange",function(e){t._productId=e.productId,t._variationId=e.variationId,t._openFromFragment()})}},{key:"_initClickListener",value:function(){var t=this;o_util.event.delegate(this._rootElement,"click",".js_submitReview",function(e){e.preventDefault(),t._sourceToOpenSubmitLayer=e.target.getAttribute("data-tracking-information"),t._checkPreconditionsAndLoadSubmitLayer()})}},{key:"_openFromFragment",value:function(){var e=o_util.fragment.deserialize(!1);e.openLayer&&"true"===e.openLayer&&(this._sourceToOpenSubmitLayer=e.sourceToOpenSubmitLayer,this._checkPreconditionsAndLoadSubmitLayer(),delete e.openLayer,delete e.sourceToOpenSubmitLayer,window.location.replace(o_util.fragment.serialize(e)))}},{key:"setTitleContent",value:function(e){this._getSubmitFormElement().querySelector("#cr_reviewTitle").value=e}},{key:"setTextAreaContent",value:function(e){this._getSubmitFormElement().querySelector(o_cr.widgets.TEXTAREA_SELECTOR).value=e}},{key:"setReviewRating",value:function(e){this._getSubmitFormElement().querySelector("#cr_reviewRating").value=e}},{key:"setRecommendProduct",value:function(e){e?(this._getSubmitFormElement().querySelector("#recommended_0").checked=!0,this._getSubmitFormElement().querySelector("#recommended_1").checked=!1):(this._getSubmitFormElement().querySelector("#recommended_0").checked=!1,this._getSubmitFormElement().querySelector("#recommended_1").checked=!0)}},{key:"setAnonymousReview",value:function(e){e?(this._getSubmitFormElement().querySelector("#name_0").checked=!1,this._getSubmitFormElement().querySelector("#name_1").checked=!0):(this._getSubmitFormElement().querySelector("#name_0").checked=!0,this._getSubmitFormElement().querySelector("#name_1").checked=!1)}},{key:"_trackLayerClosing",value:function(){this._dataSubmitted||this._trackEvent({review_CustomerReviewWrite:"close"})}},{key:"_getSubmitFormElement",value:function(){return document.getElementById("js_cr_reviewSubmitForm")}},{key:"_openMessageLayer",value:function(e,t){o_cr.util.PaliLayer.openPaliLayer({modal:!0,width:"768px",createTrackingContext:!1,layerClass:"js_prd_reviewSubmitLayer p_layer",content:'<div data-title="'.concat(e,'"><div class="p_message p_message--hint">').concat(t,"</div></div>")})}},{key:"_submitHandlerCustomerReview",value:function(e,t,r){t.setAttribute("data-replaceWithSpinner","true");e=i._extractFormInput(e),e=i._prepareReviewData(e,r);this._postCustomerReview(e,r)}},{key:"_postCustomerReview",value:function(t,e){var r=this;this._dataSubmitted=!0;e={method:"POST",url:"/product-customerreview/reviews/currentUser",data:JSON.stringify(t),headers:{"Content-Type":"application/vnd.otto.product.review+json",Accept:"application/vnd.otto.product.review+json","X-Form-Checksum":e.checkSum}};o_util.ajax(e,function(e){201===e.status?(r._trackEvent({review_CustomerReviewWrite:"send",review_CustomerReviewSuccess:"true",review_CustomerReviewStars:t.rating,review_CustomerReviewTextLength:t.text.length,review_CustomerReviewRecommendation:t.recommended}),r._submitLayer.setContent('<div><div class="p_layer__headline">Deine Bewertung für diesen Artikel</div><div class="p_layer__body"><div class="p_message p_message--success"><b>Vielen Dank.</b> Deine Bewertung wird in Kürze angezeigt.</div></div></div>',"qs_submitResult initial")):(r._trackEvent({review_CustomerReviewWrite:"send",review_CustomerReviewSuccess:"false",review_CustomerReviewStars:t.rating,review_CustomerReviewTextLength:t.text.length,review_CustomerReviewRecommendation:t.recommended}),r._submitLayer.setContent('<div><div class="p_layer__headline">Deine Bewertung für diesen Artikel</div><div class="p_layer__body"><div class="p_message p_message--error"><strong>Hinweis</strong><br/> Es gab einen Fehler bei der Abgabe deiner Bewertung.<br />Bitte versuche es später erneut.</div></div></div>',"qs_submitResult error")),r._submitLayer.resetViewport()})}},{key:"_showErrorsHandler",value:function(e,t){for(var r=e.querySelector(".js-review-errorContainer-list");r.firstChild;)r.removeChild(r.firstChild);t.forEach(function(e){var t=document.createElement("li");t.textContent=e.message,r.appendChild(t)}),e.style.display="flex",o_util.animation.scrollTo(e,500)}},{key:"_trackValidationError",value:function(e){this._trackEvent({review_CustomerReviewWrite:"error",review_ErrorUserCustomerReview:e.map(function(e){return e.name}).join("|")})}},{key:"_trackInAllEvents",value:function(){return{ot_PageCluster:"Kundenbewertungsseite",product_VariationId:this._variationId,review_Source:this._sourceToOpenSubmitLayer,review_VariationCount:this._orderPositionCount}}},{key:"_trackEvent",value:function(e){e=o_util.core.extend(e,this._trackInAllEvents()),e=o_cr.util.StringUtil.slugifyDataContainer(e,o_cr.widgets.keysNotToBeSlugified);o_global.eventQBus.emit("tracking.bct.submitEvent",e)}},{key:"_reviewStars",value:function(e){var a="star-filled",o="star-empty",s="js-selected",c=".js-star";function l(e){return[].slice.call(e.parentNode.children).indexOf(e)}function u(e,r,i,n){e.forEach(function(e,t){t<=r?(e.classList.add(a),e.classList.remove(o)):(e.classList.remove(a,s),e.classList.add(o)),t===r?i.textContent=e.getAttribute("data-message"):-1===r&&(i.textContent=n)})}e=e.getElementsByClassName("js-starSelection");[].forEach.call(e,function(e){var r=[].slice.call(e.querySelectorAll(c)),i=e.querySelector(".js-message"),t=i.textContent,n=e.querySelector(".js-review-rating"),a=-1;o_util.event.delegate(e,"mouseover",c,function(e){e=l(e.target);u(r,e,i)}),o_util.event.delegate(e,"click",c,function(e){var t=e.target,e=l(t);a=l(t),u(r,e,i),t.classList.add(s),n.value=a+1}),o_util.event.delegate(e,"mouseout",c,function(){u(r,a,i,t)})})}},{key:"_checkPreconditionsAndLoadSubmitLayer",value:function(){var t=this,e="/product-customerreview/reviews/getUserDataForReviewSubmitLayer/".concat(this._productId);o_util.ajax({method:"GET",url:e},function(e){switch(e.status){case 200:t._formData=JSON.parse(e.responseText),t._openReviewFormLayer();break;case 401:window.location="/product-customerreview/redirect/login/".concat(t._variationId,"?sourceToOpenSubmitLayer=").concat(t._sourceToOpenSubmitLayer);break;case 412:t._trackEvent({review_CustomerReviewWrite:"open",review_CustomerReviewAdvice:"double_review"}),t._openMessageLayer("Deine Bewertung für diesen Artikel","<b>Lieber Kunde,</b> dieser Artikel wurde bereits von dir bewertet.");break;case 423:t._openMessageLayer("Wartungsarbeiten","Es ist unser Ziel otto.de kontinuierlich für dich zu verbessern. Wegen Wartungsarbeiten können daher aktuell leider keine Kundenbewertungen abgegeben werden.<br><br>Die Funktion wird dir zeitnah wieder zur Verfügung stehen. Bitte versuche es später noch einmal.<br><br>Vielen Dank für dein Verständnis.");break;case 424:t._trackEvent({review_CustomerReviewWrite:"open",review_CustomerReviewAdvice:"not_verified"}),t._openMessageLayer("Deine Bewertung für diesen Artikel","<b>Lieber Kunde,</b> du kannst den Artikel leider erst bewerten, wenn du diesen bestellt und erhalten hast.")}})}},{key:"_openReviewFormLayer",value:function(){var e=this;this._orderPositionCount=this._formData&&this._formData.orderPositions?this._formData.orderPositions.length:0;var t=o_cr.model.ReviewFormModel.buildFormModel(this._variationId,this._sourceToOpenSubmitLayer,this._formData),t=o_cr.util.MustacheRenderer.render("tmplReviewFormLayer",t);this._submitLayer=o_cr.util.PaliLayer.openPaliLayer({modal:!0,width:"768px",height:"800px",layerClass:"".concat(o_cr.widgets.CLASS_DIALOG_REVIEWS," ").concat(o_cr.widgets.JS_CLASS_DIALOG_REVIEWS," p_layer"),closeCallback:function(){return e._trackLayerClosing()},content:t}),this._initializeReviewForm(),window.o_global.eventQBus.emit("assets.formular.counter",".reviewContent")}},{key:"_initializeReviewForm",value:function(){var t,i=this,n=this._getSubmitFormElement();null!==n&&(this._reviewStars(n),n.addEventListener("submit",function(e){var t=i._validateAllRequired(),r=n.querySelector("#cr_reviewErrorContainer");e.preventDefault(),0<t.length?(i._showErrorsHandler(r,t),i._trackValidationError(t)):(r.style.display="none",t=o_cr.model.ReviewFormModel.selectOrderPosition(i._variationId,i._sourceToOpenSubmitLayer,i._formData.orderPositions),r=n.querySelector("[type=submit]"),i._submitHandlerCustomerReview(n,r,t))},!1),(t=n.querySelector(".cr_reviewImage img")).addEventListener("error",function e(){t.removeEventListener("error",e),t.setAttribute("src",t.getAttribute("data-product-image-fallback-url")),t.setAttribute("alt",t.getAttribute("data-fallback-text")||"Kein Bild vorhanden")}),this._trackEvent({review_CustomerReviewWrite:"open"}))}},{key:"_validateAllRequired",value:function(){var e=this._getSubmitFormElement(),t=[];return this._validateReviewStars(e,t),this._validateReviewText(e,t),t}},{key:"_validateReviewText",value:function(e,t){var r=e.querySelector('[data-qa="cr_review-rating-title"]'),e=e.querySelector("#cr_reviewText");e.value.trim().length<50?(e.parentNode.classList.add("pl_textarea--invalid"),r.classList.add("cr_review__stars--error"),t.push({message:e.getAttribute("data-required-message"),name:e.name})):r.classList.remove("cr_review__stars--error")}},{key:"_validateReviewStars",value:function(e,t){var r=e.querySelector("#cr_reviewRating"),i=e.querySelector('[data-qa="cr_review-rating-label"]'),e=e.querySelector('[data-qa="cr_review-rating-message"]');""===r.value?(i.classList.add("cr_review__stars--error"),e.classList.add("cr_review__stars--error"),t.push({message:r.getAttribute("data-required-message"),name:r.name})):(i.classList.remove("cr_review__stars--error"),e.classList.remove("cr_review__stars--error"))}}],[{key:"_extractFormInput",value:function(e){var t=e.querySelector('input[name="recommended"]:checked');return{customerIsAnonymous:e.querySelector('input[name="anonymous"]:checked').value,rating:e.querySelector("[name=rating]").value,text:e.querySelector("[name=text]").value,title:i._createTitleFromTextIfNoneIsGivenByUser(e),recommended:t?t.value:void 0}}},{key:"_prepareReviewData",value:function(e,t){var r=t.product,i=t.partner;return{productId:r&&r.id,productName:r&&r.name,variationId:r&&r.variationId,articleNumber:r&&r.articleNumber,moin:r&&r.moin,dimensions:r&&r.dimensions,partnerId:i&&i.id,partnerName:i&&i.name,fulfillmentStatus:t.fulfillmentStatus,customerIsAnonymous:e.customerIsAnonymous,rating:e.rating,title:e.title,text:e.text,recommended:e.recommended}}},{key:"_createTitleFromTextIfNoneIsGivenByUser",value:function(e){var t=e.querySelector("[name=title]").value;return t=0===t.length?o_cr.util.StringUtil.abbreviateString(e.querySelector("[name=text]").value,45," ..."):t}}]),i}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.ReviewLoader=function(){function r(e){_classCallCheck(this,r),this._reviewEndpoint="/product-customerreview/reviews/presentation/product",this._BIReviewEndpoint="/product-customerreview/reviews/presentation/product/bi",this._loaderElement=e,this._config={biReviewSearchParams:{aspect:o_cr.aspect},reviewSearchParams:{filter:o_cr.filter,sortingRank:o_cr.sortingRank},sharedSearchParams:{limit:o_cr.renderedReviewsMax-o_cr.renderedReviewsInitial,offset:(o_cr.page-1)*o_cr.renderedReviewsMax+o_cr.renderedReviewsInitial},isBIReview:!!o_cr.aspect,productId:o_cr.productId,endpoint:o_cr.aspect?this._BIReviewEndpoint:this._reviewEndpoint}}return _createClass(r,[{key:"_constructRequestUrl",value:function(){var e="".concat(this._config.endpoint,"/").concat(this._config.productId),t=this._config.isBIReview?this._config.biReviewSearchParams:this._config.reviewSearchParams,t=o_util.core.extend(JSON.parse(JSON.stringify(this._config.sharedSearchParams)),t);return r._addRequestParamsToUrl(e,t)}},{key:"_convertReviews",value:function(e){var t=null;return t=e&&e.items?this._config.isBIReview?o_cr.data.ProductReviewsToReviewsModelConverter.convertBIReviews(e.items,this._config.productId,window.localStorage):o_cr.data.ProductReviewsToReviewsModelConverter.convert(e.items,this._config.productId,window.localStorage):t}},{key:"loadMore",value:function(){var a=this;return this._loaderElement&&this._loaderElement.classList.remove("hide"),new Promise(function(i,n){var e=a._constructRequestUrl();o_util.ajax.get(e).then(function(e){try{var t,r;200===e.status?(t=e.response?JSON.parse(e.response):null,null!==(r=a._convertReviews(t))&&i({isBIReview:a._config.isBIReview,total:t.total,reviews:r})):n(new Error("Error calling endpoint: ".concat(a._config.endpoint,", responseStatus: ").concat(e.status,", responseData: ").concat(e.response)))}catch(e){n(e)}finally{a._loaderElement&&a._loaderElement.classList.add("hide")}})})}}],[{key:"_addRequestParamsToUrl",value:function(e,t){var r=[],e=e;return Object.keys(t).forEach(function(e){t[e]&&r.push("".concat(e,"=").concat(t[e]))}),0<r.length&&(e+="?".concat(r.join("&"))),e}}]),r}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.ScrollInteraction=function(){function i(e,t,r){_classCallCheck(this,i),this._rootElement=e,this._reviewLoader=t,this._paging=r,this._scrollEventThrottle=null,this._scrollEventHandler=null,this._config={page:o_cr.page,initialReviewsCount:o_cr.renderedReviewsInitial,maxReviewsCount:o_cr.renderedReviewsMax,totalReviewsCount:o_cr.numberOfReviews},this._featureManager=new o_cr.util.ToggleService,this._onexInfoService=new o_cr.util.OnexInfoService}return _createClass(i,[{key:"init",value:function(){(this._config.page-1)*this._config.maxReviewsCount+this._config.initialReviewsCount<this._config.totalReviewsCount&&(this._scrollEventHandler=this._onScroll.bind(this),window.addEventListener("scroll",this._scrollEventHandler,!1))}},{key:"_renderTemplate",value:function(e){var t=this,r=e.isBIReview?"tmplReviewBI":"tmplReview",i=this._rootElement.querySelector(".cr_js_review:last-of-type"),n='<hr class="p_line100 cr_review__line" />';i&&(e.reviews.forEach(function(e){n+=o_cr.util.MustacheRenderer.render(r,{review:e,disableDbWrite:t._featureManager.isEnabled("CONFIG_DISABLE_DB_WRITE")})}),i.insertAdjacentHTML("afterend",n))}},{key:"_reviewsLoadedHandler",value:function(e){this._renderTemplate(e),this._paging.updatePaging(this._config.page,this._config.maxReviewsCount,e.total)}},{key:"_loadMore",value:function(){var e=this._rootElement.querySelector(".cr_js_review:last-of-type"),e=e&&e.getBoundingClientRect?e.getBoundingClientRect().top:null;null!==e&&e<window.innerHeight&&(window.removeEventListener("scroll",this._scrollEventHandler),this._reviewLoader.loadMore().then(this._reviewsLoadedHandler.bind(this),function(e){AS.RUM.sendCustomRequest("o_cr",{eventType:"loadMoreReviews",error:e})}))}},{key:"_onScroll",value:function(){var e=this;this._scrollEventThrottle||(this._scrollEventThrottle=setTimeout(function(){clearTimeout(e._scrollEventThrottle),e._scrollEventThrottle=null,e._loadMore()},200))}}]),i}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.Sorting=function(){function r(e,t){_classCallCheck(this,r),this._rootElement=e,this._webPageLoader=t,this._selectBoxElement=null}return _createClass(r,[{key:"init",value:function(){var t=this;this._selectBoxElement=this._rootElement.getElementsByClassName("cr_sortingForm__select")[0],this._selectBoxElement&&o_util.event.add(this._selectBoxElement,"change",function(e){t._sortingChangeHandler(e)})}},{key:"_sortingChangeHandler",value:function(e){e=e.target;this._webPageLoader.changeSorting(e.value)}}]),r}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.StarHistogram=function(){function r(e,t){_classCallCheck(this,r),this._rootElement=e,this._filterIndicatorElement=this._rootElement.querySelector(".js_cr_filterIndicator"),this._reviewHeadlineAmountElement=this._rootElement.querySelector(".js_cr_reviewHeadline__amount"),this._webPageLoader=t,this._filtered=!1}return _createClass(r,[{key:"_toggleReviewHeadlineAmountElementState",value:function(){this._reviewHeadlineAmountElement.classList.toggle("js_cr_deselectFilter",this._filtered),this._reviewHeadlineAmountElement.classList.toggle("cr_reviewHeadline__amount--clickable",this._filtered)}},{key:"_renderFilterIndicator",value:function(e,t){t="1"===t?"1 Stern":"".concat(t," Sternen"),e=o_cr.util.MustacheRenderer.render("tmplFilterIndicator",{reviewStars:t,reviewsCount:e});this._filterIndicatorElement&&(this._filterIndicatorElement.innerHTML=e)}},{key:"_filterClickHandler",value:function(e){var t=o_util.event.getTarget(e),r=o_util.dom.getParentByClassName(t,"js_cr_histogram__row"),e=r.getAttribute("data-filter"),t=o_util.dom.getParentByClassName(t,"js_cr_histogram__clickTarget").getAttribute("data-target");this._addFilter(r,e),this._webPageLoader.filterByStars("1"===e?"1star":"".concat(e,"stars"),"select",t)}},{key:"_addFilter",value:function(e,t){var r=this._rootElement.querySelector(".cr_histogram__row--selected");this._filtered=!0,r&&o_cr.widgets.StarHistogram._toggleHistogramRowStatus(r),o_cr.isLandingPage&&(o_cr.widgets.StarHistogram._toggleHistogramRowStatus(e),this._renderFilterIndicator(e.getAttribute("data-amount"),t),this._toggleReviewHeadlineAmountElementState())}},{key:"_removeFilter",value:function(){this._filtered=!1,o_cr.widgets.StarHistogram._toggleHistogramRowStatus(this._rootElement.querySelector(".cr_histogram__row--selected")),this._toggleReviewHeadlineAmountElementState(),this._filterIndicatorElement.innerHTML=""}},{key:"_deselectClickHandler",value:function(e){e=o_util.dom.getParentByClassName(o_util.event.getTarget(e),"js_cr_deselectFilter").getAttribute("data-target");this._removeFilter(),this._webPageLoader.filterByStars(null,"deselect",e)}},{key:"init",value:function(){var t=this;this._rootElement.querySelector(".js_cr_histogram")&&o_util.event.delegate(".js_cr_histogram","click",".cr_histogram__row--clickable",function(e){t._filterClickHandler(e)}),o_util.event.delegate("#cr_js_topReviews","click",".js_cr_deselectFilter",function(e){t._deselectClickHandler(e)})}}],[{key:"_toggleHistogramRowStatus",value:function(e){e.classList.toggle("cr_histogram__row--clickable"),e.classList.toggle("cr_histogram__row--selected")}}]),r}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.WebPageLoader=function(){function t(e){_classCallCheck(this,t),this._webPageLoaderTracking=e,this._requestParams={sortingRank:""===o_cr.sortingRank?null:o_cr.sortingRank,filter:o_cr.filter,page:1===o_cr.page?null:o_cr.page,aspect:""===o_cr.aspect?null:o_cr.aspect},this._scrollTarget=null}return _createClass(t,[{key:"_generateRequestParamsFromSortingFilterAndPage",value:function(e){var i=e.length?e.split("&"):[];return Object.entries(this._requestParams).forEach(function(e){var t=_slicedToArray(e,2),r=t[0],e=t[1],t=o_cr.widgets.WebPageLoader._indexOfRequestKeyInArray(r,i);-1===t&&null!=e?i.push("".concat(r,"=").concat(e)):-1!==t&&null!=e?i[t]="".concat(r,"=").concat(e):-1!==t&&null==e&&i.splice(t,1)}),i.length?i.join("&"):null}},{key:"_generateHashFromScrollTarget",value:function(e){if(null===this._scrollTarget)return e;if(!e.length)return"#scrollTarget=".concat(this._scrollTarget);if(-1===e.indexOf("scrollTarget="))return"".concat(e,"&scrollTarget=").concat(this._scrollTarget);for(var t=e.substr(1,e.length).split("&"),r=0;r<t.length;r++)"_scrollTarget"===t[r].split("=")[0]&&(t[r]="scrollTarget=".concat(this._scrollTarget));return"#".concat(t.join("&"))}},{key:"_reload",value:function(){var e=o_cr.widgets.WebPageLoader._getWindowLocation(),t=this._generateRequestParamsFromSortingFilterAndPage(e.search.substr(1,e.search.length)),r=e.origin;o_cr.isLandingPage?r+=e.pathname:r+=o_cr.widgets.WebPageLoader._addLandingPageSuffixToPathName(e.pathname),null!==t&&(r+="?".concat(t)),r+=this._generateHashFromScrollTarget(e.hash),o_cr.widgets.WebPageLoader._setWindowLocation(r)}},{key:"changeReviewPage",value:function(e,t){this._requestParams.page=1===e?null:e,this._scrollTarget="cr_histogram",this._webPageLoaderTracking.trackChangeReviewPage(e,t),this._reload()}},{key:"changeSorting",value:function(e){this._resetFilterOnSortChange(e),this._requestParams.sortingRank="initial"===e?null:e,this._requestParams.page=null,this._scrollTarget="sortingForm",this._webPageLoaderTracking.trackChangeSorting(e),this._reload()}},{key:"_resetFilterOnSortChange",value:function(e){null===this._requestParams.filter||!e||"mostPositive"!==e&&"mostNegative"!==e||(this._requestParams.filter=null,this._webPageLoaderTracking.trackFilterForResetBySort())}},{key:"filterByStars",value:function(e,t,r){this._requestParams.filter=e,this._requestParams.sortingRank=null,this._requestParams.page=null,this._requestParams.aspect=null,this._scrollTarget="cr_histogram",this._webPageLoaderTracking.trackFilterByStars(e,t,r),this._reload()}},{key:"filterByAspect",value:function(e){this._requestParams.filter=null,this._requestParams.sortingRank=null,this._requestParams.page=null,this._requestParams.aspect=e,this._scrollTarget="cr_aspectFilter",null!==e?this._webPageLoaderTracking.trackFilterByAspect(decodeURI(e)):this._webPageLoaderTracking.trackRemoveAspectFilter(),this._reload()}}],[{key:"_setWindowLocation",value:function(e){window.location!==e&&(window.location=e)}},{key:"_getWindowLocation",value:function(){return window.location}},{key:"_indexOfRequestKeyInArray",value:function(e,t){for(var r=-1,i=0;i<t.length;i++)if(t[i].split("=")[0]===e){r=i;break}return r}},{key:"_addLandingPageSuffixToPathName",value:function(e){return e.lastIndexOf("/")===e.length-1&&(e=e.substr(0,e.length-1)),"".concat(e,"-kundenbewertungen/")}}]),t}(),(o_cr=window.o_cr||{}).widgets=o_cr.widgets||{},o_cr.widgets.WebPageLoaderTracking=function(){function t(e){_classCallCheck(this,t),this._rootElement=e,this._trackingData={review_SortReview:""===o_cr.sortingRank?"initial":o_cr.sortingRank,review_FilterReview:null!==o_cr.filter?"select":"initial",review_ReviewPage:o_cr.page},o_cr.filter&&(this._trackingData.review_FilterReviewStars=o_cr.filter.substr(0,1)),this._aspectTracking=new o_cr.widgets.AspectTracking(e)}return _createClass(t,[{key:"_track",value:function(){o_cr.util.Tracking.trackOnNextPI(this._trackingData)}},{key:"trackChangeReviewPage",value:function(e,t){this._trackingData.review_ReviewAction="paging",this._trackingData.review_ReviewPage=e,null!==t&&(this._trackingData.review_ReviewPageJump=t),this._track()}},{key:"trackChangeSorting",value:function(e){this._trackingData.review_ReviewAction="sort",this._trackingData.review_SortReview=e,this._trackingData.review_ReviewPage=1,this._track()}},{key:"trackFilterByStars",value:function(e,t,r){this._trackingData.review_ReviewAction="filter",this._trackingData.review_FilterReview=t,this._trackingData.review_FilterReviewPosition=r,this._trackingData.review_ReviewPage=1,this._trackingData.review_SortReview="initial",null!==e&&(this._trackingData.review_FilterReviewStars=e.substr(0,1)),this._track()}},{key:"trackFilterForResetBySort",value:function(){this._trackingData.review_FilterReview="deselect",this._trackingData.review_FilterReviewPosition="deselectlink",this._trackingData.review_ReviewPage=1}},{key:"trackAspectsView",value:function(){this._aspectTracking.trackAspectsView()}},{key:"trackFilterByAspect",value:function(e){this._aspectTracking.trackFilterByAspect(e)}},{key:"trackRemoveAspectFilter",value:function(){this._trackingData.review_AspectCancel="deselect",this._track()}}]),t}();/*]]>*/
+//# sourceMappingURL=/product-customerreview/js/product-customerreview1.279.5682.min.js.map
+</script>
+
+
+
+
+
+
+<script id="cr_featuresJSON" type="application/json">{"CONFIG_SANITIZE_OPAL_INPUT":"true","CONFIG_SANITIZE_BI_AGGREGATIONS":"true","CONFIG_ENABLE_RESPONSE_TIME_LOGGING":"false","CONFIG_DISABLE_WRITE_CLIENT_TOKEN":"false","FEATURE_1405_CONSIDER_OFFER_PRODUCTS":"true","CONFIG_DISABLE_OTTO_API_MEASUREMENT":"false","FEATURE_1178_ENABLE_REVIEW_FORM_LAYER":"true","BUGFIX_DELETE_OUTDATED_PRODUCTS":"true","CONFIG_DISABLE_CHECKSUM_CHECK":"false","CONFIG_DISABLE_DB_WRITE":"false","FEATURE_214_ENCRYPT_CUSTOMER_DATA_WITH_KMS":"false","CONFIG_DEACTIVATE_SERVICE_EMERGENCY":"false","CONFIG_DISABLE_ACCOUNT_REMOVED_HANDLER":"false"}</script>
+<script id="cr_onexInfoJSON" type="application/json">{}</script>
+
+
+
+
+
+    <script id="cr_trackingInformation" type="application/json">{"review_VerifiedReviews":"1.0"}</script>
+
+
+
+    <script type="text/javascript">
+        /*<![CDATA[*/
+        (function () {
+            window.o_cr = window.o_cr || {};
+            o_cr.version = "1.279.5682";
+            o_cr.isLandingPage = false;
+            o_cr.inlineJS = true;
+            let isNewArch = true;
+
+            o_cr.api = new o_cr.util.Api(new o_cr.widgets.CustomerReviewPageLinks());
+
+            function initializeWidget() {
+                let customerReviewListWidget = new o_cr.widgets.MinimalProductReviewListWidget(document.getElementById('cr_js_topReviews'));
+
+                customerReviewListWidget.init();
+                document.getElementById('cr_js_topReviews')
+                    .setAttribute('data-js-loaded', 'true');
+            }
+
+            /* workaround as long as old architecture is online and in dual-mode */
+            o_global.eventLoader.onLoad(0, function () {
+                if (isNewArch) {
+                    o_global.eventQBus.on('ft5.product-reviews.variationChange', (eventPayload) => {
+                        initializeWidget()
+                        o_cr.api.updateLandingPageHref();
+                    });
+                } else {
+                    initializeWidget();
+                }
+            });
+        })();
+        /*]]>*/
+    </script>
+    <script id="tmplReportReviewLayer" type="x-tmpl-mustache"><h2 class="p_layer__headline">Kundenbewertung melden</h2>
+<div class="p_layer__body cr_reportReviewLayer">
+    <div class="cr_reportReviewLayer__surveyWrapper cr_js_reportReviewLayer__surveyWrapper">
+        <div class="p_message--error p_message cr_reportReviewLayer__error cr_js_reportReviewLayer__error">
+            <b>Bitte gib einen Grund an.</b>
+        </div>
+        <p class="cr_reportReviewLayer__request">
+            Bitte gib einen Grund an, warum du diese Bewertung melden möchtest:
+        </p>
+        <form class="p_form cr_reportReviewLayer__survey">
+            <ul class="cr_reportReviewList">
+                {{#reasons}}
+                <li class="cr_reportReviewList__item">
+                    <input id="cr_reportReviewSurvey__{{label}}" class="p_form__input cr_js_reportReviewList__radio" name="cr_reportReviewSurvey" type="radio" value="{{label}}" />
+                    <label for="cr_reportReviewSurvey__{{label}}" class="p_form__label">{{description}}</label>
+                </li>
+                {{/reasons}}
+            </ul>
+        </form>
+        <span class="cr_reportReviewLayer__disclaimer">
+            Mit Absenden erkennst du die <a class="p_link--1st js_openInPaliLayer" href="/shoppages/kundenbewertung_datenschutz">Datenschutz- und Einsendebedingungen</a> an.
+        </span>
+        <button type="button" class="p_btn100--1st cr_reportReviewLayer__button cr_js_reportReviewLayer__button">
+            Absenden<i>&nbsp;&gt;</i>
+        </button>
+    </div>
+    <div class="cr_reportReviewLayer__successWrapper cr_js_reportReviewLayer__successWrapper">
+        <div class="p_message--success p_message cr_reportReviewLayer__success">
+            <b>Vielen Dank für deine Hilfe!</b> Ein Mitarbeiter wird die von dir gemeldete Kundenbewertung schnellstmöglich prüfen.
+        </div>
+    </div>
+</div>
+</script>
+
+    <script id="tmplReviewFormLayer" type="x-tmpl-mustache">
+<div class="reviewContent pl_m150">
+    <div class="pl_headline100 pl_mb100">Deine Bewertung für diesen Artikel</div>
+    <form id="js_cr_reviewSubmitForm" class="p_form">
+
+        <div class="pl_headline50" data-qa="cr_review-form-layer-product-name">{{ product.name }}</div>
+        <div class="pl_mt150 cr_reviewImageContainer">
+            <div class="cr_reviewImage" data-qa="cr_review-form-layer-product-image">
+                <img src="{{ product.imageUrl }}" data-product-image-fallback-url="{{ product.imageFallbackUrl }}"/>
+            </div>
+            <div class="cr_reviewDimensions pl_pl100">
+                <ul>
+                    {{# product.dimensions }}
+                        <li class="pl_copy100">{{ displayName }}: <b>{{ value }}</b></li>
+                    {{/ product.dimensions }}
+                </ul>
+            </div>
+        </div>
+
+        <div id="cr_reviewErrorContainer" class="pl_mt100 pl_banner pl_banner--error qs_submitResult">
+
+            <span>
+                <ul class="js-review-errorContainer-list"></ul>
+            </span>
+        </div>
+
+
+        <div class="cr_reviewRatingContainer pl_mt175">
+            <span class="pl_headline50">
+                <label for="cr_reviewRating" data-qa="cr_review-rating-label">
+                    <strong>Wie viele Sterne vergibst du?</strong>
+                </label>
+            </span>
+            <div class="js-starSelection pl_mt100">
+                <div class="js-stars">
+                    <span data-message="Sehr schlecht" class="star-empty js-star pl_icon100"></span>
+                    <span data-message="Schlecht" class="star-empty js-star pl_icon100"></span>
+                    <span data-message="Mittelmäßig" class="star-empty js-star pl_icon100"></span>
+                    <span data-message="Gut" class="star-empty js-star pl_icon100"></span>
+                    <span data-message="Sehr gut" class="star-empty js-star pl_icon100"></span>
+                </div>
+                <div class="js-message pl_copy100" data-qa="cr_review-rating-message">Bitte wählen</div>
+                <input
+                    id="cr_reviewRating"
+                    class="js-review-rating"
+                    type="hidden"
+                    name="rating"
+                    data-required-message="Bitte wähle eine Bewertung zwischen 1 und 5 Sternen."
+                    value=""
+                />
+            </div>
+        </div>
+
+        <div class="cr_recommendationContainer pl_mt150">
+            <div class="pl_headline50"><strong>Würdest du diesen Artikel weiterempfehlen?</strong></div>
+            <div class="pl_mt100">
+                <div class="pl_radio pl_mr150 left">
+                    <input class="pl_radio__button" type="radio" id="recommended_0" name="recommended" value="true"/>
+                    <label class="pl_radio__label" for="recommended_0">Ja</label>
+                </div>
+
+                <div class="pl_radio">
+                    <input class="pl_radio__button" type="radio" id="recommended_1" name="recommended" value="false"/>
+                    <label class="pl_radio__label" for="recommended_1">Nein</label>
+                </div>
+            </div>
+        </div>
+
+        <div class="pl_mt150 cr_reviewHeadingContainer">
+            <div class="pl_headline50 pl_mb100">
+                <label for="cr_reviewTitle" data-qa="cr_review-rating-title"><strong>Verfasse deine Bewertung:</strong></label>
+            </div>
+
+            <div class="js-pl_input pl_input">
+                <input
+                    class="pl_input__field js-pl_counter"
+                    id="cr_reviewTitle"
+                    placeholder="Überschrift für deine Bewertung (optional)"
+                    type="text"
+                    extraClass="js-pl_counter"
+                    value=""
+                    maxlength="46"
+                    name="title"
+                />
+
+                <label for="cr_reviewTitle" class="js-pl_label pl_label">
+                    Überschrift für deine Bewertung (optional)
+                </label>
+
+                <small class="pl_input__note">Zum Beispiel: Ein toller Artikel, der Spaß macht!</small>
+            </div>
+        </div>
+
+        <div class="pl_textarea cr_reviewTextContainer" data-qa="cr_review-text-container">
+            <textarea
+                class="pl_textarea__element js-pl_counter"
+                id="cr_reviewText"
+                placeholder="Beschreibe bitte in kurzen Sätzen einige Vor- und Nachteile des Artikels und wie du ihn verwendest."
+                extraClass="js-pl_counter"
+                data-minlength="50"
+                maxlength="4000"
+                name="text"
+                data-required-message="Bitte fülle den Bewertungstext aus."
+                data-minlength-message="Der Bewertungstext sollte mindestens 50 Zeichen lang sein."
+            ></textarea>
+
+            <label class="js-pl_label pl_label" for="cr_reviewText">
+                Deine ausführliche Bewertung
+            </label>
+
+            <small class="pl_textarea__note">
+                Beschreibe bitte in kurzen Sätzen einige Vor-und Nachteile des Artikels und wie du ihn verwendest.
+            </small>
+        </div>
+
+        <a class="js_openInPaliLayer pl_link100--primary" href="/shoppages/kundenbewertung_richtlinien" data-contentclass="richtlinien">Richtlinien für Bewertungen</a>
+
+        <div class="cr_reviewCustomerData pl_mt150" data-qa="cr_review-form-layer-customer-name">
+            <div class="pl_headline50"><strong>Deine Angaben</strong> (werden mit der Bewertung veröffentlicht)</div>
+
+            <div class="pl_radio pl_mt100">
+               <input class="pl_radio__button" checked="checked" type="radio" id="name_0" name="anonymous" value="false"/>
+               <label class="pl_radio__label" for="name_0">{{ user.firstName }} {{ user.lastNameAbbr }}. aus {{user.city}}</label>
+            </div>
+
+            <div class="pl_radio pl_mt75">
+                <input class="pl_radio__button" type="radio" id="name_1" name="anonymous" value="true"/>
+                <label class="pl_radio__label" for="name_1">{{ user.anonymousSalutation }} aus {{ user.city }}</label>
+            </div>
+        </div>
+
+        <div class="pl_copy100 pl_mt175">
+            Mit Absenden erkennst du die
+            <a class="js_openInPaliLayer pl_link100--primary" href="/shoppages/kundenbewertung_datenschutz" data-contentclass="datenschutz">
+                Datenschutz- und Einsendebedingungen
+            </a>
+            an.
+        </div>
+
+        <div class="pl_mt175">
+            <button class="pl_button100--primary" type="submit" data-qa="cr_reviewSubmitButton">
+                <span>Absenden</span>
+            </button>
+        </div>
+    </form>
+</div>
+
+
+</script>
+    <script type="text/javascript">
+    let isNewArch = true;
+    /*<![CDATA[*/
+    (() => {
+        o_global.eventLoader.onLoad(0, function () {
+
+            if (isNewArch) {
+                o_global.eventQBus.on('ft5.product-reviews.variationChange', (eventPayload) => {
+                    const reviewFormLayer = new o_cr.widgets.ReviewFormLayer(document.getElementById('cr_js_topReviews'));
+                    reviewFormLayer.initNewArch(eventPayload);
+                });
+            } else {
+                const reviewFormLayer = new o_cr.widgets.ReviewFormLayer(document.getElementById('cr_js_topReviews'));
+                reviewFormLayer.initOldArch();
+                o_global.eventQBus.emitModuleLoaded('ft5.customerreview.reviewFormLayer');
+            }
+
+        });
+    })();
+    /*]]>*/
+</script>
+
+</section>
+
+</div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/product-reviews-OUZOUNYL.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/expert-reviews-4YIKSPWD.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/expert-reviews-4YIKSPWD.css" crossorigin="anonymous"/></noscript>
+            <div class="pl_block pl_block--transparent pl_block--no-padding pdp_reco-complementary pdp_reco-complementary--e549-active js_pdp_reco-complementary" data-variation-id="682285928"></div>
+
+  <link rel="preload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.3afc4579.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.3afc4579.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.module.46bea43c.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.nomodule.a87b68b8.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+
+<div style="display:none;" id="reco_cinema__toggle-state" data-toggle-state="{&quot;SHOW_DEALS&quot;:true,&quot;CSR&quot;:false,&quot;USE_OPAL_RELATIONSHIPS&quot;:true,&quot;TESLA_COLDSTART&quot;:false,&quot;USE_TESLA_ARTHURDENT&quot;:true,&quot;USE_TESLA_META&quot;:true,&quot;SHOW_DETAILVIEW_ONLY&quot;:false,&quot;DISPLAY_LAST_SEEN_ARTICLES&quot;:true,&quot;USE_TESLA_HITCHHIKER&quot;:true,&quot;WISHLIST_RECO_REDESIGN&quot;:true,&quot;RECO_REDESIGN&quot;:true}">
+</div>
+<script>
+  window.o_reco = window.o_reco || {};
+  window.o_reco.api = window.o_reco.api || {};
+  window.o_reco.private = window.o_reco.private || {};
+  window.o_reco.private.toggleState = JSON.parse(document.getElementById('reco_cinema__toggle-state').dataset.toggleState);
+
+  window.o_reco.private.delegate = function (originalFunction) {
+    return function () {
+      var passedArguments = arguments;
+      return new Promise(function (resolve, reject) {
+        o_global.eventLoader.onAllScriptsExecuted(10, function () {
+          window.o_reco.private[originalFunction].apply(null, passedArguments).then(resolve).catch(reject);
+        });
+      });
+    };
+  };
+
+  window.o_reco.private.delegateAndWrap = function (originalFunction) {
+    return function () {
+      var passedArguments = arguments;
+      return new Promise(function (resolve) {
+        o_global.eventLoader.onAllScriptsExecuted(10, function () {
+          var result = window.o_reco.private[originalFunction].apply(null, passedArguments);
+          resolve(result);
+        });
+      });
+    };
+  };
+
+  window.o_reco.api.initializeCinema = window.o_reco.private.delegateAndWrap('initializeCinema');
+  window.o_reco.api.initializeExpandableCinema = window.o_reco.private.delegateAndWrap('initializeExpandableCinema');
+  window.o_reco.api.loadRecommendationsForDetailView = window.o_reco.private.delegateAndWrap('asyncLoadRecommendationsForDetailView');
+
+  window.o_reco.api.loadRecommendationsForOrderOverview = window.o_reco.private.delegate('loadRecommendationsForOrderOverview');
+  window.o_reco.api.loadRecommendationsForWishlist = window.o_reco.private.delegate('loadRecommendationsForWishlist');
+  window.o_reco.api.loadRecommendationsForEntryPage =
+          window.o_reco.private.toggleState["CSR"] ?
+                  window.o_reco.private.delegateAndWrap('loadRecommendationsForEntryPageCsr') :
+                  window.o_reco.private.delegate('loadRecommendationsForEntryPage');
+  window.o_reco.api.loadBounceLayerCinema = window.o_reco.private.delegateAndWrap('loadBounceLayerCinema');
+
+  o_global.eventQBus.emit("ft6bcn.reco.init", ".reco.cinema.needsInitialization");
+</script>
+
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/reco-complementary-XSERL5VU.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/reco-complementary-AMHOQZBH.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/reco-complementary-AMHOQZBH.css" crossorigin="anonymous"/></noscript>
+            <div class="dcs_link-boxes pl_block">
+    <div class="nav_link-boxes"><h2 class="nav-linkbox-headline pl_headline100">Mehr entdecken</h2><div class="nav-brand-different"><h3 class="pl_headline50">Backöfen anderer Marken</h3><ul class="nav-link-list"><li class="nav-separable-link"><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/einbaubackoefen/?marke=siemens" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_other_brands&quot;}">Siemens Einbaubacköfen</a></li><li class="nav-separable-link"><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/einbaubackoefen/?marke=neff" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_other_brands&quot;}">Neff Einbaubacköfen</a></li><li class="nav-separable-link"><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/einbaubackoefen/?marke=aeg" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_other_brands&quot;}">AEG Einbaubacköfen</a></li><li class="nav-separable-link"><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/einbaubackoefen/?marke=beko" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_other_brands&quot;}">Beko Einbaubacköfen</a></li><li class="nav-separable-link"><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/einbaubackoefen/?marke=miele" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_other_brands&quot;}">Miele Einbaubacköfen</a></li><li class="nav-separable-link"><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/pyrolyse-backoefen/?marke=aeg" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_other_brands&quot;}">AEG Pyrolyse-Backöfen</a></li></ul></div><div class="nav-brand-all"><h3 class="pl_headline50">Ähnliche Kategorien</h3><ul class="nav-link-list"><li><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/einbaubackoefen/" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Einbaubacköfen</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/backofen-sets/" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Backofen-Sets</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/minibackoefen/" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Mini-Backöfen</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/backofen-sets/?reduziert" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Günstige Backofen-Sets</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/pyrolyse-backoefen/" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Pyrolyse-Backöfen</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/backoefen-mit-mikrowelle/" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Backöfen mit Mikrowelle</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/einbaubackoefen/?reduziert" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Günstige Einbaubacköfen</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/?thema=einbaugeraete" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Einbaugeräte</a></li></ul><ul class="nav-link-list-right"><li><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/einbaubackoefen/?ausstattung=teleskopauszug" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Teleskopauszug Einbaubacköfen</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/pizzaoefen/" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Pizzaöfen</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/einbaubackoefen/?farbe=schwarz" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Schwarzer Einbaubackofen</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/minibackoefen/?reduziert" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Günstige Mini-Backöfen</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/minibackoefen/?black-friday" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Black Friday Mini-Backöfen</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/pyrolyse-backoefen/?reduziert" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Günstige Pyrolyse-Backöfen</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/backofen-sets/?black-friday" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Black Friday Backofen-Sets</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/backoefen/backofen-sets/?farbe=schwarz" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Schwarze Backofen-Sets</a></li></ul></div><div class="nav-static"><link rel="preload" href="/nav-tyson/static/compiled/nav.tyson.link_boxes.be992ea6.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous" /><link rel="stylesheet" href="/nav-tyson/static/compiled/nav.tyson.link_boxes.be992ea6.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous" /></div></div>
+</div>
+        </div>
+    </div>
+</div>
+    <div class="pdp_sustainability-sheet js_pdp_sustainability-sheet" style="display: none;">
+        <div class="js_pdp_sustainability-sheet-inner">
+            <div class="pdp_sustainability-sheet__intro pl_copy100">
+                Dieser Artikel ist mit folgenden Nachhaltigkeitssiegeln ausgezeichnet:
+            </div>
+                <div class="pdp_sustainability-sheet__label pl_copy100 pl_mt150">
+                    <figure class="pdp_sustainability-sheet__label-figure">
+                        <img class="pdp_sustainability-sheet__label-image" src="https://i.otto.de/i/otto/energieverbrauchskennzeichnung_teat" alt="Energieeffizientes Gerät">
+                        <figcaption class="pdp_sustainability-sheet__label-name pl_headline100 pl_pl100">Energieeffizientes Gerät
+                        </figcaption>
+                    </figure>
+                    <div class="pdp_sustainability-sheet__label-description pl_mt100">
+                        Energieeffiziente Haushalts- und TV-Geräte spielen für den Klimaschutz eine wichtige Rolle: Je besser die Effizienz, desto mehr Strom wird gespart. Dieses Gerät ist also energiesparend und daher umweltfreundlich.
+
+Seit dem 01.03.21 gibt es ein neues EU-Energielabel (Skala A-G), das schrittweise eingeführt wird und effiziente Geräte, wie bspw. Waschmaschinen und Kühlschränke kennzeichnet. Backöfen, Trockner und Dunstabzugshauben werden noch mit dem alten EU-Energielabel, das in der Regel die Skala A+++ bis D umfasst, gekennzeichnet.
+                    </div>
+                        <div class="pdp_sustainability-sheet__category pl_copy75 pl_mt100">
+                            <svg class="pdp_sustainability-sheet__category-icon pl_icon" role="img">
+                                <use xlink:href="/assets-static/icons/pl_icon_sustainable-energy-efficient.svg#pl_icon_sustainable-energy-efficient"/>
+                            </svg>
+                            <span class="pdp_sustainability-sheet__category-description pl_pl100">Energieeffiziente Nutzung</span>
+                        </div>
+                </div>
+        </div>
+    </div>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/sustainability-sheet-ZR5KKX5J.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/sustainability-sheet-N2GLLQR4.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/sustainability-sheet-N2GLLQR4.css" crossorigin="anonymous"/></noscript>
+<div class="js_pdp_ui-aggregator" data-variation-id="682285928" hidden></div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/ui-aggregator-ENRGMEEM.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<div id="dcs_tracking-data" data-ft5-view-tracking='{ "product_VariationId":"682285928" }' data-variation-id="682285928" class="js_pdp_tracking_component"></div>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/tracking-AX4AOIET.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/pdp-frame-RV7ZNNUH.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/pdp-frame-RV7ZNNUH.css" crossorigin="anonymous"/></noscript></div>
+
+<div class="js_tracking" data-track="true"></div>
+<script id="productDataJson" type="application/json">
+        {"id":"682285688","offerId":null,"brand":"Privileg Family Edition","brandImageId":"b41aa7c26700144ac38f0ccee5baead9","variations":{"682285928":{"id":"682285928","name":"Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie","productId":"682285688","links":null,"images":[{"id":"19651738","width":2480,"height":3543,"mainImage":true,"initializeImage":true,"selected":true,"number":1,"index":0},{"id":"19651739","width":2752,"height":3543,"mainImage":false,"initializeImage":false,"selected":false,"number":2,"index":1},{"id":"19651740","width":3543,"height":3389,"mainImage":false,"initializeImage":false,"selected":false,"number":3,"index":2},{"id":"19651741","width":3523,"height":3543,"mainImage":false,"initializeImage":false,"selected":false,"number":4,"index":3},{"id":"19651742","width":3543,"height":540,"mainImage":false,"initializeImage":false,"selected":false,"number":5,"index":4},{"id":"18463778","width":1770,"height":1743,"mainImage":false,"initializeImage":false,"selected":false,"number":6,"index":5},{"id":"32530018","width":3543,"height":2817,"mainImage":false,"initializeImage":false,"selected":false,"number":7,"index":6},{"id":"32530357","width":3543,"height":2783,"mainImage":false,"initializeImage":false,"selected":false,"number":8,"index":7},{"id":"25218326","width":2131,"height":1136,"mainImage":false,"initializeImage":false,"selected":false,"number":9,"index":8}],"availability":{"limitation":null,"limited":false,"orderable":true,"buyable":true,"status":"available","displayName":"lieferbar - in 5-6 Werktagen bei dir","displayNameNotOrderable":"bald zurück - voraussichtlich verfügbar in 5-7 Werktagen","avgDeliveryTime":"6.0","minDeliveryTime":"5.0","maxDeliveryTime":"7.0","avgDeliveryTimeRegionalDiff":null,"showCoronaDeliveryDelayInfo":false},"businessModel":"OTTO","deliveryInfo":{"shippingFlags":["SPEDITION"],"nextPossibleDeliveryDate":"Mittwoch bei Bestellung bis 13 Uhr"},"dimensions":{"dimension":[]},"articleNumber":"64649515","promotionNumber":"30","skuSuffix":null,"retailer":{"id":"0","name":"OTTO","isOtto":true},"patternSample":null,"customDimensions":{"dimension":[]},"customMeasureType":null,"assortmentCode":"289","articleNumberWithPromotion":"6464951530","description":null,"htmlCharacteristics":null,"sellingPoints":{"sellingPoint":["Energieeffizienzklasse A+ (A+++ bis D)","8 Beheizungsarten","Pyrolyse-Selbstreinigung","Inkl. 2-fach Teleskopauszug","Turn&Go - über 100 Rezepte mit nur einem Dreh"]},"sale":true,"businessCategory":{"value":"HAUSHALTSELEKTRO","group":"ELECTRONIC_DIGITAL"},"companyId":0,"mainImageRelativeHeight":143,"seoImageUrlCurrent":"https:#ft5_slash##ft5_slash#i.otto.de#ft5_slash#i#ft5_slash#otto#ft5_slash#19651738#ft5_slash#privileg-family-edition-pyrolyse-backofen-pbwr6-op8v2-in-mit-2-fach-teleskopauszug-pyrolyse-selbstreinigung-50-monate-herstellergarantie.jpg?$formatz$","energyEfficiency":{"base64DataSheetUrl":"aHR0cHM6Ly9kLm90dG8uZGUvZmlsZXMvNTgzNTE3MWMtYjg3NS01YjI1LTkyMTAtNWU4YjQ5M2M4MjU3LnBkZg==","showNewEnergyLabelInfoLayer":false,"energyEfficiencyClasses":[{"category":null,"component":null,"slugifiedComponent":null,"energyLabel":{"color":"lightGreen","letter":"A","plus":"+"},"scaleUniform":false,"colorHexcode":null,"encodedDocumentUrl":null,"images":null,"imageList":["https:#ft5_slash##ft5_slash#i.otto.de#ft5_slash#i#ft5_slash#otto#ft5_slash#25218324"]}]},"energyEfficiencyClass":null,"downloadableDocuments":[{"dataUrl":"https:#ft5_slash##ft5_slash#d.otto.de#ft5_slash#files#ft5_slash#25218135.pdf","displayName":"Bedienungsanleitung","type":"BEDIENUNGSANLEITUNG"}],"displayPrice":{"comparativePriceAdvantage":"73","hasSuggestedRetailPrice":true,"comparativePriceAmount":"1.219,00","priceAmount":33300,"formattedPriceAmount":"333,00","techPriceAmount":"333.00","priceDifferenceToFirstVariation":null,"customMeasureType":null,"normPrice":null,"installments":{"amount":"16,00","count":24},"hasMoreExpensiveAvailableVariation":false},"expertReviews":null,"detailIcons":{"cut":[],"care":[],"quality":[]},"consultingDetails":[{"displayName":"Entsorgungshinweis","name":"DISPOSAL_NOTE","contentUrl":"#ft5_slash#shoppages#ft5_slash#consultingdetail_disposal_note"}],"deal":{"name":"Unser Tipp!_Haushalt","contentUrl":"#ft5_slash#shoppages#ft5_slash#contentelements#ft5_slash#5a057af218883900016454c6?asLayerBody=true","iconUrl":"https:#ft5_slash##ft5_slash#i.otto.de#ft5_slash#i#ft5_slash#otto#ft5_slash#001_2021_unser-tipp_flag","highlight":"nur diesen Monat"},"ean":"8003437938573","moin":"M00MX200QU","cashback":null,"manufacturerContent":{"provider":"LOADBEE","id":"8003437938573"},"score":null,"richContentUrl":"#ft5_slash#product-richcontent#ft5_slash#loadbee_8003437938573.html","sustainable":true,"sustainability":{"categories":{"ENERGIEEFFIZIENTE_NUTZUNG":true},"detailsUrl":"#ft5_slash#product#ft5_slash#sustainability#ft5_slash#layerContent?labels=%5B%7B%22id%22%3A%22ENERGIEEFFIZIENTES_GERAET%22%7D%5D","encodedStatementUrl":"L3Nob3BwYWdlcy9uYWNoaGFsdGlna2VpdA=="},"benefits":null,"hazmat":false,"title":"Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie online kaufen | OTTO","dimensionCount":0}},"sortedVariationIds":["682285928"],"distinctDimensions":[],"htmlCharacteristics":"<table class=\"dv_characteristicsTable\"><caption>Top-Feature<#ft5_slash#caption><tr><td class=\"left\"><span>Top-Features<#ft5_slash#span><#ft5_slash#td><td>Teleskopauszüge<br #ft5_slash#>Bedienung über Knebel<br #ft5_slash#>versenkbare Knebel<br #ft5_slash#>Turn&amp;Go: Profitieren Sie von der Turn&amp;Go-Funktion, die Ihnen den Alltag leichter macht. Mit nur einem Dreh sind über 100 Gerichte in nur einer Stunde fertig. Die praktische Turn&amp;Go Rezepte-App ist ab sofort im App-Store erhältlich.<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Reinigungs-Funktion<#ft5_slash#span><#ft5_slash#td><td>Pyrolyse-Selbstreinigung: Dieser Backofen ist mit dem Pyroluxe®Plus Selbstreinigungssystem ausgestattet,das für Sauberkeit sorgt,die den höchsten professionellen Ansprüchen entspricht. Es erhitzt Ihren Backofen auf 500 °C und lässt dabei alle Speisereste zu Asche zerfallen,die nach dem Abkühlen einfach mit einem feuchten Tuch ausgewischt werden kann. Chemische Reinigungsmittel sind überflüssig.<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table> <table class=\"dv_characteristicsTable\"><caption>Produktdetails<#ft5_slash#caption><tr><td class=\"left\"><span>Farbe<#ft5_slash#span><#ft5_slash#td><td>edelstahlfarben<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table> <table class=\"dv_characteristicsTable\"><caption>Leistung &amp; Verbrauch<#ft5_slash#caption><tr><td class=\"left\"><span>Modellbezeichnung<#ft5_slash#span><#ft5_slash#td><td>PBWR6 OP8V2 IN<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Energieeffizienzklasse (Skala)<#ft5_slash#span><#ft5_slash#td><td>A&#43; (A&#43;&#43;&#43; bis D)<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Energieverbrauch konventioneller Betrieb in kWh<#ft5_slash#span><#ft5_slash#td><td>0,89 kWh<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Energieverbrauch Heißluft oder Umluft in kWh<#ft5_slash#span><#ft5_slash#td><td>0,69 kWh<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Anzahl Garräume<#ft5_slash#span><#ft5_slash#td><td>1<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Wärmequelle pro Garraum<#ft5_slash#span><#ft5_slash#td><td>elektrisch<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Backofenvolumen je Garraum<#ft5_slash#span><#ft5_slash#td><td>71 l<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table> <table class=\"dv_characteristicsTable\"><caption>Ausstattung &amp; Funktionen<#ft5_slash#caption><tr><td class=\"left\"><span>Standard Beheizungsarten<#ft5_slash#span><#ft5_slash#td><td>Ober- und Unterhitze<br #ft5_slash#>Grill<br #ft5_slash#>Heißluft<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Zusätzliche Beheizungsarten<#ft5_slash#span><#ft5_slash#td><td>Pizzastufe<br #ft5_slash#>Heißluft-Eco<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Bedienelemente<#ft5_slash#span><#ft5_slash#td><td>Drehknöpfe<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Drehknöpfe<#ft5_slash#span><#ft5_slash#td><td>versenkbar<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Display<#ft5_slash#span><#ft5_slash#td><td>Uhr<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Auszugssystem<#ft5_slash#span><#ft5_slash#td><td>2-fach-Teleskopauszug<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Art Tür<#ft5_slash#span><#ft5_slash#td><td>Glastür<br #ft5_slash#>3-fach-Verglasung<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Selbstreinigung<#ft5_slash#span><#ft5_slash#td><td>Pyrolyse-Selbstreinigung<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Mitgeliefertes Zubehör<#ft5_slash#span><#ft5_slash#td><td>1 Backblech emailliert<br #ft5_slash#>1 Grillrost<br #ft5_slash#>1 Fettpfanne<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table> <table class=\"dv_characteristicsTable\"><caption>Maße &amp; Gewicht<#ft5_slash#caption><tr><td class=\"left\"><span>Höhe<#ft5_slash#span><#ft5_slash#td><td>59,5 cm<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Breite<#ft5_slash#span><#ft5_slash#td><td>59,5 cm<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Tiefe<#ft5_slash#span><#ft5_slash#td><td>55,1 cm<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Nischenhöhe minimal<#ft5_slash#span><#ft5_slash#td><td>60 cm<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Nischenbreite minimal<#ft5_slash#span><#ft5_slash#td><td>56 cm<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Nischentiefe<#ft5_slash#span><#ft5_slash#td><td>56 cm<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table> <table class=\"dv_characteristicsTable\"><caption>Technische Daten<#ft5_slash#caption><tr><td class=\"left\"><span>Spannung<#ft5_slash#span><#ft5_slash#td><td>220-240 V<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Absicherung<#ft5_slash#span><#ft5_slash#td><td>16 A<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Anschlusswert<#ft5_slash#span><#ft5_slash#td><td>3,3 kW<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table>","description":null,"variationTree":null,"gratisInformationValue":"50 Monate Herstellergarantie","hasOptions":true}
+</script>
+
+<script id="productSettings" type="application/json">
+    {"CONFIG_ENABLE_MANUFACTURER_CONTENT":"true","FEATURE_1236_ONLINE_ADVICE_ONEX":"true","FEATURE_INCLUDE_JSON_LD":"true","FEATURE_1178_CR_RENDERS_REVIEW_FORM":"true","CONFIG_PRODUCT_COMPARISON":"true","FEATURE_WISHLIST_VIA_API":"true","FEATURE_1165_VERIFIED_PURCHASE":"true","FEATURE_1186_SHOW_RED_PRICE_ON_ACTIVE_BENEFIT":"true","FEATURE_NEW_SPONSORED_PRODUCTS_ENDPOINT":"true","FEATURE_NEW_PDP_FRAME":"true","FEATURE_1340_ENABLE_SHARING_ON_ALL_DEVICES":"true","FEATURE_747_PBKBASED_TABLESIZE":"true","FEATURE_934_ADD_LINK_TO_SUSTAINABLE_BADGE":"true","ONEX_USE_CHALLENGER_SCORE_RANKING":"true","FEATURE_1395_SEND_BENEFIT_SLOTS_COMPLETE_EVENT":"true","CONFIG_SHOW_VIDEOS_LINK":"true","FEATURE_1119_SHOW_NEW_EEK_LABEL_LAYER":"true","FEATURE_1311_ENABLE_ONEX_E497_SHOW_CO2_NEUTRAL_SHIPPING":"true","FEATURE_1447_OTTO_UP_REDIRECT":"true"}
+</script>
+
+<script id="js_prd_imageConfig" type="application/json">
+    {"imageServerPath":"https:\/\/i.otto.de\/i\/otto\/","presets":{"brandLogoRetina":"?$ov_brandlogo_retina$","colorDimension":"?$articlecolorthumbsmall$","patternSampleStoff":"?$stanze_stoff$","patternSampleLeder":"?$stanze_leder$","mainImage":{"S":"?h=900&w=1200&qlt=40&fmt.options=interlaced&unsharp=0,1,0.6,7&sm=clamp","XL":"?h=520&w=551&sm=clamp","L":"?h=520&w=481&sm=clamp","M":"?h=1200&w=1800&qlt=40&fmt.options=interlaced&unsharp=0,1,0.6,7&sm=clamp"},"thumbnail":"?$001PICT36$","patternSampleHolz":"?$stanze_holz$","mainImageReviewSubmit":"?$001PICT31$","mainImageMiniDetailView":"?$001PICT30$","productDetails":"?$ov_quality_details_retina$","brandLogo":"?$ov_brandlogo$","soldOut":"?$001PICT25$"},"fallbackImageId":"lh_platzhalter_ohne_abbildung"}
+</script>
+
+    <script id="productStaticAssetUrls" type="application/json">
+{"reviewSubmitLayerUnverified":{"js":"/product/static/assets/ft5.detailview.reviewSubmitLayerUnverified.cc2739b1.js"},"body":{"js":"/product/static/assets/ft5.detailview.body.f1427b2e.js"},"head":{"css":"/product/static/assets/ft5.detailview.head.6b642614.css"},"order":{"css":"/product/static/assets/ft5.detailview.order.89635da4.css","js":"/product/static/assets/ft5.detailview.order.a6239390.js"},"installmentsCalculator":{"css":"/product/static/assets/ft5.detailview.installmentsCalculator.370e8860.css"},"photoswipe":{"js":"/product/static/assets/ft5.detailview.photoswipe.ddc8d4bc.js"},"dummy":{"css":"/product/static/assets/ft5.detailview.dummy.3dd5d4e0.css"},"submitReview":{"css":"/product/static/assets/ft5.detailview.submitReview.5040ecb0.css"},"reviewSubmitLayer":{"js":"/product/static/assets/ft5.detailview.reviewSubmitLayer.adfef318.js"}}    </script>
+                    <div class="clear"></div>
+                </div>
+                <div class="clear"></div>
+                <footer class="prd_footer">
+                    <link href="/shoppages/static/assets/sho.shoppages.assets-public.c2691b52.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/shoppages/static/assets/sho.shoppages.assets-public.c2691b52.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" crossorigin="anonymous" href="/shoppages/static/assets/sho.shoppages.assets-public.21298cd5.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>  <div class="sp_footerNormal" style="visibility:hidden;">
+        <div class="pl_grid-content pl_mb25">
+          <div class="pl_grid-container pl_block--full-bleed">
+            <div class="pl_grid-col-12">
+                  <div class="user_system_rwd">
+<link href="/user/assets/ft4.user.newsletter-snippet.f445ce0c.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/user/assets/ft4.user.newsletter-snippet.f445ce0c.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" crossorigin="anonymous" href="/user/assets/ft4.user.newsletter-snippet.d387de48.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>        <div id="us_id_newsletterSnippet" class="us_newsletterSnippet">
+        </div>
+    </div>
+
+            </div>
+          </div>
+        </div>
+      <div class="pl_grid-content pl_mb25 sp_first_row">
+        <div class="pl_grid-container pl_block">
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 sp_first_column" style="align-self: center">
+            <div class="pl_grid-content">
+              <div class="pl_grid-container pl_pr50" style="display: flex;">
+                <div>
+                  <svg class="pl_icon100 pl_mr100 sp_mein_konto_logo" role="img" style="vertical-align: middle;">
+                    <use xlink:href="/assets-static/icons/pl_icon_person.svg#pl_icon_person"/>
+                  </svg>
+                </div>
+                <span class="ts-link ub64e pl_link100--secondary sp_mein_konto_link sp_mein_konto_text"
+                      data-ub64e="L3VzZXIvYWNjb3VudE92ZXJ2aWV3P2VudHJ5UG9pbnQ9Zm9vdGVy"
+                      data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_MeinKonto&quot;}"
+                >
+                Mein Konto
+              </span>
+              </div>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 sp_second_column" style="align-self: center">
+            <div class="pl_grid-content">
+              <div class="pl_grid-container pl_pr50" style="display: flex;">
+                    <div>
+                      <svg class="pl_icon100 pl_mr100 sp_geschenkgutscheine_logo" role="img" style="vertical-align: middle;">
+                        <use xlink:href="/assets-static/icons/pl_icon_voucher.svg#pl_icon_voucher"/>
+                      </svg>
+                    </div>
+                    <span class="ts-link ub64e pl_link100--secondary sp_geschenkgutscheine_link"
+                          data-ub64e="L3Avb3R0by1nZXNjaGVua2d1dHNjaGVpbi12b24tMTAtMjUwLWV1cm8tMTAwNjM0MTQz"
+                          data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Geschenkgutscheine&quot;}"
+                    >
+                    Geschenkgutscheine
+                  </span>
+              </div>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 sp_third_column" style="align-self: center">
+            <div class="pl_grid-content">
+              <div class="pl_grid-container pl_pr50" style="display: flex;">
+                <div>
+                  <svg class="pl_icon100 pl_mr100 sp_lobUndKritik_logo" role="img" style="vertical-align: middle;">
+                    <use xlink:href="/assets-static/icons/pl_icon_feedback.svg#pl_icon_feedback"/>
+                  </svg>
+                </div>
+                <span class="ts-link ub64e pl_link100--secondary sp_js_track_feedback sp_lobUndKritik_link"
+                      data-ub64e="L2NvbnRhY3QtZmVlZGJhY2svZmVlZGJhY2s="
+                      data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_LobUndKritikBig&quot;}"
+                >
+                Lob &amp; Kritik
+              </span>
+              </div>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 sp_fourth_column">
+            <div class="pl_block--no-padding">
+            <span class="ts-link ub64e pl_link--primary sp_shop_link"
+                  data-ub64e="aHR0cHM6Ly9laGktc2llZ2VsLmRlL3ZlcmJyYXVjaGVyL3Nob3BzLW1pdC1zaWVnZWwvemVydGlmaXppZXJ0ZS1zaG9wcy96ZXJ0aWZpa2F0L2M3MWUyNGM5ZmRmNjgxMGQxYjY5NDc5YzcxMDk5YjJmLw=="
+                  data-target="_blank"
+                  data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Shop&quot;}">
+              <svg class="pl_logo sp_shop_logo" role="img" height="40" width="40">
+                <use xlink:href="/assets-static/icons/pl_logo_ehi.svg#pl_logo_ehi"/>
+              </svg>
+            </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="pl_grid-content pl_block pl_mb25 sp_second_row">
+        <div class="pl_grid-container">
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 sp_first_column">
+            <div class="pl_headline100">
+              <a class="ts-link pl_link sp_color_black100" href="/shoppages/service/"
+                 style="text-decoration: none;"
+                 data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Otto-Service&quot;}">
+                <span style="all: unset;">Service</span></a>
+            </div>
+            <div class="pl_mb50 pl_mt100 pl_copy100 sp_color_black100 sp_questions">
+              Wir sind gerne für dich da.
+            </div>
+            <div class="pl_mb50 sp_phoneNumber">
+              <a class="ts-link pl_link100--secondary" href="tel:+494036033603"
+                 data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_ServiceHotline&quot;}">
+            <span style="all: unset;">
+              040 - 3603 3603
+            </span>
+              </a>
+            </div>
+            <div class="pl_mb50 pl_copy100">
+              <a class="ts-link pl_link100--secondary sp_callback_link" href="/contact-callback/callback"
+                 data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_RueckrufService&quot;}">
+            <span style="all: unset;">
+              Kostenloser Rückrufservice
+            </span>
+              </a>
+            </div>
+            <div class="pl_mb175 pl_copy100">
+              <a class="ts-link js_openInPopup pl_link100--secondary sp_contactform_link"
+                 href="/user/contactForm" target="_blank" rel="noopener noreferrer"
+                 data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Kontakt&quot;}">
+                service@otto.de
+              </a>
+            </div>
+            <div class="pl_mb150 sp_logos_container">
+              <div class="sp_logo_appStore pl_mb100">
+                <a class="ts-link sp_apple-app-store-badge_link"
+                   href="https://frj4.adj.st/www.otto.de/extern/?page=%2F&amp;otto_deep_link=https%3A%2F%2Fwww.otto.de&amp;adjust_t=ne03zg_ig5rmn&amp;adjust_deeplink=otto%3A%2F%2Fwww.otto.de%2Fextern%2F%3Fpage%3D%252F&amp;adjust_fallback=https%3A%2F%2Fwww.otto.de%2Fapp&amp;adjust_redirect_macos=https%3A%2F%2Fwww.otto.de%2Fapp"
+                   rel="noopener noreferrer"
+                   data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_AppStoreApple&quot;}">
+                  <img class="sp_apple-app-store-badge_logo"
+                       src="/assets-static/icons/pl_logo_app-store.svg#pl_logo_app-store" width="120"
+                       height="40" alt="App Store">
+                </a>
+              </div>
+              <div class="sp_logo_playStore">
+                <a class="ts-link sp_google-play-badge_link"
+                   href="https://frj4.adj.st/www.otto.de/extern/?page=%2F&amp;otto_deep_link=https%3A%2F%2Fwww.otto.de&amp;adjust_t=ne03zg_ig5rmn&amp;adjust_deeplink=otto%3A%2F%2Fwww.otto.de%2Fextern%2F%3Fpage%3D%252F&amp;adjust_fallback=https%3A%2F%2Fwww.otto.de%2Fapp&amp;adjust_redirect_macos=https%3A%2F%2Fwww.otto.de%2Fapp"
+                   rel="noopener noreferrer"
+                   data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_AppStoreAndroid&quot;}">
+                  <img class="sp_google-play-badge_logo"
+                       src="/assets-static/icons/pl_logo_play-store.svg#pl_logo_play-store" width="135"
+                       height="40" alt="Play Store">
+                </a>
+              </div>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 sp_second_column">
+        <span class="pl_headline100 sp_color_black100">
+          Zahlungsarten
+        </span>
+            <div class="pl_mb50 pl_mt100">
+              <span class="ts-link ub64e pl_link100--secondary sp_sepa_link"
+                    data-ub64e="L3Nob3BwYWdlcy9wYXltZW50IzVkYTliZWNmNmYxYzIxMzUxY2RlNTZiMQ=="
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Sepa&quot;}">
+                  <svg class="pl_logo sp_sepa_logo" role="img" viewBox="0 0 106 40" height="16">
+                    <use xlink:href="/assets-static/icons/pl_logo_sepa.svg#pl_logo_sepa">
+                    </use>
+                  </svg>
+              </span>
+            </div>
+            <div class="pl_mb50">
+              <span class="ts-link ub64e pl_link100--secondary sp_credit_cards"
+                    data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3BheW1lbnQjNTEyMjAxNGJlNGIwNThlZWRlNzMxNTY5"
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Kreditkarten&quot;}">&nbsp;
+                <svg class="pl_logo sp_visa_logo" role="img" viewBox="0 0 124 40" height="12">
+                  <use xlink:href="/assets-static/icons/pl_logo_visa.svg#pl_logo_visa">
+                  </use>
+                </svg>
+                <svg class="pl_logo sp_mastercard_logo" role="img" viewBox="0 0 65 40" height="16">
+                  <use xlink:href="/assets-static/icons/pl_logo_mastercard.svg#pl_logo_mastercard">
+                  </use>
+                </svg>
+                <svg class="pl_logo sp_amex_logo" role="img" viewBox="0 0 40 40" height="16">
+                  <use xlink:href="/assets-static/icons/pl_logo_amex.svg#pl_logo_amex">
+                  </use>
+                </svg>
+              </span>
+            </div>
+            <div class="pl_mb50">
+              <span class="ts-link ub64e pl_link100--secondary sp_paypal_link"
+                    data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3BheW1lbnQjNTgyZGJlZGMzMjIzZTg1OTMyYTNiMjUy"
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_PayPal&quot;}">
+                <svg class="pl_logo sp_paypal_logo" role="img" viewBox="0 0 164 40" height="16">
+                  <use xlink:href="/assets-static/icons/pl_logo_paypal.svg#pl_logo_paypal">
+                  </use>
+                </svg>
+              </span>
+            </div>
+            <div class="pl_mb50">
+          <span class="ts-link ub64e pl_link100--secondary sp_paydirekt_link" data-target="_self"
+                data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3BheW1lbnQjNTlkYzg2M2YxNjgwMDUwMDAxYjU5NGZm"
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_PayDirekt&quot;}">
+            <svg class="pl_logo sp_paydirekt_logo" role="img" viewBox="0 0 175 80" height="32">
+              <use xlink:href="/assets-static/icons/pl_logo_giropay_paydirekt.svg#pl_logo_giropay_paydirekt">
+              </use>
+            </svg>
+          </span>
+            </div>
+            <div class="pl_mb50 pl_copy100">
+              <span class="ts-link ub64e pl_link100--secondary sp_invoice_link"
+                    data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3BheW1lbnQjNTExZTYwZGJlNGIwMzkyOGFlOGMyNmVm"
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Rechnung&quot;}">
+                Rechnung
+              </span>
+            </div>
+            <div class="pl_mb50 pl_copy100 sp_ratepay_link">
+          <span class="ts-link ub64e pl_link100--secondary"
+                data-ub64e="L3Nob3BwYWdlcy9scF9tb25hdHNyYXRlbg=="
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Ratenzahlung&quot;}">
+            <span style="all: unset;">
+              Ratenzahlung*
+            </span>
+          </span>
+            </div>
+                <div class="pl_mb50 pl_copy100 sp_ratepay_insurance_link">
+                <span class="ts-link ub64e pl_link100--secondary"
+                      data-ub64e="L3Nob3BwYWdlcy9vcnM="
+                      data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_RatenschutzVersicherung&quot;}">
+                  <span style="all: unset;">
+                    Ratenschutz-Versicherung*
+                  </span>
+                </span>
+                </div>
+            <div class="pl_mb50 pl_copy100">
+                <span class="ts-link ub64e pl_link100--secondary sp_payment_pause_link"
+                      data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3BheW1lbnQjNTExZTU1ZjRlNGIwYmQ4ODRjNTgyZjFl"
+                      data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Zahlpause&quot;}">
+                  Zahlpause*
+                </span>
+            </div>
+            <div class="pl_mb25 pl_copy100">
+                <span class="ts-link ub64e pl_link100--secondary sp_prepayment_link"
+                      data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3BheW1lbnQjNTEyMjA2ZWZlNGIwMzkyOGFlOGMyNmYw"
+                      data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Vorkasse&quot;}">
+                  Vorkasse
+                </span>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 sp_third_column sp_about_headline">
+        <span class="pl_headline100 sp_color_black100 ">
+          Über uns
+        </span>
+            <div class="pl_mb50 pl_mt100 pl_copy100 sp_sustainability_link">
+              <span class="ts-link ub64e pl_link100--secondary"
+                    data-ub64e="L3Nob3BwYWdlcy9uYWNoaGFsdGlna2VpdA=="
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Nachhaltigkeit&quot;}">
+                Nachhaltigkeit
+              </span>
+            </div>
+            <div class="pl_mb50 pl_copy100 sp_company_link">
+              <span class="ts-link ub64e pl_link100--secondary"
+                    data-ub64e="L3VudGVybmVobWVu"
+                    data-target="_blank"
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Unternehmen&quot;}">
+                Unternehmen
+              </span>
+            </div>
+            <div class="pl_mb50 pl_copy100 sp_newsroom_link">
+              <span class="ts-link ub64e pl_link100--secondary"
+                    data-ub64e="L25ld3Nyb29t"
+                    data-target="_blank"
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Newsroom&quot;}">
+                Newsroom
+              </span>
+            </div>
+            <div class="pl_mb150 pl_copy100 sp_jobs_link">
+          <span class="ts-link ub64e pl_link100--secondary" data-ub64e="L2pvYnM=" data-target="_blank"
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Jobs&quot;}">
+            <span style="all: unset;">
+              Jobs
+            </span>
+          </span>
+            </div>
+            <div class="pl_mb100">
+          <span class="pl_headline100 sp_color_black100 sp_blogs_headline">
+            Blogs
+          </span>
+            </div>
+            <div class="pl_mb100">
+              <a class="ts-link pl_link--primary sp_blogs_updated_link"
+                 href="https://www.otto.de/updated/" target="_blank" rel="noopener noreferrer"
+                 data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_UpdatedBlog&quot;}">
+                <svg class="pl_logo sp_blogs_updated_logo" role="img" viewBox="0 0 231 40" height="16">
+                  <use xlink:href="/assets-static/icons/pl_logo_updated.svg#pl_logo_updated">
+                  </use>
+                </svg>
+              </a>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 sp_fourth_column">
+            <span class="pl_headline100 sp_color_black100 sp_marketplace_headline">
+              Verkaufen bei OTTO
+            </span>
+            <div class="pl_mb150 pl_mt100 pl_copy100">
+              <span class="ts-link ub64e pl_link100--secondary sp_otto_market_link"
+                data-ub64e="aHR0cHM6Ly93d3cub3R0by5tYXJrZXQv" data-target="_blank"
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_OttoMarket&quot;}">
+                <svg class="pl_logo sp_otto_market_logo" role="img" viewBox="0 0 385 40" height="16">
+                  <use xlink:href="/assets-static/icons/pl_logo_market.svg#pl_logo_market">
+                  </use>
+                </svg>
+              </span>
+            </div>
+            <span class="pl_headline100 sp_color_black100 sp_partner_headline">
+              OTTO Partner
+            </span>
+            <div class="pl_mb50 pl_mt100 pl_copy100">
+              <span class="ts-link ub64e pl_link100--secondary sp_finanz_plus_link"
+                data-ub64e="L3Nob3BwYWdlcy92ZXJzaWNoZXJ1bmdlbg==" data-target="_blank"
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_OttoFinanzPlus&quot;}">
+                <svg class="pl_logo sp_finanz_plus_logo" role="img" viewBox="0 0 78 40" height="24">
+                  <use xlink:href="/assets-static/icons/pl_logo_finanzplus.svg#pl_logo_finanzplus">
+                  </use>
+                </svg>
+              </span>
+            </div>
+            <div class="pl_mb50 pl_copy100">
+          <span class="ts-link ub64e pl_link100--secondary sp_otto_retail_media_link"
+                data-ub64e="aHR0cHM6Ly93d3cub3R0b3JldGFpbC5tZWRpYQ==" data-target="_blank"
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_OttoRetailMedia&quot;}">
+            <svg class="pl_logo sp_otto_retail_media_logo" role="img" viewBox="0 0 387 40" height="16">
+              <use xlink:href="/assets-static/icons/pl_logo_retailmedia.svg#pl_logo_retailmedia">
+              </use>
+            </svg>
+          </span>
+            </div>
+            <div class="pl_mb50 pl_copy100 sp_shopping_more_link">
+              <span class="ts-link ub64e pl_link100--secondary"
+                    data-ub64e="L3Nob3BwYWdlcy9zaG9wcGluZy1tb3Jl"
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_ShoppingMore&quot;}">
+                Shopping&amp;more
+              </span>
+            </div>
+            <div class="pl_mb50 pl_copy100 sp_fotoservice_link">
+          <span class="ts-link ub64e pl_link100--secondary"
+                data-ub64e="L3RlY2huaWsva2FtZXJhL2Nld2UtZm90b3NlcnZpY2U="
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_OttoFotoservice&quot;}">
+            <span style="all: unset;">
+              OTTO Fotoservice
+            </span>
+          </span>
+            </div>
+            <div class="pl_mb50 pl_copy100 sp_affiliate_link">
+          <span class="ts-link ub64e pl_link100--secondary"
+                data-ub64e="aHR0cHM6Ly93d3cub3R0by1wYXJ0bmVycHJvZ3JhbW0uZGU=" data-target="_blank"
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Affiliate&quot;}">
+            <span style="all: unset;">
+              OTTO Affiliate
+            </span>
+          </span>
+            </div>
+            <div class="pl_mb75 pl_copy100 sp_cgi_link">
+          <span class="ts-link ub64e pl_link100--secondary"
+                data-ub64e="aHR0cHM6Ly9jZ2lieW90dG8uZGUvZGUv" data-target="_blank"
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_OttoCgi&quot;}">
+            <svg class="pl_logo" role="img" viewBox="0 0 254 40" height="16">
+              <use xlink:href="/assets-static/icons/pl_logo_cgi.svg#pl_logo_cgi">
+              </use>
+            </svg>
+          </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="pl_block pl_mb25 pl_grid-content sp_usps_row">
+        <div class="pl_grid-container sp_usps_container">
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 pl_my50 pl_pr50">
+            <div class="sp_usp_container1">
+              <svg class="pl_icon100 pl_mr100 sp_usp_checkmark1" role="img" style="vertical-align: middle;">
+                <use xlink:href="/assets-static/icons/pl_icon_check.svg#pl_icon_check"></use>
+              </svg>
+              <span class="ts-link ub64e pl_link100--secondary sp_usp_description1"
+                    data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3BheW1lbnQjNTExZTYwZGJlNGIwMzkyOGFlOGMyNmVm"
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_SichererKaufAufRechnung&quot;}">
+                Sicherer Kauf auf Rechnung
+              </span>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 pl_pr50 pl_my50">
+            <div class="sp_usp_container2">
+              <svg class="pl_icon100 pl_mr100 sp_usp_checkmark2" role="img" style="vertical-align: middle;">
+                <use xlink:href="/assets-static/icons/pl_icon_check.svg#pl_icon_check"></use>
+              </svg>
+              <span class="ts-link ub64e pl_link100--secondary sp_usp_description2"
+                    data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3J1ZWNrc2VuZHVuZw=="
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_30TageRueckgabegarantie&quot;}">
+                <span style="all: unset;">
+                  Kostenlose Rücksendung
+                </span>
+              </span>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 pl_pr50 pl_my50">
+            <div class="sp_usp_container3">
+              <svg class="pl_icon100 pl_mr100 sp_usp_checkmark3" role="img" style="vertical-align: middle;">
+                <use xlink:href="/assets-static/icons/pl_icon_check.svg#pl_icon_check"></use>
+              </svg>
+              <span class="ts-link ub64e pl_link100--secondary sp_usp_description3"
+                    data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3BheW1lbnQjNTExZTViOTZlNGIwMzkyOGFlOGMyNmVl"
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_EinfacheRatenzahlung&quot;}">
+                Einfache Ratenzahlung*
+              </span>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 pl_pr50 pl_my50">
+            <div class="sp_usp_container4">
+              <svg class="pl_icon100 pl_mr100 sp_usp_checkmark4" role="img" style="vertical-align: middle;">
+                <use xlink:href="/assets-static/icons/pl_icon_check.svg#pl_icon_check"></use>
+              </svg>
+              <span class="ts-link ub64e pl_link100--secondary sp_usp_description4"
+                    data-ub64e="L3Nob3BwYWdlcy9vcnM="
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_RatenschutzVersicherungUSP&quot;}">
+                <span style="all: unset;">
+                  Ratenschutz-Versicherung*
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    <div class="pl_block pl_mb25 sp_fourth_row">
+      <div class="sp_social_container" style="text-align: center;">
+          <span class="ts-link ub64e pl_mx50 pl_link--secondary sp_pinterest_link"
+                data-ub64e="aHR0cHM6Ly9kZS5waW50ZXJlc3QuY29tL290dG9kZS8="
+                data-target="_blank"
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Pinterest&quot;}">
+            <svg class="pl_logo sp_pinterest_logo" role="img" height="24" width="24">
+              <use xlink:href="/assets-static/icons/pl_logo_pinterest.svg#pl_logo_pinterest"/>
+            </svg>
+          </span>
+        <span class="ts-link ub64e pl_mx50 pl_link--secondary sp_facebook_link"
+              data-ub64e="aHR0cHM6Ly93d3cuZmFjZWJvb2suY29tL090dG8="
+              data-target="_blank"
+              data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Facebook&quot;}">
+            <svg class="pl_logo sp_facebook_logo" role="img" height="24" width="24">
+              <use xlink:href="/assets-static/icons/pl_logo_facebook.svg#pl_logo_facebook"/>
+            </svg>
+          </span>
+        <span class="ts-link ub64e pl_mx50 pl_link--secondary sp_twitter_link"
+              data-ub64e="aHR0cHM6Ly90d2l0dGVyLmNvbS9vdHRvX2Rl"
+              data-target="_blank"
+              data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Twitter&quot;}">
+            <svg class="pl_logo sp_twitter_logo" role="img" height="24" width="24">
+              <use xlink:href="/assets-static/icons/pl_logo_twitter.svg#pl_logo_twitter"/>
+            </svg>
+          </span>
+        <span class="ts-link ub64e pl_mx50 pl_link--secondary sp_youtube_link"
+              data-ub64e="aHR0cDovL3d3dy55b3V0dWJlLmNvbS9vdHRv"
+              data-target="_blank"
+              data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_YoutTube&quot;}">
+            <svg class="pl_logo sp_youtube_logo" role="img" height="24" width="24">
+              <use xlink:href="/assets-static/icons/pl_logo_youtube.svg#pl_logo_youtube"/>
+            </svg>
+          </span>
+        <span class="ts-link ub64e pl_mx50 pl_link--secondary sp_instagram_link"
+              data-ub64e="aHR0cHM6Ly93d3cuaW5zdGFncmFtLmNvbS9vdHRvX2RlLw=="
+              data-target="_blank"
+              data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Instagram&quot;}">
+            <svg class="pl_logo sp_instagram_logo" role="img" height="24" width="24">
+              <use xlink:href="/assets-static/icons/pl_logo_instagram.svg#pl_logo_instagram"/>
+            </svg>
+          </span>
+      </div>
+    </div>
+      <div class="pl_grid-content sp_imprint_row pl_pt50 pl_px100">
+        <div class="pl_grid-container" style="text-align: center;">
+          <div class="pl_grid-col-12 pl_my50 sp_legal_links_container">
+            <ul>
+              <li>
+                <a class="ts-link pl_link100--secondary sp_js_footerCookieBanner footerCookieBanner"
+                   href="#" target="_blank" rel="noopener noreferrer"
+                   data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_CookieBanner&quot;}">Cookie-Einstellungen</a>
+              </li>
+              <li>
+                <a class="ts-link pl_link100--secondary sp_agb_link" href="/shoppages/service/agb"
+                   rel="noopener noreferrer"
+                   data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_AGB&quot;}">
+                  AGB
+                </a>
+              </li>
+              <li>
+                <a class="ts-link pl_link100--secondary sp_privacy_link" href="/shoppages/service/datenschutz"
+                   rel="noopener noreferrer"
+                   data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Datenschutz&quot;}">
+                  Datenschutz
+                </a>
+              </li>
+              <li>
+                <a class="ts-link pl_link100--secondary sp_imprint_link" href="/shoppages/service/impressum"
+                   rel="noopener noreferrer"
+                   data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Impressum&quot;}">Impressum</a>
+              </li>
+              <li>
+                <span class="ts-link ub64e sp_link pl_link100--secondary sp_js_track_feedback sp_feedback_link"
+                      data-ub64e="L2NvbnRhY3QtZmVlZGJhY2svZmVlZGJhY2s="
+                      data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_LobUndKritikBig&quot;}">Lob &amp; Kritik</span>
+              </li>
+            </ul>
+          </div>
+          <div class="pl_grid-col-12 pl_copy100 pl_my50 sp_finePrint_row1">
+            Preisangaben inkl. gesetzl. MwSt. und zzgl.
+            <a class="ts-link pl_link100--secondary" href="/shoppages/service/lieferung#533173e9e4b08cc160e21a34"
+               data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_ServiceUndVersandkosten&quot;}">
+              Service- und Versandkosten
+            </a>
+          </div>
+          <div class="pl_grid-col-12 pl_copy100 pl_my50 sp_finePrint_row2">
+            * Bonität vorausgesetzt, gegen Aufpreis
+          </div>
+      <div class="pl_grid-col-12 pl_mt175 pl_mb75 sp_ottoLogo">
+        <svg class="pl_logo--grey" role="img" style="height: 40px;">
+          <use xlink:href="/assets-static/icons/pl_logo_slogan.svg#pl_logo_slogan"/>
+        </svg>
+      </div>
+        </div>
+      </div>
+  </div>
+
+                    <div class="us_js_esiAjax"
+     data-url="/user/sessionMaintenance"
+     data-eventtype="load"
+     data-priority="24"
+     data-qa="user_session_maintenance">
+</div>
+<link href="/user/assets/ft4.user.public.b850da79.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/user/assets/ft4.user.public.b850da79.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" crossorigin="anonymous" href="/user/assets/ft4.user.public.cda2922c.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+
+<div id="us_js_id_loginAreaFooter">
+    <div id="us_js_id_loginAreaContentToRemove" class="user_system_rwd">
+        <div class="us_hide">
+            <div id="us_js_id_loginAreaContentToReplaceHeader">
+                <div class="us_loginAreaContainerWithName" data-qa="user_login_area_header_container"
+                     id="us_id_loginAreaContainerWithName">
+                    <div class="us_loginArea us_js_loginAreaMenuHandle ub64e" id="us_id_loginArea" data-qa="user_login_area_header" data-ub64e="amF2YXNjcmlwdDp2b2lkKDApOw==">
+<span class="us_loginAreaIcon p_icons" data-qa="user_login_area_icon">
+Θ
+</span>
+                        <span class="us_iconSubtitle us_js_loginAreaIconSubtitle"
+                              data-qa="user_login_area_icon_subtitle"
+                              data-loggedin="false"
+                              data-login-state="UNKNOWN_VISITOR" >
+                                        <span class="us_js_loginAreaIconSubtitleMyAccount"
+                                              data-qa="user_loginAreaIconSubtitleMyAccount">Mein Konto</span>
+                                    </span>
+                    </div>
+                    <div class="clear"></div>
+                </div>
+
+                <div class="us_loginMenu" id="us_id_loginAreaMenu" data-qa="user_login_area_menu">
+    <button id="us_id_closeLoginMenuButton" class="us_closeLoginMenuButton p_symbolBtn100--4th" type="button"
+            data-qa="user_login_area_menu_close">
+        <i>x</i>
+    </button>
+    <ul>
+        <ul class="us_loginAreaMenuItems  us_bottomLine">
+            <li class="login_area_overview_link">
+            <span class="ub64e p_link100--2nd" data-ub64e="L3VzZXIvYWNjb3VudE92ZXJ2aWV3P2VudHJ5UG9pbnQ9bG9naW5BcmVh"
+                  data-qa="user_login_area_menu_myaccount">
+Mein Konto            </span>
+            </li>
+            <li class="login_area_menu_link">
+            <span class="ub64e p_link100--2nd" data-ub64e="L215YWNjb3VudC9vcmRlcnM/ZW50cnlQb2ludD1sb2dpbkFyZWE="
+                  data-qa="user_login_area_menu_myorders">
+Meine Bestellungen            </span>
+            </li>
+            <li class="login_area_menu_link">
+            <span class="ub64e p_link100--2nd" data-ub64e="L3VzZXIvaW52b2ljZXM/ZW50cnlQb2ludD1sb2dpbkFyZWE="
+                  data-qa="user_login_area_menu_myinvoices">
+Meine Rechnungen            </span>
+            </li>
+            <li class="login_area_menu_link">
+            <span class="user_js_show_more_login_area_links p_link100--2nd"
+                  data-qa="user_login_area_menu_show_more_links">
+mehr...            </span>
+            </li>
+
+                <li class="login_area_menu_link login_area_menu_hide_link">
+            <span class="user_js_more_login_area_links_follow p_link100--2nd" data-ub64e="L3VzZXIvbXlib29raW5ncz9lbnRyeVBvaW50PWxvZ2luQXJlYQ=="
+                  data-qa="user_login_area_menu_mybookings">
+Meine Konto-Buchungen            </span>
+                </li>
+            <li class="login_area_menu_link login_area_menu_hide_link">
+            <span class="user_js_more_login_area_links_follow p_link100--2nd"
+                  data-ub64e="L215YWNjb3VudC9teWRhdGE/ZW50cnlQb2ludD1sb2dpbkFyZWE="
+                  data-qa="user_login_area_menu_mydata">
+Meine persönlichen Daten            </span>
+            </li>
+            <li class="login_area_menu_link login_area_menu_hide_link">
+            <span class="user_js_more_login_area_links_follow p_link100--2nd" data-ub64e="L215YWNjb3VudC9hZGRyZXNzZXM/ZW50cnlQb2ludD1sb2dpbkFyZWE="
+                  data-qa="user_login_area_menu_myaddresses">
+Meine Anschriften            </span>
+            </li>
+            <li class="login_area_menu_link login_area_menu_hide_link">
+            <span class="user_js_more_login_area_links_follow p_link100--2nd" data-ub64e="L3VzZXIvbXlzZXR0aW5ncz9lbnRyeVBvaW50PWxvZ2luQXJlYQ=="
+                  data-qa="user_login_area_menu_mysettings">
+Meine Einstellungen            </span>
+            </li>
+        </ul>
+            <li class="login_area_menu_button">
+            <span class="ub64e p_btn100--1st" data-ub64e="L3VzZXIvbG9naW4/ZW50cnlQb2ludD1sb2dpbkFyZWE=" data-qa="user_login_area_login">
+Anmelden            </span>
+            </li>
+                <li class="login_area_register_link">
+                <span class="p_link100--1st ub64e" data-ub64e="L3VzZXIvcmVnaXN0ZXI/ZW50cnlQb2ludD1sb2dpbkFyZWE="
+                      data-qa="user_login_area_register">
+Neu bei OTTO? Jetzt registrieren                </span>
+                </li>
+    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+
+
+
+
+                </footer>
+            </div>
+
+    <div id="wato_onsite_advert" class="infoContainer av_anchor"></div>
+
+    <link rel="stylesheet" href="/wato-onsite/assets/ft7bcn.wato.onsite.534a0894.css" crossorigin="anonymous" integrity="sha256-eVb/QxnlL2Wnvy9HetHxvf4IeYz3bYlmCDD+q4KAZlQ=">
+
+<link rel="modulepreload" href="/wato-onsite/assets/ft7bcn.wato.onsite.module.7cd1b263.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/wato-onsite/assets/ft7bcn.wato.onsite.nomodule.76d54cc3.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+
+                    <script id="avJson" type="application/json">
+                        {
+                            "id":"682285688",
+                            "brand":"Privileg Family Edition",
+                            "classificationGroup": "OFEN",
+                            "businessCategory": {"group":"ELECTRONIC_DIGITAL", "value":"HAUSHALTSELEKTRO"},
+                            "retailPrice":"33300",
+                            "placementId":"SKYSCRAPER_PDP"
+                        }
+                    </script>
+        </div>
+
+<script src="/assets-static/global-resources/assets.global-resources.body.nomodule.c9330900.js" crossorigin="anonymous" integrity="sha256-ePVFKi1ce9sU3247s2137nCEt9CWObF+oOVoBpvA7HA="></script>
+<link rel="modulepreload" href="/assets-static/global-resources/assets.global-resources.bodyasync.module.4b41a647.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/assets-static/global-resources/assets.global-resources.bodyasync.nomodule.914c3843.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<script src="/tracking-bct/tracking.bct.bct.3fc84c9d.js" integrity="sha256-8SVSvFBkJB3ncUcHIPmnosxkcAsZkkIwu4dx6Tz257E=" crossorigin="anonymous"></script>
+<link rel="preload" href="/apps-assets/apps.global.assets.6780b120.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/apps-assets/apps.global.assets.6780b120.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/apps-assets/apps.global.assets.module.af559819.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/apps-assets/apps.global.assets.nomodule.598410b8.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<section class="cookieBanner cookieBanner__bottom" id="cookieBanner" style="display: none" xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html"><div class="cookieBanner__container"><div class="cookieBanner__wrapper"><a href="/suche/Kekse/" class="cookieBanner__iconLink ts-link" data-ts-link='{"ot_CookieBannerIcon" : "cookiesearch"}'><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24"><style>.st1 {
+                        fill: #dedede
+                    }
+
+                    .st4 {
+                        fill: none;
+                        stroke: #dedede;
+                        stroke-width: .2;
+                        stroke-miterlimit: 10
+                    }</style><symbol id="bg_4" viewBox="0 -24 24 24"><path fill="#fff" d="M.1-23.9h23.8V-.1H.1z"/><path class="st1" d="M23.8-.2v-23.6H.2V-.2h23.6m.2.2H0v-24h24V0z"/><path class="st1" d="M21.795-2.205v-19.6H2.205v19.6h19.59m.2.2H2.006v-20h19.99v20z" opacity=".4"/><g><defs><path id="SVGID_1_" d="M0-24h24V0H0z"/></defs><clipPath id="SVGID_2_"><use xlink:href="#SVGID_1_" overflow="visible"/></clipPath><g opacity=".4" clip-path="url(#SVGID_2_)"><path class="st4" d="M0-12h24M12-24V0"/></g></g></symbol><path fill="none" d="M0 0h24v24H0z" id="Ebene_2"/><g id="test6"><circle cx="19.5" cy="11.5" r=".5"/><circle cx="10.5" cy="11.5" r=".5"/><circle cx="14.5" cy="16.5" r=".5"/><circle cx="10.5" cy="17.5" r=".5"/><circle cx="18.5" cy="6.5" r=".5"/><circle cx="19.25" cy="4.75" r=".75"/><circle cx="6.25" cy="9.75" r=".75"/><circle cx="8.25" cy="11.75" r=".75"/><circle cx="13.25" cy="17.75" r=".75"/><path d="M9.5 7C8.673 7 8 7.673 8 8.5S8.673 10 9.5 10 11 9.327 11 8.5 10.327 7 9.5 7zm0 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1z"/><circle cx="18.5" cy="8.5" r=".75"/><circle cx="20.25" cy="6.5" r=".75"/><path d="M19.791 14.099c-.006.002-.599.154-1.038.154-1.103 0-2-.898-2-2 0-.287.258-1.045.441-1.386.094-.16.107-.451.008-.609-.188-.299-.525-.272-.702-.258-.827 0-1.5-.673-1.5-1.5 0-.852.59-1.583 1.12-1.706a.5.5 0 0 0 .1-.938c-.006-.003-.72-.365-.72-.856 0-.254.073-.567.164-.698a.498.498 0 0 0-.218-.745c-1.196-.502-2.48-.566-3.466-.566-4.962 0-9 4.037-9 9s4.038 9 9 9c3.298 0 6.334-1.767 7.734-4.503.339-.662.667-1.713.68-1.757a.5.5 0 1 0-.604-.633zm-.968 1.934c-1.23 2.405-3.916 3.958-6.843 3.958-4.41 0-8-3.589-8-8s3.59-8 8-8c1.093 0 1.907.096 2.612.317A2.8 2.8 0 0 0 14.5 5c0 .53.271.943.565 1.236A2.9 2.9 0 0 0 14 8.5c0 1.23.893 2.255 2.064 2.462-.162.425-.311.94-.311 1.291 0 1.789 1.584 3.184 3.413 2.975a7.96 7.96 0 0 1-.343.805z"/></g></svg></a><div class="cookieBanner__scrollable"><div class="p_headline100 cookieBanner__headline">Cookies erlauben?</div><div class="cookieBanner__info"><a href="#datennutzungen" id="otto_partner" class="p_link--1st ts-link" data-ts-link='{"ot_CookieBanner" : "otto_partner"}'>OTTO und acht Partner brauchen</a> Deine Zustimmung (Klick auf &bdquo;OK&rdquo;) bei vereinzelten <a href="/datenschutz/#block43" id="data_usage" class="p_link--1st">Datennutzungen</a>, um Informationen auf einem Ger&auml;t zu speichern und/oder abzurufen (IP-Adresse, Nutzer-ID, Browser-Informationen, Ger&auml;te-Kennungen). Die Datennutzung erfolgt f&uuml;r personalisierte Anzeigen und Inhalte, Anzeigen- und Inhaltsmessungen sowie um Erkenntnisse &uuml;ber Zielgruppen und Produktentwicklungen zu gewinnen. Mehr Infos zur Einwilligung (inkl. Widerrufsm&ouml;glichkeit) und zu Einstellungsm&ouml;glichkeiten gibt’s jederzeit <a href="/datenschutz/#block43" id="info_agreement" class="p_link--1st">hier</a>. Mit Klick auf den Link &quot;Cookies ablehnen&quot; kannst Du Deine Einwilligung jederzeit ablehnen.<div class="p_headline100 cookieBanner__headline headline_data_usage_head"><a id="datennutzungen">Datennutzungen</a></div><div class="data_usage_text">OTTO arbeitet mit Partnern zusammen, die von Deinem Endger&auml;t abgerufene Daten (Trackingdaten) auch zu eigenen Zwecken (z.B. Profilbildungen) / zu Zwecken Dritter verarbeiten. Vor diesem Hintergrund erfordert nicht nur die Erhebung der Trackingdaten, sondern auch deren Weiterverarbeitung durch diese Anbieter einer Einwilligung. Die Trackingdaten werden erst dann erhoben, wenn Du auf den in dem Banner auf otto.de wiedergebenden Button &bdquo;OK&rdquo; anklickst. Bei den Partnern handelt es sich um die folgenden Unternehmen:<br>Meta Platforms Ireland Limited, Google Ireland Limited, Pinterest Europe Limited, Microsoft Ireland Operations Limited, OS Data Solutions GmbH & Co. KG, Otto Group Media GmbH, Str&ouml;er SSP GmbH, TikTok Information Technologies UK Limited (Ausschlie&szlig;lich bei App-Nutzung).<br>Weitere Informationen zu den Datenverarbeitungen durch diese Partner findest Du in der Datenschutzerkl&auml;rung auf otto.de. Die Informationen sind au&szlig;erdem &uuml;ber einen Link in dem Banner abrufbar.</div></div></div><div class="cookieBanner__footer"><button type="button" class="p_btn100--1st cookieBanner__button js_cookieBannerPermissionButton">OK</button> <span class="p_link--1st js_cookieBannerProhibitionButton">Cookies ablehnen</span> <a href="/datenschutz/#block43" id="more_info" class="p_link--1st cookieBanner__more_info">Mehr Informationen</a></div></div></div></section><link href="/user-cookie-banner/ft4.cookie-banner.bottom_assets.21e75f9e.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"><noscript><link rel="stylesheet" href="/user-cookie-banner/ft4.cookie-banner.bottom_assets.21e75f9e.css" crossorigin="anonymous"></noscript><link rel="preload" crossorigin="anonymous" href="/user-cookie-banner/ft4.cookie-banner.bottom_assets.c777e30d.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)">
+<link rel="preload" crossorigin="anonymous" href="/user-cmp/assets/ft4.user.cmp_stub.1c338b58.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/user-cmp/assets/ft4.user.cmp.d015eb57.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+
+
+    <link rel="preload" href="/benefit-detailview/ft9.benefit-detailview.app.0f44f865.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/benefit-detailview/ft9.benefit-detailview.app.0f44f865.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/benefit-detailview/ft9.benefit-detailview.app.module.495db2e1.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/benefit-detailview/ft9.benefit-detailview.app.nomodule.ecfca20a.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+        <link rel="preload" href="/up-teaser/ft9.up-teaser.detailview.5102dbe4.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/up-teaser/ft9.up-teaser.detailview.5102dbe4.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<script src="/up-teaser/ft9.up-teaser.detailview.nomodule.1ae6f9ca.js" crossorigin="anonymous" integrity="sha256-0vWpolOWFSojpNruPeE1NMzPsxQlry4h7J1o76towT0="></script>
+
+
+    <link href="/combo-combopromo/assets/ft3.combo.combopromo.4fe6207a.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/combo-combopromo/assets/ft3.combo.combopromo.4fe6207a.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" critical="critical" crossorigin="anonymous" href="/combo-combopromo/assets/ft3.combo.combopromo.562bb0dd.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+
+
+  <link rel="preload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.3afc4579.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.3afc4579.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.module.46bea43c.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.nomodule.a87b68b8.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+
+<div style="display:none;" id="reco_cinema__toggle-state" data-toggle-state="{&quot;SHOW_DEALS&quot;:true,&quot;CSR&quot;:false,&quot;USE_OPAL_RELATIONSHIPS&quot;:true,&quot;TESLA_COLDSTART&quot;:false,&quot;USE_TESLA_ARTHURDENT&quot;:true,&quot;USE_TESLA_META&quot;:true,&quot;SHOW_DETAILVIEW_ONLY&quot;:false,&quot;DISPLAY_LAST_SEEN_ARTICLES&quot;:true,&quot;USE_TESLA_HITCHHIKER&quot;:true,&quot;WISHLIST_RECO_REDESIGN&quot;:true,&quot;RECO_REDESIGN&quot;:true}">
+</div>
+<script>
+  window.o_reco = window.o_reco || {};
+  window.o_reco.api = window.o_reco.api || {};
+  window.o_reco.private = window.o_reco.private || {};
+  window.o_reco.private.toggleState = JSON.parse(document.getElementById('reco_cinema__toggle-state').dataset.toggleState);
+
+  window.o_reco.private.delegate = function (originalFunction) {
+    return function () {
+      var passedArguments = arguments;
+      return new Promise(function (resolve, reject) {
+        o_global.eventLoader.onAllScriptsExecuted(10, function () {
+          window.o_reco.private[originalFunction].apply(null, passedArguments).then(resolve).catch(reject);
+        });
+      });
+    };
+  };
+
+  window.o_reco.private.delegateAndWrap = function (originalFunction) {
+    return function () {
+      var passedArguments = arguments;
+      return new Promise(function (resolve) {
+        o_global.eventLoader.onAllScriptsExecuted(10, function () {
+          var result = window.o_reco.private[originalFunction].apply(null, passedArguments);
+          resolve(result);
+        });
+      });
+    };
+  };
+
+  window.o_reco.api.initializeCinema = window.o_reco.private.delegateAndWrap('initializeCinema');
+  window.o_reco.api.initializeExpandableCinema = window.o_reco.private.delegateAndWrap('initializeExpandableCinema');
+  window.o_reco.api.loadRecommendationsForDetailView = window.o_reco.private.delegateAndWrap('asyncLoadRecommendationsForDetailView');
+
+  window.o_reco.api.loadRecommendationsForOrderOverview = window.o_reco.private.delegate('loadRecommendationsForOrderOverview');
+  window.o_reco.api.loadRecommendationsForWishlist = window.o_reco.private.delegate('loadRecommendationsForWishlist');
+  window.o_reco.api.loadRecommendationsForEntryPage =
+          window.o_reco.private.toggleState["CSR"] ?
+                  window.o_reco.private.delegateAndWrap('loadRecommendationsForEntryPageCsr') :
+                  window.o_reco.private.delegate('loadRecommendationsForEntryPage');
+  window.o_reco.api.loadBounceLayerCinema = window.o_reco.private.delegateAndWrap('loadBounceLayerCinema');
+
+  o_global.eventQBus.emit("ft6bcn.reco.init", ".reco.cinema.needsInitialization");
+</script>
+
+
+        <link rel="stylesheet" href="/spa-formicary/assets/ft7bcn.spa-formicary.spa_formicary_assets.7935b393.css" crossorigin="anonymous" integrity="sha256-IQzbUIGIxvC+RmQ1n3QFAF9eiKwlozE/v/tnQ5ByB8c=">
+
+<link rel="modulepreload" href="/spa-formicary/assets/ft7bcn.spa-formicary.spa_formicary_assets.module.18c96fd4.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/spa-formicary/assets/ft7bcn.spa-formicary.spa_formicary_assets.nomodule.22c7d8e1.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<script>
+    window.o_spa_formicary = window.o_spa_formicary || {};
+    window.o_spa_formicary.api = window.o_spa_formicary.api || {};
+    window.o_spa_formicary.private = window.o_spa_formicary.private || {};
+    window.o_spa_formicary.private.jlineup = window.o_spa_formicary.private.jlineup || {};
+
+    window.o_spa_formicary.private.delegate = function (originalFunction) {
+        return function () {
+            var passedArguments = arguments;
+            return new Promise(function (resolve, reject) {
+                o_global.eventLoader.onAllScriptsExecuted(10, function () {
+                    window.o_spa_formicary.private[originalFunction].apply(null, passedArguments).then(resolve).catch(reject);
+                });
+            });
+        };
+    };
+
+    window.o_spa_formicary.private.delegateAndWrap = function (originalFunction) {
+        return function () {
+            var passedArguments = arguments;
+            return new Promise(function (resolve) {
+                o_global.eventLoader.onAllScriptsExecuted(10, function () {
+                    var result = window.o_spa_formicary.private[originalFunction].apply(null, passedArguments);
+                    resolve(result);
+                });
+            });
+        };
+    };
+
+    window.o_spa_formicary.api.initializeCinema = window.o_spa_formicary.private.delegateAndWrap('initializeCinema');
+    window.o_spa_formicary.api.loadSponsoredArticlesForDetailView = window.o_spa_formicary.private.delegate('loadSponsoredArticlesForDetailView');
+</script>
+
+    <link rel="preload" critical="critical" crossorigin="anonymous" href="/order/statics/ft1.order-core.common-public.9b8d052b.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/><link href="/order/statics/ft1.order-core.addtobasket.81254ed8.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/order/statics/ft1.order-core.addtobasket.81254ed8.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" crossorigin="anonymous" href="/order/statics/ft1.order-core.addtobasket.ab2e4750.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+        <link rel="preload" crossorigin="anonymous" href="/product-richcontent/ft5-richcontent.css" as="style" onload="invokePreload.onStyleLoad(this)"/>
+        <noscript><link rel="stylesheet" href="/product-richcontent/ft5-richcontent.css" crossorigin="anonymous"/></noscript>
+<div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">
+
+    <div class="pswp__bg"></div>
+
+    <div class="pswp__scroll-wrap">
+
+        <div class="pswp__container">
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+        </div>
+
+        <div class="pswp__ui pswp__ui--hidden">
+
+            <div class="pswp__top-bar">
+
+                <div class="pswp__preloader">
+                    <div class="pswp__preloader__icn">
+                        <div class="pswp__preloader__cut">
+                            <div class="pswp__preloader__donut"></div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="pswp__counter"></div>
+                <button class="pswp__button pswp__button--close" title="schlie&slig;en (Esc)">x</button>
+
+                <button class="pswp__button pswp__button--share" title="Share">?</button>
+                <button class="pswp__button pswp__button--fs" title="Toggle fullscreen">?</button>
+
+            </div>
+
+            <div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap">
+                <div class="pswp__share-tooltip"></div>
+            </div>
+
+            <button class="pswp__button pswp__button--arrow--left" title="zurück (Pfeiltaste links)">&lt;</button>
+
+            <button class="pswp__button pswp__button--arrow--right" title="weiter (Pfeiltaste rechts)">&gt;</button>
+
+            <div class="pswp__top-bar pswp__bottom-bar">
+                <div class="pswp__zoom-controls">
+                    <span>Zoom</span>
+                    <button class="pswp__button pswp__button--zoom pswp__button--zoom-out" title="verkleinern">-</i></button>
+                    <button class="pswp__button pswp__button--zoom pswp__button--zoom-in" title="vergr;&ouml;&slig;ern">p</button>
+                </div>
+            </div>
+
+            <div class="pswp__caption">
+                <div class="pswp__caption__center"></div>
+            </div>
+        </div>
+
+    </div>
+    <svg class="pswp__pinch-icon hidden" preserveAspectRatio="xMidYMin slice" width="20%" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 90.79"><path d="M13.91 53.12l3.48 4.73L0 59.5l1.84-18.74 4.44 4.44 14-14 8.11 8.11-7.82 8.5-2.75.1h-.34q-3.28.39-3.43 2.8zm30.42 37.67h28.5a46.09 46.09 0 0 0 5-13.28 91.07 91.07 0 0 0 1.93-13.62 94.4 94.4 0 0 0 .1-11.2q-.29-4.78-.48-6a3.6 3.6 0 0 0-2.46-3.43q-2.27-.82-2.37-.14t-.34 3.77a33 33 0 0 1-.63 4.64q-.39 1.74-1.69 1.45t-1.19-1.5q-.1-.48 0-4.93t0-6.08q.1-1.55-3-2.9t-3.37.43q-.1 1.74-.29 6a17.58 17.58 0 0 1-.87 5.7q-.87 1.06-1.5.43a2.39 2.39 0 0 1-.72-1.13q-.1-.39 0-6.42l.1-6q-.1-4.25-3.19-4.49t-3.57.82q-.39 1.06-.48 6.76a64.79 64.79 0 0 1-.4 7.33q-.29 1.64-1.5 1.35t-1.21-.87v-3.77-7.58-8-4.88q0-2.32-2-2.61l-2-.29q-3.28 0-3.86 1.5L42 23.37l-.14 4.2q-.14 4.2-.29 9.56t-.34 10.38q-.19 5-.19 6.76-.1 3.28-1 4.1l-.87.82a6 6 0 0 1-3.57.87 7 7 0 0 1-2.51-.68 32.66 32.66 0 0 1-3.57-3.24l-2.8-2.75a6.67 6.67 0 0 0-4.2-1.64l-1.88.1q-2.32.1-2.22 1.45l.1 1.35zm5.7-73a4.19 4.19 0 0 0-2.75-1.21h-1.5q-4.64 0-5.94 2.12l-1.3 2.12-.1 1.16q-.1 1.16-.19 5.89L31 20.19l14-14-4.43-4.45L59.4 0l-1.84 18.74-4.44-4.44z"/></svg>
+</div><link rel="preload" crossorigin="anonymous" href="/product/static/assets/ft5.detailview.body.f1427b2e.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+
+        <script type="text/javascript">
+        (function (loaderScript) {
+          "use strict";
+
+          var script, firstScript, parts, len, i, mpathyVersion;
+
+          function cookie(name) {
+            parts = document.cookie.split(/;\s*/);
+            len = parts.length;
+            name += '=';
+            for (i = 0; i < len; i += 1) {
+              if (parts[i].indexOf(name) !== -1) {
+                return parts[i].replace(name, '');
+              }
+            }
+          }
+
+          o_global.eventLoader.onLoad(99, function () {
+            if (o_global.mpathy.isEnabled()) {
+              if (cookie('trackingDisabled') !== "v1" && cookie('cb') !== undefined && cookie('cb') !== "0") {
+                mpathyVersion = cookie("mpathyVersion");
+                if (mpathyVersion !== undefined && /^[_0-9a-zA-Z/]*a2995_[0-9]+\.js$/.test(mpathyVersion)) {
+                  loaderScript = "//cdn.m-pathy.com/js/" + mpathyVersion;
+                }
+                script = document.createElement('script');
+                script.setAttribute('src', loaderScript);
+                script.setAttribute('type', 'text/javascript');
+                script.setAttribute('async', true);
+                script.setAttribute('crossorigin', 'anonymous');
+                firstScript = document.getElementsByTagName('script')[0];
+                firstScript.parentNode.insertBefore(script, firstScript);
+              }
+            }
+          });
+        }('//cdn.m-pathy.com/js/otto/a2995_2205301600.js'));
+        </script>
+
+<link href="/shoppages/static/assets/sho.shoppages.assets-public.c2691b52.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/shoppages/static/assets/sho.shoppages.assets-public.c2691b52.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" crossorigin="anonymous" href="/shoppages/static/assets/sho.shoppages.assets-public.21298cd5.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>    <div data-title="" data-callback="o_shoppages.layer.init">
+        <div class="shoppages shoppagesFragment">
+
+        </div>
+    </div>
+
+
+
+    </body>
+    </html>

--- a/extract/tests/otto/data/electronics-fridge.html
+++ b/extract/tests/otto/data/electronics-fridge.html
@@ -1,0 +1,2395 @@
+
+    <!DOCTYPE html>
+    <html data-pagecluster="Artikeldetailseite">
+    <head>
+        <title>Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit online kaufen | OTTO</title>
+        <meta charset="utf-8"/>
+        <script>
+"use strict";
+
+var o_global = o_global || {};
+
+o_global.toggles = Object.freeze({
+    "EMR_PXC": true,
+    "RUM_PageCluster": true,
+    "RUM_Viewport": true,
+    "EMR_MPATHY": true,
+    "tr_add_mini_actions": true,
+    "RUM_CustomEvents": true,
+    "IAB_FEATURE_ACTIVE": true,
+    "FTFIND_REMOVE_UNFILTERED_ON_BROWSER_BACK": false,
+    "FTFIND_JS_ERRORS": true,
+    "FT9_USE_SLIDESHOWLEVER_API": true,
+    "SCALE_SendUserTimings": true,
+    "RUM_SendErrorsWithoutStack": false,
+    "ENABLE_NEW_MAIN_LEVER_TRACKING": true,
+    "FEATURE_TRACKING_BENEFITS": true,
+    "RUM_Visibility": false,
+    "LHAS_2048_TRACK_COOKIES": false,
+    "quality_use_pass_proxy": true,
+    "RUM_RoundTripTime": true,
+    "FTFIND_ENABLE_SCROLL_RESTORE": true,
+    "FT6_EASTEREGGS": false,
+    "FT9_UP_TEASER_LAYER_TRACKING": true,
+    "RUM_DetailedPerformance": true,
+    "RUM_BasicInformation": true,
+    "nitro_js_enabled": true,
+    "ASSETS_POLYFILL_SERVICE_ENABLED": true,
+    "RUM_AssetX": false,
+    "FTFIND_JS_ERROR_COLORTHUMB": false,
+    "FTFIND_LATER_SCROLLTO_ON_ADS_BACK": true,
+    "RUM_DeviceInformation": true,
+    "DEBUG_TEST_TOGGLE_SERVICE": false,
+    "FT9_UP_TEASER_SHEET_SIGNUP_TRACKING": false,
+    "FT6_BEAT_FEATURE_TRACKING_CLICK": false,
+    "RUM_JavascriptErrors": true,
+    "EMR_PRELOAD_POLYFILL_DISABLE_FETCH": true,
+    "ENABLE_NEW_MAIN_LEVER_COPY": true,
+    "RUM_ScreenSize": false,
+    "USE_MOVE_TRACKING": false,
+    "tr_use_pass_proxy": false,
+    "EMR_RUM": true,
+    "RUM_Connection": false,
+    "RUM_ImportantPerformance": true,
+    "FTFIND46_ENABLE_INTERVAL_TRACKING": false,
+    "tr_disable_bct_requests": false,
+    "SCALE_SendRumData": true
+});
+</script>
+<script src="/assets-polyfills/assets.polyfills.head.js" crossorigin="anonymous"></script>
+
+<script>!function(){"use strict";function e(e){var t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:"success";"success"===t&&e.hasAttribute("noinvoke")?(e.removeAttribute("noinvoke"),window.invokePreload.setLifecycleData(e,"data-preloaded","noinvoke")):window.invokePreload.setLifecycleData(e,"data-preloaded",t),e.removeEventListener("load",window.invokePreload.onLoad),e.onload=null}function t(e){e.setAttribute("rel","stylesheet"),e.setAttribute("type","text/css"),e.setAttribute("media","all"),e.removeAttribute("as")}function o(e){var t=document.createElement("script"),o="\n  window.invokePreload.browserSupport.typemodule=".concat(e,';\n  window.invokePreload.browserSupport.detectionComplete=true;\n  document.dispatchEvent(new CustomEvent("PreloadFeatureDetectionComplete"));\n  ');e?t.type="module":t.setAttribute("nomodule","true");try{t.appendChild(document.createTextNode(o)),document.head.appendChild(t)}catch(e){t.text=o,document.head.appendChild(t)}}window.invokePreload=window.invokePreload||{},function(){var e,t={preload:!1,modulepreload:!1,typemodule:!1,dynamicimport:!1,detectionComplete:!1};window.invokePreload.browserSupport=t;try{var n=(e=document.createElement("link").relList)?{preload:e.supports("preload"),modulepreload:e.supports("modulepreload")}:{preload:!1,modulepreload:!1},r=n.modulepreload,d=n.preload;if(t.modulepreload=r,t.preload=d,t.modulepreload)return t.typemodule=!0,t.dynamicimport=!0,t.detectionComplete=!0,t;if(t.dynamicimport=function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"return import('data:text/javascript;base64,Cg==')";try{return new Function(e)(),!0}catch(e){return!1}}(),t.dynamicimport)return t.typemodule=!0,t.detectionComplete=!0,t;if(t.typemodule="noModule"in document.createElement("script")||([!1,!0].forEach(o),!1),t.typemodule)return t.detectionComplete=!0,t}catch(e){t.detectionComplete=!0}}(),window.invokePreload.setLifecycleData=function(e,t,o){e.setAttribute(t,o)},window.invokePreload.getLifeCycleData=function(e,t){return e.getAttribute(t)},window.invokePreload.onLoad=e,window.invokePreload.onScriptLoad=e,window.invokePreload.onScriptError=function(e){return window.invokePreload.onScriptLoad(e,"try-with-error")},window.invokePreload.onStyleLoad=function(e){return-1===[].map.call(document.styleSheets,(function(e){try{return"all"===e.media.mediaText?e.href:null}catch(e){return null}})).indexOf(e.href)&&(window.requestAnimationFrame?window.requestAnimationFrame((function(){return t(e)})):t(e)),e.removeAttribute("onload"),e};var n=document.createElement("script");!("noModule"in n)&&"onbeforeload"in n&&document.addEventListener("beforeload",(function(e){e.target.hasAttribute("nomodule")&&window.invokePreload.browserSupport.typemodule&&e.preventDefault()}),!0)}();
+
+//# sourceMappingURL=/assets-static/global-resources/assets.global-resources.preflight.nomodule.31c1a5d6.js.map
+</script><script src="/assets-static/global-resources/assets.global-resources.legacy.nomodule.1e7abb4b.js" crossorigin="anonymous" integrity="sha256-X8ODH/E+ZwlwrYijRDSIs6p7sEYkbVOGAZXDbreqsIQ=" nomodule=""></script>
+<link rel="stylesheet" href="/assets-static/global-resources/assets.global-resources.head.4127e24b.css" crossorigin="anonymous" integrity="sha256-JZfiz9BFZsALPa3u1Bg+HCP3N6ZjCIc6M8gEHGUl74c=">
+
+<script src="/assets-static/global-resources/assets.global-resources.head.nomodule.0a475768.js" crossorigin="anonymous" integrity="sha256-lFCvZpv5IsvPDr71CJ5RTFVzHpJOy0LCUWsdfVh9Bgc="></script>
+<link rel="preload" href="/assets-static/global-resources/assets.global-resources.fonts.607dafe6.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/assets-static/global-resources/assets.global-resources.fonts.607dafe6.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="preload" name="OttoSans" as="font" weight="400" crossorigin="anonymous" type="font/woff2" href="/assets-static/global-resources/assets/otto-sans_fb84ead3.woff2"/>
+<link rel="preload" name="OttoSans" as="font" weight="700" crossorigin="anonymous" type="font/woff2" href="/assets-static/global-resources/assets/otto-sans-bold_b7bb08ce.woff2"/>
+<link rel="preload" name="OttoSansThin" as="font" weight="400" crossorigin="anonymous" type="font/woff2" href="/assets-static/global-resources/assets/otto-sans-thin_f4c271f3.woff2"/>
+<link rel="preload" name="OttoIconFonts" as="font" weight="400" crossorigin="anonymous" type="font/woff2" href="/assets-static/global-resources/assets/OTTO-Icons_8a586867.woff2"/>
+<link rel="preload" name="OttoIcons" as="font" weight="400" crossorigin="anonymous" type="font/woff2" href="/assets-static/global-resources/assets/OTTO-Icons_8a586867.woff2"/>
+<link rel="preload" crossorigin="anonymous" href="/scale-shop-assets/scale.shop-assets.scale_beacon.8cbe987d.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link
+        rel="stylesheet"
+        href="/assets-static/global-pattern/assets.global-pattern.main.38488765.css"
+          crossorigin="anonymous"
+          integrity="sha256-qfGQ+aBCianJzswRGx8q/JslUBSt14GqvgiFWKy6zjM="
+      />
+    <script
+      src="/assets-static/global-pattern/assets.global-pattern.main.nomodule.fbe4b581.js"
+        crossorigin="anonymous"
+        integrity="sha256-8Kp8Xshu5bvf6+mdyoxU9R9i5wJ7RzGvmHqz2yMN2jo="
+></script>
+<link rel="shortcut icon" type="image/x-icon" href="/assets-static/global-favicons/favicon.ico">
+<link rel="icon" type="image/x-icon" href="/assets-static/global-favicons/favicon.ico">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon.png">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-57x57.png" sizes="57x57">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-60x60.png" sizes="60x60">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-72x72.png" sizes="72x72">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-76x76.png" sizes="76x76">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-114x114.png" sizes="114x114">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-120x120.png" sizes="120x120">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-128x128.png" sizes="128x128">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-144x144.png" sizes="144x144">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-152x152.png" sizes="152x152">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-180x180.png" sizes="180x180">
+<link rel="apple-touch-icon" href="/assets-static/global-favicons/apple-touch-icon-precomposed.png">
+<link rel="icon" type="image/png" href="/assets-static/global-favicons/favicon-16x16.png" sizes="16x16">
+<link rel="icon" type="image/png" href="/assets-static/global-favicons/favicon-32x32.png" sizes="32x32">
+<link rel="icon" type="image/png" href="/assets-static/global-favicons/favicon-96x96.png" sizes="96x96">
+<link rel="icon" type="image/png" href="/assets-static/global-favicons/favicon-160x160.png" sizes="160x160">
+<link rel="icon" type="image/png" href="/assets-static/global-favicons/favicon-192x192.png" sizes="192x192">
+<link rel="icon" type="image/png" href="/assets-static/global-favicons/favicon-196x196.png" sizes="196x196">
+<link rel="manifest" href="/assets-static/global-favicons/manifest.json">
+<meta name="msapplication-TileImage" content="/assets-static/global-favicons/ms-icon-144x144.png">
+<meta name="msapplication-TileColor" content="#ffffff">
+<meta name="msapplication-navbutton-color" content="#d52b1e">
+<meta name="msapplication-square70x70logo" content="/assets-static/global-favicons/ms-icon-70x70.png">
+<meta name="msapplication-square144x144logo" content="/assets-static/global-favicons/ms-icon-144x144.png">
+<meta name="msapplication-square150x150logo" content="/assets-static/global-favicons/ms-icon-150x150.png">
+<meta name="msapplication-wide310x150logo" content="/assets-static/global-favicons/ms-icon-310x150.png">
+<meta name="msapplication-square310x310logo" content="/assets-static/global-favicons/ms-icon-310x310.png">
+<meta name="theme-color" content="#f0f0f0">
+
+<link rel="stylesheet" href="/product/static/assets/ft5.detailview.head.6b642614.css" integrity="sha256-y8+LfR/BP/GIRp+bSQw8pXB8QH0CLtbA5XFBczKuOiY=" crossorigin="anonymous"/><meta name="description" content="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit für 1.999,00€. Nutzinhalt: 635 Liter, No Frost – nie wieder abtauen!, Metal Cooling bei OTTO"/>
+<meta name="robots" content="index,follow"/>
+<meta property="og:image" content="https://i.otto.de/i/otto/02f85090-393a-5bd1-b56a-bac9f66295f7/samsung-side-by-side-rs6ga884csl-178-cm-hoch-91-2-cm-breit.jpg?$formatz$">
+<meta property="og:title" content="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit online kaufen | OTTO">
+<meta property="og:description" content="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit für 1.999,00€. Nutzinhalt: 635 Liter, No Frost – nie wieder abtauen!, Metal Cooling bei OTTO">
+<meta property="og:url" content="https://www.otto.de/p/samsung-side-by-side-rs6ga884csl-178-cm-hoch-91-2-cm-breit-1524534276/">
+<meta property="og:site_name" content="OTTO">
+<meta property="og:type" content="product">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@otto_de">
+<meta name="twitter:description" content="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit für 1.999,00€. Nutzinhalt: 635 Liter, No Frost – nie wieder abtauen!, Metal Cooling bei OTTO">
+<meta name="twitter:image" content="https://i.otto.de/i/otto/02f85090-393a-5bd1-b56a-bac9f66295f7/samsung-side-by-side-rs6ga884csl-178-cm-hoch-91-2-cm-breit.jpg?$formatz$">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="canonical" href="https://www.otto.de/p/samsung-side-by-side-rs6ga884csl-178-cm-hoch-91-2-cm-breit-1524534276/"/>
+
+
+    <style>@charset "UTF-8";.cr_aggregation{display:inline-block;margin-top:8px}.cr_aggregation__starsWithAmount{cursor:pointer;text-decoration:none}.cr_aggregation__button{display:inline;margin-left:8px;width:auto}.cr_aggregation__amount,.cr_aggregation__label{text-decoration:underline}.cr_aggregation__label-icon{font-style:normal;vertical-align:bottom}.cr_aspectFilter{margin-top:32px}@media (min-width:48em){.cr_aspectFilter--old-{margin-top:16px}}.cr_aspectFilter__headline{font-size:14px;font-size:.875rem;line-height:1.4285714286em}.cr_aspectFilter__headline--old-design{font-weight:700}.cr_aspectFilter__buttons{overflow:hidden}.cr_aspectButton{-webkit-tap-highlight-color:transparent;background:#f3f1ec;background:-webkit-linear-gradient(180deg,#fefefe,#f3f1ec);background:linear-gradient(180deg,#fefefe,#f3f1ec);border:1px solid #c4c4c4;border-radius:3px;color:#333;cursor:pointer;float:left;font-size:12px;font-size:.75rem;height:31px;line-height:1.5em;margin:8px 8px 0 0;max-width:300px;outline:0 none;padding:5px 9px;text-align:center;text-decoration:none;vertical-align:baseline;white-space:nowrap}.cr_aspectButton:hover{background:#fefefe;color:#d5281e}.cr_aspectButton:last-of-type{margin:8px 16px 0 0}.cr_aspectButton--selected{border-color:#9e9e9e;cursor:auto}.cr_aspectButton--selected,.cr_aspectButton--selected:hover{background:#fff;background:-webkit-linear-gradient(180deg,#d7d5cf,#fff);background:linear-gradient(180deg,#d7d5cf,#fff);font-weight:700}.cr_aspectButton--selected:hover{color:inherit}.cr_aspectButton__text{display:inline-block;margin-right:4px;max-width:235px;overflow:hidden;text-overflow:ellipsis;vertical-align:bottom;white-space:nowrap}.cr_aspectDeselectLink{float:left;line-height:31px;margin-top:8px}.cr_histogram__row{display:table-row}.cr_histogram__row--clickable{cursor:pointer}.cr_histogram__row--clickable .cr_histogram__amount span{text-decoration:underline}.cr_histogram__row--selected .cr_histogram__amount,.cr_histogram__row--selected .cr_histogram__label{font-weight:700}.cr_histogram__row--selected .cr_bar{border:1px solid #777}.cr_histogram__row--selected .cr_bar__fill{background-color:#9e9e9e}.cr_histogram__row--selected .cr_histogram__amount span{text-decoration:none}@media (min-width:48em){.cr_histogram__row--selected .cr_histogram__deselect{display:table-cell}}.cr_histogram__amount,.cr_histogram__label,.cr_histogram__percent{display:table-cell;padding-top:12px;vertical-align:top}.cr_histogram__row:first-child .cr_histogram__amount,.cr_histogram__row:first-child .cr_histogram__deselect,.cr_histogram__row:first-child .cr_histogram__label,.cr_histogram__row:first-child .cr_histogram__percent{padding-top:0}.cr_histogram__amount,.cr_histogram__deselect,.cr_histogram__label{font-size:14px;font-size:.875rem;line-height:1.4285714286em;line-height:20px}.cr_histogram__amount,.cr_histogram__label,.cr_histogram__percent{padding-right:8px}.cr_bar{border:1px solid #c4c4c4;-moz-border-radius:2px;-webkit-border-radius:2px;border-radius:2px;height:20px;width:170px}.cr_bar__fill{background-color:#e6e6e6;height:100%}.cr_histogram__deselect{display:none;padding-top:12px;vertical-align:top}.cr_filterIndicator{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:16px 0 0}@media (min-width:48em){.cr_filterIndicator{display:inline-block;line-height:38px}}.cr_filterIndicator__deselect{white-space:nowrap}@media (min-width:48em){.cr_filterIndicator__deselect{display:none}}.cr_landingPage .cr_reviewHeadline__row--FEATURE_2065 .cr_reviewHeadline__starsWithAmount>*{display:inline-block;vertical-align:middle}@media (min-width:48em){.cr_landingPage .cr_histogram--old-design{float:left}.cr_landingPage .cr_aspectFilter--old-design{margin-left:480px}}.cr_landingPage .cr_filterWrapper{margin:16px 0 0;overflow:hidden}.cr_landingPage .cr_filterWrapper--old-design{margin:8px 0 0}.cr_landingPage .cr_priceAmount--reduced{color:#f00020}.cr_landingPage .cr_priceNote{display:block}.cr_landingPage .cr_productVariationImage{max-height:74px;max-width:74px}.cr_landingPage .cr_variationImage{display:inline;float:left;padding:0 0 0 8px}@media (min-width:28em){.cr_landingPage .cr_variationImage{padding:0 8px}}.cr_landingPage .cr_priceAndMoreVariationsLink{float:left}.cr_landingPage .cr_headLink{text-decoration:none}.cr_loadingSpinner{margin-bottom:8px;text-align:center}.cr_loadingSpinner__loader{display:inline-block}@media (min-width:48em){.cr_minimal .cr_histogram--old-design{float:left}.cr_minimal .cr_aspectFilter--old-design{margin-left:360px}}.cr_minimal .cr_reviewList{margin:32px 0 24px}.cr_minimal .cr_filterWrapper{margin:16px 0 0;overflow:hidden}.cr_minimal .cr_filterWrapper--old-design{margin:8px 0 0}.cr_moreReviewsButton{max-width:350px}.cr_paging{margin-bottom:8px;overflow:hidden;text-align:center}@media (min-width:48em){.cr_paging{float:right;width:310px}}.cr_paging__button{width:auto}.cr_paging__button--first,.cr_paging__button--prev{float:left;margin-left:8px}.cr_paging__button--last,.cr_paging__button--next{float:right;margin-right:8px}.cr_paging__currentPage{font-size:14px;font-size:.875rem;line-height:1.4285714286em;line-height:30px}.cr_reportReviewLayer{font-size:14px;font-size:.875rem;line-height:1.4285714286em;overflow:hidden}.cr_reportReviewLayer--success .cr_reportReviewLayer__surveyWrapper{display:none}.cr_reportReviewLayer--success .cr_reportReviewLayer__successWrapper{display:block}.cr_reportReviewLayer__error{display:none;margin-bottom:16px}.cr_reportReviewLayer__request{font-weight:700;margin:0}.cr_reportReviewLayer__survey{margin-top:10px}.cr_reportReviewLayer__textarea{margin-top:8px}.cr_reportReviewLayer__disclaimer,.cr_reportReviewLayer__feedbackIndication,.cr_reportReviewLayer__guidelines{font-size:12px;font-size:.75rem;line-height:1.5em}.cr_reportReviewLayer__feedbackIndication{margin:8px 0 0}.cr_reportReviewLayer__feedbackIndication--success{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:16px 0 0}.cr_reportReviewLayer__disclaimer,.cr_reportReviewLayer__guidelines{display:block;margin-top:8px}@media (min-width:48em){.cr_reportReviewLayer__disclaimer{float:left;line-height:40px;margin-top:16px}}.cr_reportReviewLayer__button{margin-top:16px}@media (min-width:48em){.cr_reportReviewLayer__button{float:right;max-width:160px}}.cr_reportReviewLayer__successWrapper{display:none}.cr_reviewHeadline{position:relative}.cr_reviewHeadline__headline{margin-top:16px}.cr_reviewHeadline__headline--FEATURE_2065{font-family:OttoSansThin,OTTOSans,Arial,Helvetica,sans-serif;font-size:22px;font-size:1.375rem;line-height:1.2727272727em;margin-top:24px}@media (min-width:48em){.cr_reviewHeadline__headline--FEATURE_2065{font-size:26px;font-size:1.625rem;line-height:1.2307692308em}}.cr_reviewHeadline__recommendation{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:8px 0 0}.cr_reviewHeadline__recommendation.cr_reviewHeadline__recommendation--FEATURE_2065{margin:12px 0 0}.cr_reviewHeadline__row{overflow:hidden}.cr_reviewHeadline__starsWithAmount{float:left;margin-top:19px;white-space:nowrap}.cr_reviewHeadline__row--FEATURE_2065 .cr_reviewHeadline__starsWithAmount{margin-top:16px}.cr_reviewHeadline__row--FEATURE_2065 a.cr_reviewHeadline__starsWithAmount{cursor:pointer;text-decoration:none}.cr_reviewHeadline__amount{margin:0 8px 0 4px;vertical-align:text-bottom}.cr_reviewHeadline__row--FEATURE_2065 .cr_reviewHeadline__amount{margin:4px}.cr_reviewHeadline__label{text-decoration:underline;vertical-align:text-bottom}.cr_reviewHeadline__label-icon{font-style:normal;vertical-align:baseline}.cr_reviewHeadline__amount--clickable{cursor:pointer;text-decoration:underline}.cr_reviewHeadline__submitReviewButton{margin-top:8px;width:auto}.cr_reviewHeadline__row--FEATURE_2065 .cr_reviewHeadline__submitReviewButton{margin-top:0}.cr_reviewHeadline__submitReviewButton--old{margin-top:16px}.cr_reviewHeadline__submitReviewButton--floating{margin:12px 0 0}@media (min-width:48em){.cr_reviewHeadline__submitReviewButton--floating{margin:0;position:absolute;right:0;top:0}}.cr_reviewHeadline__submitReviewStar{margin-right:2px}.cr_reviewHeadline__submitReview{display:inline-block;float:right;margin-top:16px}.cr_reviewHeadline__noReviews{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:8px 0 0}.cr_reviewHeadline__submitReview--noReviews{float:none;margin:8px 0}#cr_reviewErrorContainer{display:none;margin-bottom:8px}#cr_js_topReviews{overflow:hidden}.cr_reviewList{margin:16px 0 24px;position:relative}@media (min-width:48em){.cr_reviewList{margin:24px 0 32px}}.cr_review{font-size:14px;font-size:.875rem;line-height:1.4285714286em}.cr_review__stars{margin-right:8px}.cr_review__stars--error{color:#f00020}.cr_review__title{display:inline;font-size:14px;font-size:.875rem;font-weight:700;line-height:1.4285714286em}.cr_review__helpfulSummary{display:block;font-size:12px;font-size:.75rem;line-height:1.5em;margin-top:2px}@media (min-width:48em){.cr_review__helpfulSummary--SandM{display:none}}.cr_review__helpfulSummary--LandXL{display:none}@media (min-width:48em){.cr_review__helpfulSummary--LandXL{display:block}}.cr_review__text{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:12px 0 0}.cr_review__reviewer{display:block;font-size:12px;font-size:.75rem;line-height:1.5em;margin-top:12px}.cr_review__reviewerName{font-weight:700}.cr_review__partner{display:block;font-size:12px;font-size:.75rem;line-height:1.5em}.cr_review__partnerName{font-weight:700}.cr_review__dimensions{display:block}.cr_review__dimensions,.cr_review__helpfulSubmit{font-size:12px;font-size:.75rem;line-height:1.5em}.cr_review__helpfulSubmit{display:inline-block;margin:8px 0 0}.cr_review__verifiedPurchase{margin-top:2px}.cr_review__verifiedPurchaseText{color:#50cc7f;font-size:12px;font-size:.75rem;line-height:1.5em}.cr_review__verifiedPurchaseIcon{fill:#50cc7f;vertical-align:middle}.cr_review__verifiedPurchaseInfo{font-size:14px;font-size:.875rem;line-height:1.4285714286em}.cr_review__verifiedPurchaseInfoText{color:#50cc7f}.cr_review__verifiedPurchaseInfoIcon{fill:#50cc7f;height:14px;vertical-align:text-bottom;width:14px}.cr_helpfulSubmit{margin-left:4px;white-space:nowrap}.cr_helpfulSubmit__button{display:inline-block;width:auto}.cr_helpfulSubmit__button:first-child{margin-right:4px}.cr_reportReviewLink{display:inline-block;font-size:12px;font-size:.75rem;line-height:1.5em;margin-top:12px;white-space:nowrap}@media (min-width:28em){.cr_reportReviewLink{display:inline;margin-left:12px;margin-top:0}}.cr_review__line{margin:16px 0!important}@media (min-width:48em){.cr_review__line{margin:24px 0!important}}.cr_bi-review:before{display:inline-block;float:left;font-family:OttoIcons,Arial,Helvetica,sans-serif;font-size:20px;font-size:1.25rem}.cr_bi-review>*{margin-left:28px}.cr_bi-review .cr_reportReviewLink,.cr_bi-review .cr_review__helpfulSubmit{display:none}.cr_bi-review.cr_review--expanded .cr_reportReviewLink,.cr_bi-review.cr_review--expanded .cr_review__helpfulSubmit{display:inline-block}.cr_bi-review--positive:before{color:#417505;content:"↑"}.cr_bi-review--negative:before{color:#ba0019;content:"↓"}.cr_bi-review--neutral:before{content:"→"}.cr_review__text--afterOccurrence,.cr_review__text--beforeOccurrence{display:none}.cr_review--expanded .cr_review__text--afterOccurrence,.cr_review--expanded .cr_review__text--beforeOccurrence{display:inline}.cr_review__highlightedWord{font-weight:700}.cr_review__highlightedWord--negative{color:#ba0019}.cr_review__highlightedWord--positive{color:#417505}.cr_review__moreLink:after{content:"...Mehr"}.cr_review--expanded .cr_review__moreLink:after{content:"...Weniger"}.cr_aspectHeader{margin-top:24px;overflow:hidden}.cr_aspectHeader__name{display:inline-block;font-size:16px;font-size:1rem;font-weight:700;line-height:1.375em;margin-right:9px;vertical-align:middle}.cr_aspectTypeDistribution{cursor:default;display:inline-block;vertical-align:middle}.cr_aspectTypeDistribution__item{display:inline-block;font-size:16px;font-size:1rem;font-weight:700;line-height:1.375em;line-height:26px;vertical-align:middle}.cr_aspectTypeDistribution__item:not(:last-child){margin-right:10px}.cr_aspectTypeDistribution__icon{font-size:20px;font-style:normal;font-weight:400;margin-right:-3px;vertical-align:bottom}.cr_aspectTypeDistribution__icon--positive{color:#417505}.cr_aspectTypeDistribution__icon--negative{color:#ba0019}.cr_sortingForm{display:block;margin-top:16px}@media (min-width:28em){.cr_sortingForm--old-design{text-align:right}}@media (min-width:48em){.cr_sortingForm--old-design{display:inline-block;float:right}}.cr_sortingForm__label{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin-right:8px}.cr_sortingForm__select{display:inline-block;width:auto}.cr_filterIndicatorAndSortingWrapper{overflow:hidden}.reviewSubmitLayer a.overlay{color:#777;display:inline-block;margin-top:16px}.reviewSubmitLayer .label{margin-bottom:4px}.reviewSubmitLayer .reviewContent p{margin-top:15px}.reviewSubmitLayer .reviewContent .cr_reviewImage img{height:164px;width:164px}.reviewSubmitLayer .reviewContent .cr_reviewDimensions{flex:1;vertical-align:top}.reviewSubmitLayer .reviewContent .cr_reviewImageContainer{display:flex}.reviewSubmitLayer .reviewContent .cr_reviewTextContainer{margin-bottom:12px!important}.reviewSubmitLayer .reviewContent .recommended{margin:8px 0}.reviewSubmitLayer .reviewContent .radio-option{margin-right:40px}.reviewSubmitLayer .reviewContent .star-empty{background-image:url(/assets-static/icons/pl_icon_rating-empty.svg)}.reviewSubmitLayer .reviewContent .star-empty,.reviewSubmitLayer .reviewContent .star-filled{background-position:0;background-repeat:no-repeat;background-size:24px;cursor:pointer;padding:14px 38px 14px 0}.reviewSubmitLayer .reviewContent .star-filled{background-image:url(/assets-static/icons/pl_icon_rating-filled.svg)}.reviewSubmitLayer .reviewContent .left{float:left}.reviewSubmitLayer .reviewContent .right{float:right}.reviewSubmitLayer .reviewContent form{float:left;margin:0 0 15px}@media (min-width:48em){.reviewSubmitLayer .reviewContent .selectBoxWrapper{width:50%}.reviewSubmitLayer .reviewContent .selectBoxWrapper:nth-child(2n){padding-left:4px}.reviewSubmitLayer .reviewContent .selectBoxWrapper:nth-child(odd){padding-right:4px}.reviewSubmitLayer .reviewContent .footer button{width:auto}}</style>
+
+
+
+        <script type="application/ld+json">
+              {
+  "@context": "https://schema.org/",
+  "@type": "Product",
+  "gtin13": "8806092536593",
+  "sku": "61094760",
+  "name": "Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit",
+  "description": "<p>Der Side-by-Side Kühlschrank »RS6GA884CSL« von Samsung hat eine hohe Funktionalität sowie die Energieeffizienz-Klassifizierung C (Skala Energieeffizienz-Klassifizierung Einheitsskala (A bis G)) und ist freistehend. Die Maße des Side-by-Side Kühlschranks liegen bei 91,2 x 178 x 73,5 cm (B/H/T). Durch die No Frost-Funktion muss das Gerät nie wieder abgetaut werden. Das Gerät verfügt auch über einen Wasserspender. Durch den Festwasseranschluss ist ganz ohne Nachfüllen immer genug gekühltes Wasser auf Lager. Zwei Gefrierschubladen und vier Gemüseschubladen stehen zur Verfügung, um Nahrungsmittel zu verstauen. Die Temperatur im Gerät wird auf dem innen installierten Display angezeigt. Auf fünf Ablageflächen ist im Side-by-Side Kühlschrank viel Platz für Lebensmittel. Die fünf Türablagen ermöglichen eine übersichtliche Lagerung. Bei offen stehender Tür meldet dies der Side-by-Side Kühlschrank mit einem Warnsignal. Den Überblick behält man außerdem durch die LED-Innenbeleuchtung. Wer auf der Suche ist nach einem Gerät, das ausreichend Platz für Lebensmittel bietet, der trifft mit dem »RS6GA884CSL« von Samsung eine gute Wahl.</p>",
+  "image": [
+    "https://i.otto.de/i/otto/02f85090-393a-5bd1-b56a-bac9f66295f7/samsung-side-by-side-rs6ga884csl-178-cm-hoch-91-2-cm-breit.jpg?$formatz$",
+    "https://i.otto.de/i/otto/e1f3b715-0081-5df1-9d50-14c19bc476e8/samsung-side-by-side-rs6ga884csl-178-cm-hoch-91-2-cm-breit.jpg?$formatz$",
+    "https://i.otto.de/i/otto/5d309975-6917-5f9e-b206-a1c99e83411c/samsung-side-by-side-rs6ga884csl-178-cm-hoch-91-2-cm-breit.jpg?$formatz$"
+  ],
+  "offers": {
+    "@type": "Offer",
+    "url": "/p/samsung-side-by-side-rs6ga884csl-178-cm-hoch-91-2-cm-breit-1524534276/",
+    "priceCurrency": "EUR",
+    "price": "1999.00",
+    "itemCondition": "http://schema.org/NewCondition",
+    "availability": "https://schema.org/InStock"
+  },
+  "brand": {
+    "@type": "Brand",
+    "name": "Samsung"
+  }
+}
+            </script>
+    </head>
+
+    <body class="product-system so_footerswitch" data-productjsloaded="true" itemscope itemtype="http://schema.org/Product">
+        <div class="javascriptUriTemplate" data-uritemplate="/product/static-assets/a8d974f65f1d57ddf6904353f1e13889/{type}/{ident}.{extension}"></div>
+        <div class="ts-bct" data-ts_sfid="4b83ce0f6bd9e4f9dc5f7992490c2f35379075084"></div>
+        <div class="gridAndInfoContainer">
+            <div class="gridContainer reducedOuterPadding wrapper">
+                <header class="withSubMenu">
+    <link rel="stylesheet" href="/walkingstick/grasshopper/ftfind.grasshopper.head.8159bab4.css" integrity="sha256-kysGnuRNtRcl17A3YFrlEzsULc2QySHIUjDnQKQWQBs=" crossorigin="anonymous"/>
+    <link rel="preload" href="/walkingstick/locust/reptile.locust.head.bacc537a.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/walkingstick/locust/reptile.locust.head.bacc537a.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/walkingstick/locust/reptile.locust.head.module.86f7d709.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/walkingstick/locust/reptile.locust.head.nomodule.bcb4befb.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+    <div class="find_header js_find_header find_header--hideSearchIconOnTop">
+        <div class="find_headerContent">
+        <div class="find_mobileMenuWrapper">
+    <nav class="nav_menu-toggle-button" id="nav_menu-toggle-button"><p class="nav_menu-toggle-button__icon"></p><p class="nav_menu-toggle-button__title-closed">Sortiment</p><p class="nav_menu-toggle-button__title-open" style="display:none;">Schließen</p></nav>
+        </div>
+        <div class="find_ottoLogo" data-qa="ftfind-otto-logo-wrapper">
+            <a href="/" data-tracking="{&quot;san_Header&quot;:&quot;logo&quot;}" title="zur Homepage">
+                <svg class="san-svg" width="100%" height="100%" viewBox="0 0 140 52">
+                    <path d="M121.136,2.75c-6.876,0-12.469,2.12-16.42,6.508c0.562-1.523,0.858-3.381,0.897-5.569H81.517 c-5.258,0-8.263,2.315-10.329,8.262l1.065-8.262H47.905c-4.458,0-7.518,2.131-8.624,6.305C36.264,5.159,30.902,2.75,24.12,2.75 c-12.893,0-21.281,7.449-22.783,23.346L1.15,28.1c-1.314,14.209,6.134,21.219,17.712,21.219c12.895,0,21.282-7.513,22.784-23.41 l0.188-2.002c0.339-3.646,0.091-6.814-0.655-9.515h10.919l-3.129,26.79c-0.626,5.32,2.253,7.761,7.072,7.761 c2.942,0,3.943-0.188,5.07-0.375l3.881-34.176h12.707l-3.131,26.79c-0.625,5.32,2.254,7.761,7.073,7.761 c2.941,0,3.943-0.188,5.069-0.375l3.881-34.176h6.26c2.165,0,3.913-0.503,5.264-1.498c-1.97,3.473-3.257,7.858-3.763,13.203 L98.166,28.1c-1.314,14.209,6.133,21.219,17.712,21.219c12.896,0,21.281-7.513,22.783-23.41l0.188-2.002 C140.164,9.76,132.716,2.75,121.136,2.75z M28.94,23.03l-0.126,1.502c-0.875,10.765-4.381,14.083-8.699,14.083 c-3.881,0-6.634-2.628-6.071-9.638l0.124-1.565c0.877-10.704,4.382-14.083,8.701-14.083C26.687,13.328,29.503,16.02,28.94,23.03z M125.957,23.03l-0.126,1.502c-0.877,10.765-4.381,14.083-8.699,14.083c-3.882,0-6.637-2.628-6.072-9.638l0.125-1.565 c0.876-10.704,4.381-14.083,8.7-14.083C123.702,13.328,126.519,16.02,125.957,23.03z"/>
+                    <image class="san-svg" src="/san/resources/san/img/header/otto_logo_2015.png"/>
+                </svg>
+            </a>
+        </div>
+    <link rel="stylesheet" href="/stomachshop/squirrel.stomachshop.resources.8c5daae2.css" crossorigin="anonymous" integrity="sha256-rRwTqaseBG0rVHjrtzb9PxONRBkvVxWUjEnCGr6UIjY=">
+
+<script src="/stomachshop/squirrel.stomachshop.resources.nomodule.0bed790c.js" crossorigin="anonymous" integrity="sha256-BU5uEsq910WMRaJed8O+FAaEXBkfINJzZMv9lbRB19U="></script>
+
+<div class="squirrel_searchContainer js_squirrel_searchContainer js_squirrel_ignore_close_suggest">
+    <div class="squirrel_searchbarWrapper js_squirrel_ignore_close_suggest" data-qa-id="search-field-wrapper" data-qa="ftfind-search-wrapper">
+        <form class="js_squirrel_searchForm" action="/suche" data-article-number-search="/p/search/">
+            <div class="squirrel_searchline">
+                <div class="squirrel_searchbar js_squirrel_searchbar js_squirrel_ignore_close_suggest">
+                    <input class="squirrel_searchbar__input js_squirrel_searchbar__input js_squirrel_ignore_close_suggest"
+                           data-qa-id="search-field" data-qa="ftfind-search-field"
+                           type="text" placeholder="Wonach suchst du?"
+                           autocomplete="off"
+                           autocorrect="off" maxlength="50" disabled="disabled"/>
+                    <div class="squirrel_searchbar__delete js_squirrel_searchbar__delete" data-qa-id="search-field-reset">
+                        <svg class="pl_icon" data-qa="ftfind-search-reset" role="img">
+                            <use xlink:href="/assets-static/icons/pl_icon_close.svg#pl_icon_close"/>
+                        </svg>
+                    </div>
+                    <div class="squirrel_searchbar__submit js_squirrel_searchbar__submit" data-qa-id="search-field-submit">
+                        <svg class="pl_icon" data-qa="ftfind-search-submit" role="img">
+                            <use xlink:href="/assets-static/icons/pl_icon_search.svg#pl_icon_search"/>
+                        </svg>
+                    </div>
+                </div>
+                <span class="squirrel_searchline__abort js_squirrel_searchline__abort">Abbrechen</span>
+            </div>
+        </form>
+        <div class="squirrel_searchSuggestionsContainer js_squirrel_searchSuggestionsContainer js_squirrel_ignore_close_suggest"
+             data-qa-id="search-suggestions"
+             data-suggestserveruri="/san-squirrel-suggest-api/completion"
+             data-suggestscope="//catalog01/de_DE">
+            <!-- insert template searchSuggest.mustache -->
+        </div>
+    </div>
+    <div class="squirrel_searchCurtain js_squirrel_searchCurtain"></div>
+</div>
+<script type="text/javascript">
+  if (!!o_squirrel && !!o_squirrel.searchHandler) {
+    o_squirrel.searchHandler.init();
+  }
+</script>
+
+        <div class="find_headerIcons">
+            <div class="find_headerIcon find_searchIcon">
+    <div class="squirrel_searchIcon js_squirrel_searchIcon">
+    <span class="p_icons squirrel_searchIcon__icon">»</span>
+    <span class="squirrel_searchIcon__label">Suche</span>
+</div>
+<script type="text/javascript">
+  if (!!o_squirrel && !!o_squirrel.searchbar) {
+    o_squirrel.searchbar();
+  }
+</script>
+
+            </div>
+            <div class="find_headerIcon find_serviceIcon">
+                <a id="serviceLink" href="/shoppages/service/"
+                   data-tracking="{&quot;san_Header&quot;:&quot;service&quot;}">
+                    <span class="p_icons find_headerIcon__icon">s</span>
+                    <span class="find_headerIcon__label">Service</span>
+                </a>
+            </div>
+            <div class="find_headerIcon find_userIcon">
+    
+<div id="us_js_id_loginAreaContainerWrapper" class="us_loginAreaContainerWrapper" style="visibility: hidden">
+    <div id="us_js_id_loginAreaContainerToReplace" class="us_loginAreaContainerBackground">
+        <a class="us_loginAreaFallbackLink" href="/user/accountOverview">
+            <span class="p_icons us_loginAreaContainerIcon">Θ</span>
+            <span class="us_iconSubtitle">Mein Konto</span>
+        </a>
+    </div>
+<link href="/user/assets/ft4.user.login-area.a5a182bf.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/user/assets/ft4.user.login-area.a5a182bf.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" crossorigin="anonymous" href="/user/assets/ft4.user.login-area.3b346b0d.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/></div>
+
+            </div>
+            <div class="find_headerIcon find_wishlistIcon">
+    <link rel="stylesheet" href="/wishlist-view/statics/ft1.wishlist-view.miniWishlist.6306a45b.css" crossorigin="anonymous" integrity="sha256-rTxcaUP2bC2z4qiavRGCDr/kM3DYsLwFH2PxIbJHYuw=">
+
+<link rel="modulepreload" href="/wishlist-view/statics/ft1.wishlist-view.miniWishlist.module.24299b32.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/wishlist-view/statics/ft1.wishlist-view.miniWishlist.nomodule.711da6fd.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+
+<span style="display: none" class="wl_toggleInfo"
+      data-toggles-active="REMOVE_UP_DELIVERY_FLAT_VARIATION">
+</span>
+<a href="/wishlist-view/" class="wl_mini__link">
+    <div class="wl_mini wl_js_mini_link "
+         title="Mein Merkzettel">
+        <span class="p_icons wl_mini__icon">&hearts;</span>
+        <span class="wl_mini__badge pl_badge--grey wl_mini__badge--empty wl_js_mini_amount"
+              data-qa="miniWishlistAmount"
+              data-amount-url="/wishlist-view/mini/amount.json">
+    </span>
+        <span class="wl_mini__text">Merkzettel</span>
+    </div>
+</a>
+
+            </div>
+            <div class="find_headerIcon find_basketIcon">
+    
+<link rel="preload" critical="critical" crossorigin="anonymous" href="/order/statics/ft1.order-core.common-public.9b8d052b.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/><link rel="stylesheet" href="/order/statics/ft1.order-core.minibasket.32c2269d.css" integrity="sha256-R9uwmcwZ4eqo7cu5aHbpt5uIZa1YiAlunjUcLe0328w=" crossorigin="anonymous"/>
+<link rel="preload" crossorigin="anonymous" href="/order/statics/ft1.order-core.minibasket.95d21f5b.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/><div class="or_minis or_minibasket order_js_minibasket_link ub64e ts-link"
+     data-ub64e="L29yZGVyL2Jhc2tldA=="
+     data-ts-link='{"san_Header":"basket"}'
+     title="Zum Warenkorb">
+
+    <span class="p_icons or_minis__icon">+</span>
+    <span class="or_minis__badge or_minis__badge--empty p_badge100 order_js_minibasket_amount"
+          data-loadurl="/order/basket/amount.json"
+          data-qa="miniBasketAmount"></span>
+    <span class="or_minis__text">Warenkorb</span>
+</div>
+
+
+<div id="order_js_settings" data-settings="TEST_USERS_ARE_ALWAYS_VERIFIED_CUSTOMERS,FT1_ENABLE_FEATURE_TRACKING" ></div>
+            </div>
+        </div>
+        </div>
+    </div>
+
+    <div class="nav_menu nav_menu--invisible" id="nav_menu" style="display: none;"><div class="nav_level-container nav_level-container--level-1"><div class="nav_navi-panel nav_navi-panel--level-1 nav_navi-panel--full-screen nav_navi-panel--with-bottom-divider" data-nav-swipe-status="initial"><div class="nav_navi-panel__body"><ul class="nav_navi-list nav_navi-list--level-1 nav_navi-list--tiles-layout nav_navi-list--bottom-spacing"><li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-1" data-nav-down-link="/nav-chekov/menu-fragment/(und.(oder.(ist.thema.thmntag_neuheit).(ist.trend.pride)).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:1,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Inspiration&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;inspiration&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:1,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Inspiration&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;inspiration&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/inspiration/"><span class="nav_navi-elem__tile-title">Inspiration</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/001_2020_05_kamp_ir01_thementeaser_quadratisch_54247/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-1" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.accessoires.augenpflege.bademode.bartpflege.bekleidung.erotik.gepaeck.gesichtspflege.haarentfernung.haarpflege.haarstyling.hautpflege.make-up.manikuere-pedikuere.parfums.schmuck.sonnenpflege.taschen-rucksaecke.waesche.zahnpflege).(ist.zielgruppe.damen).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:2,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Damen&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;damen&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:2,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Damen&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;damen&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/damen/"><span class="nav_navi-elem__tile-title">Damen</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/cd05c6c6-8692-5b95-95c3-c221f3e2a99c/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-1" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.accessoires.augenpflege.bademode.bartpflege.bekleidung.erotik.gepaeck.gesichtspflege.haarentfernung.haarpflege.haarstyling.hautpflege.make-up.manikuere-pedikuere.parfums.schmuck.sonnenpflege.taschen-rucksaecke.waesche.zahnpflege).(ist.zielgruppe.herren).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:3,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Herren&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;herren&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:3,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Herren&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;herren&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/herren/"><span class="nav_navi-elem__tile-title">Herren</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/28397874/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-1" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.accessoires.bademode.bekleidung.gepaeck.schmuck.taschen-rucksaecke.waesche).(ist.zielgruppe.jungen.maedchen).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:4,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Kinder&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;kindermode&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:4,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Kinder&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;kindermode&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/?selektion=(und.(ist.sortiment.accessoires.bademode.bekleidung.gepaeck.schmuck.taschen-rucksaecke.waesche).(ist.zielgruppe.jungen.maedchen).(~.(v.1)))"><span class="nav_navi-elem__tile-title">Kinder</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/307b2380-0331-5b49-bfbb-6d606ff15bf6/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-1" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.bademode.waesche).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:5,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;W\u00e4sche\/Bademode&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;waesche-bademode&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:5,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;W\u00e4sche\/Bademode&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;waesche-bademode&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/mode/waesche-bademode/"><span class="nav_navi-elem__tile-title nav_navi-elem--wbr">Wäsche/<wbr />Bademode</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/e217dc5d-7741-579c-aa44-555000e3f458/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-1" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.thema.sport).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:6,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Sport&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;sport&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:6,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Sport&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;sport&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/sport/"><span class="nav_navi-elem__tile-title">Sport</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/18517368/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-1" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.bekleidung).(sind.kategorien.schuhe).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:7,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Schuhe&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;schuhe&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:7,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Schuhe&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;schuhe&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/mode/schuhe/"><span class="nav_navi-elem__tile-title">Schuhe</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/c8ae0890-fc5d-5ba6-8571-51eeb1fa082b/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-1" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.grossegroesse).(ist.zielgruppe.damen.herren).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:8,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Gro\u00dfe Gr\u00f6\u00dfen&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;grosse-groessen&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:8,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Gro\u00dfe Gr\u00f6\u00dfen&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;grosse-groessen&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/mode/?grossegroesse"><span class="nav_navi-elem__tile-title">Große Größen</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/2fbee55d-4d4e-574d-914f-11b50625be5f/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.buerotechnik.kommunikation.medien.navigation.optik.technik-zubehoer.unterhaltungselektronik).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:9,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Multimedia&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;multimedia&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:9,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Multimedia&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;multimedia&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/technik/multimedia/"><span class="nav_navi-elem__tile-title">Multimedia</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/34177157/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.augenpflege.bartpflege.erotik.gesichtspflege.gesundheitsprodukte.haarentfernung.haarstyling.haushaltsgeraete.haushaltswaren.hautpflege.lebensmittel.make-up.manikuere-pedikuere.parfums.pflegemittel.reinigungsgeraete.sonnenpflege.zahnpflege).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:10,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Haushalt&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;haushalt&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:10,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Haushalt&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;haushalt&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/haushalt/"><span class="nav_navi-elem__tile-title">Haushalt</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/20608712/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.raum.kueche).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:11,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;K\u00fcche&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;kueche&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:11,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;K\u00fcche&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;kueche&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/moebel/?ansicht=einstieg&amp;thema=kueche"><span class="nav_navi-elem__tile-title">Küche</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/35333038/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ansicht.variante).(oder.(ist.sortiment.heimtextilien).(und.(ist.sortiment.moebel).(sind.kategorien.lattenroste)).(und.(ist.sortiment.waesche).(sind.kategorien.bademaentel))).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:12,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Heimtextilien&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;heimtextilien&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:12,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Heimtextilien&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;heimtextilien&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/heimtextilien/?ansicht=einstieg"><span class="nav_navi-elem__tile-title">Heimtextilien</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/18763571/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ansicht.variante).(ist.sortiment.aufbewahrung.beleuchtung.dekoration.haushaltswaren.heimtextilien.moebel).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:13,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;M\u00f6bel&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;moebel&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:13,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;M\u00f6bel&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;moebel&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/moebel/?ansicht=einstieg"><span class="nav_navi-elem__tile-title">Möbel</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/19992267/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(oder.(ist.sortiment.autozubehoer.bauelemente.baumaschinen.baumaterialien.bewaesserung.bodenbelaege.eisenwaren.elektroinstallation.fahrzeuge.farben-lacke.gartengeraete.gartengestaltung.gebaeude.heizen-klima.insektenschutz.pflanzenpflege.pools.sanitaer.sicherheitstechnik.sonnenschutz.tierbedarf.werkzeug).(und.(ist.sortiment.heimtextilien).(oder.(sind.kategorien.auflagen.gartenliegenauflagen).(sind.kategorien.duschvorhaenge).(sind.kategorien.rollos).(sind.kategorien.tapeten))).(und.(ist.sortiment.reinigungsgeraete).(oder.(sind.kategorien.besen.akkubesen).(sind.kategorien.besen.dampfbesen).(sind.kategorien.dampfreiniger).(sind.kategorien.hochdruckreiniger).(sind.kategorien.kehrmaschinen).(sind.kategorien.sauger.dampfsauger).(sind.kategorien.sauger.nass-trockensauger)))).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:14,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Baumarkt&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;baumarkt&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:14,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Baumarkt&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;baumarkt&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/baumarkt/"><span class="nav_navi-elem__tile-title">Baumarkt</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/2e04cc29-0785-5cbf-ad7b-24c9bc19c946/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.accessoires.beauty.bekleidung.buerotechnik.moebel.sanitaer.schmuck.taschen-rucksaecke.uhren.unterhaltungselektronik).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:15,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Marken&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;marken&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:15,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Marken&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;marken&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/marken/"><span class="nav_navi-elem__tile-title">Marken</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/001_2020_28_kund_repraesentant_fuer_marken_kleine_shoppromotion_72615/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.sortiment.spielzeug).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:16,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;Spielzeug&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;spielzeug&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:16,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;Spielzeug&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;spielzeug&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/spielzeug/"><span class="nav_navi-elem__tile-title">Spielzeug</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/14539649/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> <li><a class="nav_navi-elem nav_navi-elem--tile nav_navi-elem--level-1 nav_navi-elem--row-2" data-nav-down-link="/nav-chekov/menu-fragment/(und.(ist.reduziert).(~.(v.1)))/?embeddingDepth=0" data-nav-tracking-down="{&quot;trackingType&quot;:&quot;EVENT&quot;,&quot;labels&quot;:{&quot;nav_MenuAction&quot;:&quot;down&quot;,&quot;nav_MenuRank&quot;:17,&quot;nav_MenuLevel&quot;:1,&quot;nav_MenuTitle&quot;:&quot;%Sale%&quot;,&quot;nav_MenuType&quot;:&quot;curated&quot;,&quot;nav_GlobalNavigation&quot;:&quot;sale&quot;}}" data-ts-link="{&quot;wk.nav_MenuRank&quot;:17,&quot;wk.nav_MenuLevel&quot;:1,&quot;wk.nav_MenuTitle&quot;:&quot;%Sale%&quot;,&quot;wk.nav_MenuType&quot;:&quot;curated&quot;,&quot;san_Interaction&quot;:&quot;global_navigation&quot;,&quot;wk.nav_GlobalNavigation&quot;:&quot;sale&quot;,&quot;wk.nav_MenuFeature&quot;:&quot;list&quot;,&quot;san_Navigation&quot;:&quot;global&quot;,&quot;nav_MenuAction&quot;:&quot;click&quot;}" href="/sale/"><span class="nav_navi-elem__tile-title">%Sale%</span><img class="nav_navi-elem__tile-image" src="https://i.otto.de/i/otto/001_2019_09_sale_dauerhafteaktionen_flexpage_22966_shopteaser_3/?h=200&amp;upscale=true&amp;w=200" /></a></li> <li class="nav_navi-list__separator" data-dot="."></li> </ul></div></div></div></div><link rel="preload" href="/nav-chekov/static/compiled/nav.chekov.kirk_bundle.1e2042c7.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/nav-chekov/static/compiled/nav.chekov.kirk_bundle.1e2042c7.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/nav-chekov/static/compiled/nav.chekov.kirk_bundle.module.197aeb7a.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/nav-chekov/static/compiled/nav.chekov.kirk_bundle.nomodule.ce16500b.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+</header>
+                <div class="content contentFullWidth">
+
+    <div class="nav_grimm-breadcrumb-container nav_grimm-breadcrumb-container--product-page" data-nav-testing="breadcrumb-container" style="visibility:hidden;"><script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"item":{"@id":"https:\/\/www.otto.de\/","name":"Startseite"}},{"@type":"ListItem","position":2,"item":{"@id":"https:\/\/www.otto.de\/haushalt\/","name":"Haushalt"}},{"@type":"ListItem","position":3,"item":{"@id":"https:\/\/www.otto.de\/haushalt\/kuehlschraenke\/","name":"K\u00fchlschr\u00e4nke"}},{"@type":"ListItem","position":4,"item":{"@id":"https:\/\/www.otto.de\/haushalt\/kuehlschraenke\/side-by-side-kuehlschraenke\/","name":"Side-by-Side K\u00fchlschr\u00e4nke"}}]}</script><div class="nav_grimm-breadcrumb-container__breadcrumb"><ul class="nav_grimm-breadcrumb"><li class="nav_grimm-breadcrumb__icon-item" data-nav-testing="breadcrumb-list-refer-back" id="nav_breadcrumb-list-refer-back"><div class="nav_grimm-refer-back"><span class="p_icons"></span></div></li><li class="nav_grimm-breadcrumb__list-item nav_grimm-breadcrumb__ellipsis-item" data-nav-testing="breadcrumb-path-element"><a class="nav_grimm-breadcrumb__link ts-link" data-nav-testing="breadcrumb-path-element-link" data-ts-link="{&quot;san_Interaction&quot;:&quot;breadcrumb&quot;, &quot;san_Navigation&quot;:&quot;Breadcrumb&quot;}" href="/haushalt/">…</a></li> <li class="nav_grimm-breadcrumb__list-item " data-nav-testing="breadcrumb-path-element"><a class="nav_grimm-breadcrumb__link ts-link" data-nav-testing="breadcrumb-path-element-link" data-ts-link="{&quot;san_Interaction&quot;:&quot;breadcrumb&quot;, &quot;san_Navigation&quot;:&quot;Breadcrumb&quot;}" href="/">Startseite</a></li> <li class="nav_grimm-breadcrumb__list-item " data-nav-testing="breadcrumb-path-element"><a class="nav_grimm-breadcrumb__link ts-link" data-nav-testing="breadcrumb-path-element-link" data-ts-link="{&quot;san_Interaction&quot;:&quot;breadcrumb&quot;, &quot;san_Navigation&quot;:&quot;Breadcrumb&quot;}" href="/haushalt/">Haushalt</a></li> <li class="nav_grimm-breadcrumb__list-item nav_grimm-breadcrumb__always-visible-list-item" data-nav-testing="breadcrumb-path-element"><a class="nav_grimm-breadcrumb__link ts-link" data-nav-testing="breadcrumb-path-element-link" data-ts-link="{&quot;san_Interaction&quot;:&quot;breadcrumb&quot;, &quot;san_Navigation&quot;:&quot;Breadcrumb&quot;}" href="/haushalt/kuehlschraenke/">Kühlschränke</a></li> <li class="nav_grimm-breadcrumb__list-item nav_grimm-breadcrumb__always-visible-list-item" data-nav-testing="breadcrumb-path-element"><a class="nav_grimm-breadcrumb__link ts-link" data-nav-testing="breadcrumb-path-element-link" data-ts-link="{&quot;san_Interaction&quot;:&quot;breadcrumb&quot;, &quot;san_Navigation&quot;:&quot;Breadcrumb&quot;}" href="/haushalt/kuehlschraenke/side-by-side-kuehlschraenke/">Side-by-Side Kühlschränke</a></li> </ul></div></div><link rel="preload" href="/nav-grimm/static/compiled/nav.grimm.main.a9b504b7.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/nav-grimm/static/compiled/nav.grimm.main.a9b504b7.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/nav-grimm/static/compiled/nav.grimm.main.module.5f513935.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/nav-grimm/static/compiled/nav.grimm.main.nomodule.04a4985d.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+<div class="prd_messageWrapper" id="js_messageWrapper"></div>
+
+    <div class="exactag js_exactag"
+        data-trigger="productDetailView"
+        data-detailviewtype="detailview"
+        data-variationId="1524535294"
+        data-productId="1524534276"
+        data-contextPathUrl="/product"
+        data-mainimage=""
+        data-pt="Artikeldetailseite"
+        data-mp="61094760"
+        data-pr="1">
+    </div>
+<meta itemprop="gtin13" content="8806092536593">
+<meta itemprop="sku" content="6109476022"/>
+<div class="js_metaVariationId" itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
+    <meta itemprop="name" content="variationId"/>
+    <meta itemprop="value" content="1524535294"/>
+</div>
+<div id="detailviewWrapper" class="detailviewWrapper prd_detailviewWrapper js_prd_detailviewWrapper"
+         data-config-installments-config-b="false"
+         data-variationid="1524535294" data-product-resource-id="1524534276"
+         data-variation-rendered-on-server-side="true"
+         data-config-customer-review-user-data-url="/product-customerreview/reviews/getUserDataForReviewSubmitLayer/1524534276"
+         data-config-shoppages-system-url="/shoppages">
+<section class="prd_section">
+    <div class="prd_module prd_module--noLine prd_shortInfo">
+    <h1 itemprop="name" class="js_shortInfo__variationName prd_shortInfo__variationName" data-qa="variationName">Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit</h1>
+        
+
+    <div class="prd_shortInfo__expertReviews js_prd_shortInfoExpertReviews"></div>
+</div>
+</section>
+<section id="detailview" class="detailview prd_section prd_section--flex" data-qa="detailview">
+    <div id="js_prd_colWithProductImages" class="prd_section__col prd_section__col--15Of24">
+
+<div class="prd_module prd_module--fullHeight prd_module--noPadding prd_productImages prd_productImages--dynamic js_prd_productImages">
+    <div class="prd_productImages__stickyContainer js_prd_productImagesStickyContainer">
+    <div class="prd_productImages__root js_prd_productImagesRoot" id="js_prd_productImagesRoot">
+<script class="js_prd_productImagesConfig" type="application/json">
+{"dynamicVerticalImages":true,"includeOutfitButton":true,"increaseHeight":true,"sticky":true}
+</script>
+        <script>
+            document.getElementById('js_prd_productImagesRoot').addEventListener('error', function(event) {
+                var target = event.target;
+                if (target.tagName === 'IMG') {
+                    var fallbackUrl = target.getAttribute('data-fallback-url');
+                    if (fallbackUrl && target.src != fallbackUrl) {
+                        target.src = fallbackUrl;
+                        target.alt = 'ohne Abbildung';
+                    }
+                }
+            }, true);
+        </script>
+        <div class="prd_mainImageWithSwiping prd_mainImageWithSwiping--increaseHeight js_prd_mainImageWithSwiping">
+<div class="prd_deal js_prd_deal"></div>            <div title="Jetzt günstiger!" class="reducedImage js_reducedImage prd_hidden">%</div>
+
+            <div class="prd_swiper-container js_prd_swiper-container" data-qa="swiper-slide-active">
+                <div class="prd_swiper-wrapper js_prd_swiper-wrapper">
+                        
+                                    <!--js_prd_zoomWrapper is a HTML API (see README.md), DO NOT REMOVE-->
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper">
+            
+            <span class="prd_verticalAlignHelper">
+            </span><a href="https://i.otto.de/i/otto/02f85090-393a-5bd1-b56a-bac9f66295f7/samsung-side-by-side-rs6ga884csl-178-cm-hoch-91-2-cm-breit.jpg?$formatz$" onclick="event.preventDefault()"><img id="prd_mainProductImage"
+                        class="js_prd_inPlaceZoomSrc"
+                        src="https://i.otto.de/i/otto/02f85090-393a-5bd1-b56a-bac9f66295f7?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+                        alt="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit"
+                        onload="this.setAttribute('data-loaded', 'true')"
+                        data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+                        data-index="0"/></a>
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/e1f3b715-0081-5df1-9d50-14c19bc476e8?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-image-text="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/5d309975-6917-5f9e-b206-a1c99e83411c?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-image-text="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/0d7df4bc-0c08-519f-bb54-ca8a99a2d13b?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-image-text="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/155d2ba9-677e-58b3-a93e-6cce63af7783?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-image-text="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/5aff029b-a3b2-53e3-b00a-c5336433eb79?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-image-text="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/34dd8fd5-3c23-5708-b534-5b890bb19d0c?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-image-text="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/e276d855-1d88-5a8e-a51e-29c0a36e0ac2?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-image-text="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/c7854689-1dfb-569a-af70-4fab73f0a3e0?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-image-text="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/680e6942-55a5-5b3b-a063-8c2228edb6a1?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-image-text="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/b349c22c-0a41-5221-bd2f-d2a160c59c41?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-image-text="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/d65789ee-743a-51c0-8d1c-e184bc5ebe82?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-image-text="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit">
+        </div>
+        <div class="js_prd_swiper-slide prd_swiper-slide js_prd_zoomWrapper"
+             data-image-url="https://i.otto.de/i/otto/ca35c0f9-7c14-5e06-b94f-b90295a71763?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-fallback-image-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?h&#61;520&amp;w&#61;551&amp;sm&#61;clamp"
+             data-image-text="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit">
+        </div>
+
+                        
+                </div>
+            </div>
+            <span class="js_prd_mainImageWithSwipingAspectRatioHelper prd_mainImageWithSwiping__aspectRatioHelper" style="padding-top: 177%;"></span>
+                <div class="prd_imageOverlays js_prd_imageOverlays"></div>
+        </div>
+        <div class="prd_productImages__verticalImageControlWrapper">
+            <div id="js_prd_verticalImageControl" class="prd_verticalImageControl">
+                <ul id="js_prd_verticalImageControlThumbnailList" class="prd_verticalImageControl__thumbnailList">
+                        <li class="prd_verticalImageControl__thumbnailItem prd_verticalImageControl__thumbnailItem--selected" data-index="0"><img src="https://i.otto.de/i/otto/02f85090-393a-5bd1-b56a-bac9f66295f7?$001PICT36$" alt="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit, Bild 1" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="02f85090-393a-5bd1-b56a-bac9f66295f7"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="1"><img src="https://i.otto.de/i/otto/e1f3b715-0081-5df1-9d50-14c19bc476e8?$001PICT36$" alt="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit, Bild 2" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="e1f3b715-0081-5df1-9d50-14c19bc476e8"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="2"><img src="https://i.otto.de/i/otto/5d309975-6917-5f9e-b206-a1c99e83411c?$001PICT36$" alt="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit, Bild 3" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="5d309975-6917-5f9e-b206-a1c99e83411c"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="3"><img src="https://i.otto.de/i/otto/0d7df4bc-0c08-519f-bb54-ca8a99a2d13b?$001PICT36$" alt="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit, Bild 4" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="0d7df4bc-0c08-519f-bb54-ca8a99a2d13b"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="4"><img src="https://i.otto.de/i/otto/155d2ba9-677e-58b3-a93e-6cce63af7783?$001PICT36$" alt="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit, Bild 5" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="155d2ba9-677e-58b3-a93e-6cce63af7783"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="5"><img src="https://i.otto.de/i/otto/5aff029b-a3b2-53e3-b00a-c5336433eb79?$001PICT36$" alt="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit, Bild 6" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="5aff029b-a3b2-53e3-b00a-c5336433eb79"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="6"><img src="https://i.otto.de/i/otto/34dd8fd5-3c23-5708-b534-5b890bb19d0c?$001PICT36$" alt="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit, Bild 7" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="34dd8fd5-3c23-5708-b534-5b890bb19d0c"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="7"><img src="https://i.otto.de/i/otto/e276d855-1d88-5a8e-a51e-29c0a36e0ac2?$001PICT36$" alt="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit, Bild 8" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="e276d855-1d88-5a8e-a51e-29c0a36e0ac2"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="8"><img src="https://i.otto.de/i/otto/c7854689-1dfb-569a-af70-4fab73f0a3e0?$001PICT36$" alt="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit, Bild 9" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="c7854689-1dfb-569a-af70-4fab73f0a3e0"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="9"><img src="https://i.otto.de/i/otto/680e6942-55a5-5b3b-a063-8c2228edb6a1?$001PICT36$" alt="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit, Bild 10" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="680e6942-55a5-5b3b-a063-8c2228edb6a1"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="10"><img src="https://i.otto.de/i/otto/b349c22c-0a41-5221-bd2f-d2a160c59c41?$001PICT36$" alt="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit, Bild 11" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="b349c22c-0a41-5221-bd2f-d2a160c59c41"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="11"><img src="https://i.otto.de/i/otto/d65789ee-743a-51c0-8d1c-e184bc5ebe82?$001PICT36$" alt="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit, Bild 12" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="d65789ee-743a-51c0-8d1c-e184bc5ebe82"></li><li class="prd_verticalImageControl__thumbnailItem" data-index="12"><img src="https://i.otto.de/i/otto/ca35c0f9-7c14-5e06-b94f-b90295a71763?$001PICT36$" alt="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit, Bild 13" onload="this.setAttribute('data-loaded', 'true')" data-fallback-url="https://i.otto.de/i/otto/lh_platzhalter_ohne_abbildung?$001PICT36$" data-image-id="ca35c0f9-7c14-5e06-b94f-b90295a71763"></li>
+                </ul>
+                <div id="js_prd_verticalImageControlBtnWrapperTop" class ="prd_verticalImageControl__btnWrapper prd_verticalImageControl__btnWrapper--top">
+                    <button id="js_prd_verticalImageControlBtnUp" class="p_symbolBtn100--4th prd_verticalImageControl__btn" type="button"><i>^</i></button>
+                </div>
+                <div id="js_prd_verticalImageControlBtnWrapperBottom" class="prd_verticalImageControl__btnWrapper prd_verticalImageControl__btnWrapper--bottom">
+                    <button id="js_prd_verticalImageControlBtnDown" class="p_symbolBtn100--4th prd_verticalImageControl__btn" type="button"><i>v</i></button>
+                </div>
+            </div>
+        </div>
+
+            <div class="prd_outfitButton"></div>
+    </div>
+    </div>
+</div>
+    </div>
+    <div class="prd_section__col prd_section__col--9Of24">
+<div class="prd_module prd_dimensions" id="js_prd_dimensionsSelection"
+     data-enableCoverColorCombo="true"
+     data-coverColorComboWide="false"></div><div class="prd_module prd_module--noLine prd_customDimensions js_customDimensions"></div><div class="prd_module prd_cashback js_prd_cashback"></div><div class="prd_module prd_deliveryInfo" data-qa="prd_ordering">
+    <div class="js_prd_availability prd_availability" data-aob-active="false" data-is-aob-stock-customer="false"></div>
+    <div class="js_deliveryServices prd_deliveryServices"></div>
+</div>
+
+                    <link rel="preload" crossorigin="anonymous" href="/product-articleoptions/static/js/ft5.articleoptions.891d2a2f.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-articleoptions/static/css/ft5.articleoptions.4f175868.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/product-articleoptions/static/css/ft5.articleoptions.4f175868.css" crossorigin="anonymous"/></noscript>
+<script id="articleoptionsJson" type="application/json">{"1524535294":{"id":"1524535294","options":[{"id":"b7904fc6-2b79-4542-9c0d-f0f5e318076b","displayName":"Altgeräte-Rücknahme nach Gesetz","group":"DISPOSAL","mandatory":false,"selected":false,"retailPrice":0,"contentUrl":"/shoppages/altgeraete_ruecknahme_nach_gesetz_hes","iconUrl":"https://i.otto.de/i/otto/001_service_mitnahme-entsorgung_rgb_90px_checkout","variationOptionConstraints":{"value":{"maximumOrderQuantity":1,"deliveryForDesiredDate":true,"deliveryWithin24H":true}},"formattedRetailPrice":"0,00"},{"id":"7c1b0b3c-2bb2-4b83-ad21-c20dd3438acf","displayName":"Anschluss von Side-by-Side Geräten","group":"INSTALLATION","mandatory":false,"selected":false,"retailPrice":3000,"contentUrl":"/shoppages/anschluss_sidebyside","iconUrl":"https://i.otto.de/i/otto/001_service_aufbau-anschluss_rgb_90px_checkout","variationOptionConstraints":{"value":{"maximumOrderQuantity":1,"deliveryForDesiredDate":false,"deliveryWithin24H":false}},"formattedRetailPrice":"30,00"},{"id":"0e671e97-a915-4d1a-84da-71ce53661b6f","displayName":"48 Monate OTTO Langzeitgarantie","group":"WARRANTY","mandatory":false,"selected":false,"retailPrice":8500,"contentUrl":"/shoppages/otto_langzeitgarantie_technik","iconUrl":"https://i.otto.de/i/otto/001_service_garantie_rgb_90px_checkout","variationOptionConstraints":{"value":{"maximumOrderQuantity":1,"deliveryForDesiredDate":true,"deliveryWithin24H":true}},"type":"BASIC","formattedRetailPrice":"85,00"}],"noHeadline":true,"uuid":"d28d2486-5aee-48bb-8198-a4ef16aa714e"}}</script>
+<div class="prd_module" id="articleoptions" data-variationId="1524535294"><ul>
+        <li class="ao_item pl_copy100">
+            <input id="d28d2486-5aee-48bb-8198-a4ef16aa714e" data-id="b7904fc6-2b79-4542-9c0d-f0f5e318076b" name="Altgeräte-Rücknahme nach Gesetz" type="checkbox" class="js_ao_item__invisibleCheckbox ao_item__invisibleCheckbox" tabindex="5">
+            <label class="ao_item__choice" data-id="b7904fc6-2b79-4542-9c0d-f0f5e318076b" for="d28d2486-5aee-48bb-8198-a4ef16aa714e">Altgeräte-Rücknahme nach Gesetz</label>
+            <span class="ao_item__price"> €&nbsp;0,00</span>
+            <span class="js_openInPaliLayer ao_item__details pl_link100--primary" data-layer-href="/shoppages/shoppages/altgeraete_ruecknahme_nach_gesetz_hes">Details</span>
+        </li>
+        <li class="ao_item pl_copy100">
+            <input id="d28d2486-5aee-48bb-8198-a4ef16aa714e" data-id="7c1b0b3c-2bb2-4b83-ad21-c20dd3438acf" name="Anschluss von Side-by-Side Geräten" type="checkbox" class="js_ao_item__invisibleCheckbox ao_item__invisibleCheckbox" tabindex="5">
+            <label class="ao_item__choice" data-id="7c1b0b3c-2bb2-4b83-ad21-c20dd3438acf" for="d28d2486-5aee-48bb-8198-a4ef16aa714e">Anschluss von Side-by-Side Geräten</label>
+            <span class="ao_item__price"> €&nbsp;30,00</span>
+            <span class="js_openInPaliLayer ao_item__details pl_link100--primary" data-layer-href="/shoppages/shoppages/anschluss_sidebyside">Details</span>
+        </li>
+        <li class="ao_item pl_copy100">
+            <input id="d28d2486-5aee-48bb-8198-a4ef16aa714e" data-id="0e671e97-a915-4d1a-84da-71ce53661b6f" name="48 Monate OTTO Langzeitgarantie" type="checkbox" class="js_ao_item__invisibleCheckbox ao_item__invisibleCheckbox" tabindex="5">
+            <label class="ao_item__choice" data-id="0e671e97-a915-4d1a-84da-71ce53661b6f" for="d28d2486-5aee-48bb-8198-a4ef16aa714e">48 Monate OTTO Langzeitgarantie</label>
+            <span class="ao_item__price"> €&nbsp;85,00</span>
+            <span class="js_openInPaliLayer ao_item__details pl_link100--primary" data-layer-href="/shoppages/shoppages/otto_langzeitgarantie_technik">Details</span>
+        </li>
+</ul></div>
+
+
+
+<div class="prd_module prd_module--noLine prd_module--highlight prd_priceBox js_prd_priceBox">
+<script class="js_prd_priceBoxConfig" type="application/json">
+{"includeSale":true,"includeHighlight":true,"includeCampaigns":true,"includeInstallments":true,"includeOttoUp":true,"variationIsAvailable":true}
+</script>
+    <div class="prd_price js_prd_price" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+    <link itemprop="itemCondition" href="http://schema.org/NewCondition"/>
+        <link itemprop="availability" href="http://schema.org/InStock"/>
+    <meta itemprop="priceCurrency" content="EUR"/>
+    <div class="prd_price__sale"><span class="prd_price__label" id="priceAdvantageAmount">-31%</span><span id="suggestedRetailPrice" class="pl_mr25 js_hasPaliTooltip" data-tooltip="Unverbindliche Preisempfehlung des Herstellers">UVP</span><span class="prd_price__oldAmount" id="oldPriceAmountWithEuroSign">&euro; <span id="oldPriceAmount">2.899,00</span></span></div>
+    <div class="prd_price__main js_prd_price__main">
+        <span class="prd_price__amount  pl_display100"> &euro;&nbsp;<span id="reducedPriceAmount" itemprop="price" content="1999.00">1.999,00</span></span>
+        <div class="prd_price__note pl_copy75">inkl.&nbsp;MwSt. zzgl.&nbsp;Versandkosten</div>
+    </div>
+</div>
+    <div class="js_prd_benefitOttoUpTargetTop prd_benefitTarget"></div>
+    <div class="js_prd_benefitOttoUpTarget prd_benefitTarget"></div>
+
+</div>
+<div class="prd_module prd_module--noLine js_prd_partnerBenefitSlot prd_partnerBenefitSlot" data-cpgn-slot="partnerBenefit"></div><div class="prd_module prd_module--noLine prd_seller js_prd_seller">
+    
+</div><div class="prd_module prd_module--noLine prd_module--gap75 prd_ordering js_prd_ordering"  data-qa="prd_ordering" data-aob-active="false">
+    <form class="p_form product_basket prd_ordering__form" method="POST" action="/order/addToBasket">
+        <div class="prd_ordering__row">
+                <input class="js_prd_orderingQuantity" data-qa="quantity" name="quantity" type="hidden" value="1">
+                <button data-qa="addToBasket" class=" prd_ordering__button pl_button100--primary js_product_addToBasket"
+                    autocomplete="off"
+                    disabled="disabled" type="submit">
+                    <i><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M17.8324 4.05c.641 0 1.1697.502 1.2029 1.1422l.7009 13.5442-.0042.127c-.0527.6166-.5699 1.1006-1.2001 1.1006H5.4645l-.1581-.0104c-.6136-.0805-1.0737-.619-1.0451-1.2486L4.8733 5.2c.029-.6434.5592-1.15 1.2032-1.15zm0 .949H6.0764a.2555.2555 0 00-.2551.244l-.612 13.505a.2555.2555 0 00.2437.2667l13.0789.0003a.2555.2555 0 00.2555-.2555l-.6999-13.5182a.2555.2555 0 00-.2551-.2423zm-2.7644 1.57c.242 0 .438.1958.438.438 0 1.2117-.3739 2.237-1.0805 2.9637-.6382.6561-1.4975 1.018-2.4197 1.018-1.7438 0-3.5091-1.3679-3.5091-3.9822 0-.2421.1959-.438.438-.438.242 0 .438.1959.438.438 0 2.134 1.3649 3.1058 2.6331 3.1058.6835 0 1.3196-.267 1.7914-.7524.5445-.56.8328-1.3739.8328-2.353 0-.242.1959-.438.438-.438z"></path>
+                    </svg></i>In den Warenkorb
+                </button>
+            <input class="js_prd_orderingVariationId" data-qa="product_variationId" type="hidden" name="variationId" value="1524535294">
+        </div>
+    </form>
+</div><div class="prd_module prd_module--noLine prd_module--gap25 prd_wishlist2" data-qa="prd_wishlist">
+    <div class="prd_wishlist2__message js_prd_wishlist2__message" data-qa="add2WishlistSuccessMessage"></div>
+    <button type="button" class="pl_button100--secondary js_prd_wishlist2__button" disabled data-qa="wishlist">
+        <svg class="pl_icon" role="img">
+            <use xlink:href="/assets-static/icons/pl_icon_wishlist.svg#pl_icon_wishlist"></use>
+        </svg><span>Artikel merken</span>
+    </button>
+    <link rel="modulepreload" href="/wishlist-view/statics/ft1.wishlist-view.addToWishlistService.module.1ea5ea20.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/wishlist-view/statics/ft1.wishlist-view.addToWishlistService.nomodule.ecfcc1f4.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+
+<span style="display: none" class="wl_toggleInfo"
+      data-toggles-active="REMOVE_UP_DELIVERY_FLAT_VARIATION">
+</span>
+
+</div>
+<div class="prd_module prd_energyEfficiency prd_energyEfficiency--singleLine js_prd_energyEfficiency"></div>
+<link rel="preload" href="https://asset.live.coco.cloud.otto.de/static/coco.localoffers.searchWidget.390d88fe.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="https://asset.live.coco.cloud.otto.de/static/coco.localoffers.searchWidget.390d88fe.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="https://asset.live.coco.cloud.otto.de/static/coco.localoffers.searchWidget.module.c452d37d.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="https://asset.live.coco.cloud.otto.de/static/coco.localoffers.searchWidget.nomodule.350468d2.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+
+<div class="prd_module prd_localOffers js_prd_localOffers" data-product-ids="1524534276"></div>
+        <div class="inPlaceZoom js_inPlaceZoom">
+            <div class="targetZoomImage js_targetZoomImage"></div>
+        </div>
+    </div>
+</section>
+<div id="pdp-frame" class="pdp_frame pl_grid-lane" data-block="pdp-frame" data-url="/dcs/pdp-frame/{variationId}">
+    <div class="pl_grid-container">
+        <!-- Bottom SECTION A -->
+        <div class="pl_grid-col-12">
+            <div class="pl_block pdp_platform-advantages js_pdp_platform-advantages"
+     data-ft5-view-tracking='{
+    "product_PlatformAdvantagesActivity":"view",
+    "product_PlatformAdvantagesType":"co2-neutraler versand|rechnung oder ratenzahlung|kostenlose rücksendung"}'>
+
+    <ul class="pdp_platform-advantages__list">
+            <li class="pdp_platform-advantages__item pdp_platform-advantages--co2 js_openInPaliSheet"
+                data-sheet-ub64e="L3Nob3BwYWdlcy9jbzJfbmV1dHJhbGVfbGllZmVydW5nX2Fkcw&#x3D;&#x3D;"
+                data-ft5-click-tracking='{"product_PlatformAdvantagesActivity": "open", "product_PlatformAdvantagesType": "co2-neutraler versand"}'>
+                <svg class="pl_icon pdp_platform-advantages__icon" role="img">
+                    <use xlink:href="/assets-static/icons/pl_icon_check.svg#pl_icon_check"/>
+                </svg>
+                <span class="pdp_platform-advantages__link pl_link75--secondary">
+                    <strong class="pdp_platform-advantages--green">CO<sub>2</sub>-neutraler Versand</strong> durch Kompensation
+                </span>
+            </li>
+            <li class="pdp_platform-advantages__item pdp_platform-advantages--invoice js_openInPaliSheet"
+                data-sheet-ub64e="L3Nob3BwYWdlcy9rYXVmX2F1Zl9yZWNobnVuZ19hZHM&#x3D;"
+                data-ft5-click-tracking='{"product_PlatformAdvantagesActivity": "open", "product_PlatformAdvantagesType": "rechnung oder ratenzahlung"}'>
+                <svg class="pl_icon pdp_platform-advantages__icon" role="img">
+                    <use xlink:href="/assets-static/icons/pl_icon_e-invoice.svg#pl_icon_e-invoice"/>
+                </svg>
+                <span class="pdp_platform-advantages__link pl_link75--secondary">
+                    Kauf auf Rechnung und Raten
+                </span>
+            </li>
+            <li class="pdp_platform-advantages__item pdp_platform-advantages--return js_openInPaliSheet"
+                data-sheet-ub64e="L3Nob3BwYWdlcy9rb3N0ZW5sb3NlX3J1ZWNrc2VuZHVuZ19hZHM&#x3D;"
+                data-ft5-click-tracking='{"product_PlatformAdvantagesActivity": "open", "product_PlatformAdvantagesType": "kostenlose rücksendung"}'>
+                <svg class="pl_icon pdp_platform-advantages__icon" role="img">
+                    <use xlink:href="/assets-static/icons/pl_icon_order-return.svg#pl_icon_order-return"/>
+                </svg>
+                <span class="pdp_platform-advantages__link pl_link75--secondary">
+                    Kostenlose Rücksendung
+                </span>
+            </li>
+    </ul>
+</div>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/platform-advantages-FPOOYKJH.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/platform-advantages-FPOOYKJH.css" crossorigin="anonymous"/></noscript>
+                <div class="pl_block pl_block--transparent pl_block--no-padding pdp_reco-productline pdp_reco-productline--e549-active js_pdp_reco-productline" data-variation-id="1524535294"></div>
+
+  <link rel="preload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.3afc4579.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.3afc4579.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.module.46bea43c.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.nomodule.a87b68b8.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+
+<div style="display:none;" id="reco_cinema__toggle-state" data-toggle-state="{&quot;SHOW_DEALS&quot;:true,&quot;CSR&quot;:false,&quot;USE_OPAL_RELATIONSHIPS&quot;:true,&quot;TESLA_COLDSTART&quot;:false,&quot;USE_TESLA_ARTHURDENT&quot;:true,&quot;USE_TESLA_META&quot;:true,&quot;SHOW_DETAILVIEW_ONLY&quot;:false,&quot;DISPLAY_LAST_SEEN_ARTICLES&quot;:true,&quot;USE_TESLA_HITCHHIKER&quot;:true,&quot;WISHLIST_RECO_REDESIGN&quot;:true,&quot;RECO_REDESIGN&quot;:true}">
+</div>
+<script>
+  window.o_reco = window.o_reco || {};
+  window.o_reco.api = window.o_reco.api || {};
+  window.o_reco.private = window.o_reco.private || {};
+  window.o_reco.private.toggleState = JSON.parse(document.getElementById('reco_cinema__toggle-state').dataset.toggleState);
+
+  window.o_reco.private.delegate = function (originalFunction) {
+    return function () {
+      var passedArguments = arguments;
+      return new Promise(function (resolve, reject) {
+        o_global.eventLoader.onAllScriptsExecuted(10, function () {
+          window.o_reco.private[originalFunction].apply(null, passedArguments).then(resolve).catch(reject);
+        });
+      });
+    };
+  };
+
+  window.o_reco.private.delegateAndWrap = function (originalFunction) {
+    return function () {
+      var passedArguments = arguments;
+      return new Promise(function (resolve) {
+        o_global.eventLoader.onAllScriptsExecuted(10, function () {
+          var result = window.o_reco.private[originalFunction].apply(null, passedArguments);
+          resolve(result);
+        });
+      });
+    };
+  };
+
+  window.o_reco.api.initializeCinema = window.o_reco.private.delegateAndWrap('initializeCinema');
+  window.o_reco.api.initializeExpandableCinema = window.o_reco.private.delegateAndWrap('initializeExpandableCinema');
+  window.o_reco.api.loadRecommendationsForDetailView = window.o_reco.private.delegateAndWrap('asyncLoadRecommendationsForDetailView');
+
+  window.o_reco.api.loadRecommendationsForOrderOverview = window.o_reco.private.delegate('loadRecommendationsForOrderOverview');
+  window.o_reco.api.loadRecommendationsForWishlist = window.o_reco.private.delegate('loadRecommendationsForWishlist');
+  window.o_reco.api.loadRecommendationsForEntryPage =
+          window.o_reco.private.toggleState["CSR"] ?
+                  window.o_reco.private.delegateAndWrap('loadRecommendationsForEntryPageCsr') :
+                  window.o_reco.private.delegate('loadRecommendationsForEntryPage');
+  window.o_reco.api.loadBounceLayerCinema = window.o_reco.private.delegateAndWrap('loadBounceLayerCinema');
+
+  o_global.eventQBus.emit("ft6bcn.reco.init", ".reco.cinema.needsInitialization");
+</script>
+
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/reco-productline-FGYVZRSB.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/reco-productline-V53F2QXV.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/reco-productline-V53F2QXV.css" crossorigin="anonymous"/></noscript>
+        </div>
+        <!-- Bottom SECTION B -->
+        <div class="pl_grid-col-12 pl_grid-col-lg-8 pl_grid-col-lg--fill-remaining-space-with-block-color">
+            <div class="pl_block pdp_details-short-info">
+    <div class="pdp_details-short-info__wrapper">
+        <h2 class="pdp_details-short-info__title pl_headline200">Artikelbeschreibung</h2>
+        <div class="pdp_article-number pl_copy100" data-qa="articleNr" data-variation-id="1524535294">
+    Artikel-Nr. <span itemprop="productID" class="pdp_article-number__number">6109476022</span>
+</div>
+
+    </div>
+        <div class="pdp_details-short-info__brand-image js_pdp_details-short-info__brand-image"
+             data-ft5-click-tracking='{"product_BrandLogo": "click"}'>
+            <a data-qa="brand"
+               href="/technik/?marke&#x3D;samsung"
+               data-brand="Samsung">
+                <span itemprop="brand">Samsung</span>
+                <img src="https://i.otto.de/i/otto/1c317aaf7751f8b652912956fea2ae60?$ov_brandlogo_retina$"
+                     alt="Samsung" class="pdp_detail-short-info__logo">
+            </a>
+        </div>
+</div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/details-short-info-P6H74WEJ.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/details-short-info-P6H74WEJ.css" crossorigin="anonymous"/></noscript>
+            <link rel="preload" crossorigin="anonymous" href="/product-assets/quality-details-3FX75FTE.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/quality-details-GE3VIZPW.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/quality-details-GE3VIZPW.css" crossorigin="anonymous"/></noscript>
+            <div class="pl_block pl_block--no-gap pdp_selling-points">
+    <ul class="pl_list--unordered">
+            <li>Nutzinhalt: 635 Liter</li>
+            <li>No Frost – nie wieder abtauen!</li>
+            <li>Metal Cooling</li>
+            <li>Festwasseranschluss notwendig!</li>
+            <li>Space Max</li>
+    </ul>
+</div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/selling-points-XTWGOXQG.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/selling-points-XTWGOXQG.css" crossorigin="anonymous"/></noscript>
+                <div class="pl_block pl_block--no-gap pdp_description js_pdp_description">
+        <div class="pl_text-expander pl_copy100 pdp_description__text-expander js_pdp_description__text-expander">
+            <p>Der Side-by-Side Kühlschrank »RS6GA884CSL« von Samsung hat eine hohe Funktionalität sowie die Energieeffizienz-Klassifizierung C (Skala Energieeffizienz-Klassifizierung Einheitsskala (A bis G)) und ist freistehend. Die Maße des Side-by-Side Kühlschranks liegen bei 91,2 x 178 x 73,5 cm (B/H/T). Durch die No Frost-Funktion muss das Gerät nie wieder abgetaut werden. Das Gerät verfügt auch über einen Wasserspender. Durch den Festwasseranschluss ist ganz ohne Nachfüllen immer genug gekühltes Wasser auf Lager. Zwei Gefrierschubladen und vier Gemüseschubladen stehen zur Verfügung, um Nahrungsmittel zu verstauen. Die Temperatur im Gerät wird auf dem innen installierten Display angezeigt. Auf fünf Ablageflächen ist im Side-by-Side Kühlschrank viel Platz für Lebensmittel. Die fünf Türablagen ermöglichen eine übersichtliche Lagerung. Bei offen stehender Tür meldet dies der Side-by-Side Kühlschrank mit einem Warnsignal. Den Überblick behält man außerdem durch die LED-Innenbeleuchtung. Wer auf der Suche ist nach einem Gerät, das ausreichend Platz für Lebensmittel bietet, der trifft mit dem »RS6GA884CSL« von Samsung eine gute Wahl.</p>
+            <div class="pl_text-expander__toggle">
+                <a class="pl_link100--primary pl_text-expander__link js_pl_text-expander__link"></a>
+            </div>
+        </div>
+    </div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/description-NOA62KQZ.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/description-OP6T3KIZ.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/description-OP6T3KIZ.css" crossorigin="anonymous"/></noscript>
+            
+<link rel="preload" crossorigin="anonymous" href="/product-assets/video-in-page-7DYG7U6Y.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+                <div class="js_pdp_manufacturer-content pl_block" data-variation-id="1524535294">
+        <link rel="preload" crossorigin="anonymous" href="/product-richcontent/ft5-richcontent.css" as="style"
+              onload="invokePreload.onStyleLoad(this)"/>
+        <noscript>
+            <link rel="stylesheet" href="/product-richcontent/ft5-richcontent.css" crossorigin="anonymous"/>
+        </noscript>
+
+            <div class="pdp_manufacturer-content"
+                 data-provider-name="FLIXMEDIA"
+                 data-qa="manufacturer-content-provider-container">
+                <div class="rc_component js_rc_component" data-provider="flixmedia" data-ean="8806092536593"
+     data-other-providers="" data-provider-list-a2b="flixmedia,displayed"
+     data-qa="rc_component">
+    <div class="rc_teaser rc_teaser--start js_rc_teaser">
+            <figure class="rc_teaser__figure">
+                <picture>
+                    <source media="(max-width: 767px)" srcset="/product-richcontent/images&#x2F;flixmedia_8806092536593_mood_mobile.jpg"
+                            class="rc_teaser_img" data-qa="rc_mood-image-teaser-srcset">
+                    <source media="(min-width: 768px)" srcset="/product-richcontent/images&#x2F;flixmedia_8806092536593_mood_desktop.jpg"
+                            class="rc_teaser_img" data-qa="rc_mood-image-teaser-srcset">
+                    <img src="/product-richcontent/images&#x2F;flixmedia_8806092536593_mood_desktop.jpg" alt="Side-by-Side, C*, 635 ℓ, Edelstahl Look"
+                         class="rc_teaser_img" data-qa="rc_mood-image-teaser-srcset">
+                </picture>
+            </figure>
+        <div class="rc_teaser__text">
+            <h1 class="rc_teaser__headline pl_headline100" data-qa="rc_teaser-headline">Side-by-Side, C*, 635 ℓ, Edelstahl Look</h1>
+            
+        </div>
+    </div>
+            <div class="rc_teaser rc_teaser--left js_rc_teaser" data-qa="rc_image-teaser-container">
+                <figure class="rc_teaser__figure">
+                    <picture>
+                        <source media="(max-width: 767px)" srcset="/product-richcontent/images&#x2F;flixmedia_8806092536593_hl1_mobile.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <source media="(min-width: 768px)" srcset="/product-richcontent/images&#x2F;flixmedia_8806092536593_hl1_desktop.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <img src="/product-richcontent/images&#x2F;flixmedia_8806092536593_hl1_desktop.jpg" alt="Zwei Kühlkreisläufe für noch mehr Frische"
+                             class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                    </picture>
+                </figure>
+                <div class="rc_teaser__container">
+                    <div class="rc_teaser__text">
+                        <h2 class="rc_teaser__headline pl_headline100" data-qa="rc_image-teaser-headline">Zwei Kühlkreisläufe für noch mehr Frische</h2>
+                        <p class="pl_copy100" data-qa="rc_image-teaser-text">Zwei getrennte Kühlkreisläufe sorgen dafür, dass zwischen Kühl- und Gefrierbereich kein Luftaustausch stattfindet. Dadurch wird Geruchs- und Geschmacksübertragung von Kühl- in Gefrierteil reduziert und die trockene Luft im Gefrierteil gelangt nicht in den Kühlbereich. Somit kann eine ideale Luftfeuchtigkeit gehalten werden und Obst und Gemüse bleiben länger frisch.</p>
+                    </div>
+                        <div class="rc_teaser__footnotes rc_footnotes pl_copy75" data-qa="rc_image-teaser-footnotes">
+                            * Basierend auf internen Tests und im Vergleich zu einem herkömmlichen Kühlsystem.
+                        </div>
+                </div>
+            </div>
+            <div class="rc_teaser rc_teaser--right js_rc_teaser" data-qa="rc_image-teaser-container">
+                <figure class="rc_teaser__figure">
+                    <picture>
+                        <source media="(max-width: 767px)" srcset="/product-richcontent/images&#x2F;flixmedia_8806092536593_hl2_mobile.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <source media="(min-width: 768px)" srcset="/product-richcontent/images&#x2F;flixmedia_8806092536593_hl2_desktop.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <img src="/product-richcontent/images&#x2F;flixmedia_8806092536593_hl2_desktop.jpg" alt="Das optimierte Flaschenregal"
+                             class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                    </picture>
+                </figure>
+                <div class="rc_teaser__container">
+                    <div class="rc_teaser__text">
+                        <h2 class="rc_teaser__headline pl_headline100" data-qa="rc_image-teaser-headline">Das optimierte Flaschenregal</h2>
+                        <p class="pl_copy100" data-qa="rc_image-teaser-text">Das multifunktionale Flaschenregal lässt dich den Stauraum im Kühlschrank flexibel nutzen. Durch Platzoptimierung können nicht nur besonders große Flaschen (bis 1,5l) gelagert werden, sondern auch große flache Verpackungen.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="rc_teaser rc_teaser--left js_rc_teaser" data-qa="rc_image-teaser-container">
+                <figure class="rc_teaser__figure">
+                    <picture>
+                        <source media="(max-width: 767px)" srcset="/product-richcontent/images&#x2F;flixmedia_8806092536593_hl3_mobile.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <source media="(min-width: 768px)" srcset="/product-richcontent/images&#x2F;flixmedia_8806092536593_hl3_desktop.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <img src="/product-richcontent/images&#x2F;flixmedia_8806092536593_hl3_desktop.jpg" alt="Fügt sich harmonisch und stilvoll in deine Küche ein"
+                             class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                    </picture>
+                </figure>
+                <div class="rc_teaser__container">
+                    <div class="rc_teaser__text">
+                        <h2 class="rc_teaser__headline pl_headline100" data-qa="rc_image-teaser-headline">Fügt sich harmonisch und stilvoll in deine Küche ein</h2>
+                        <p class="pl_copy100" data-qa="rc_image-teaser-text">Bring etwas frischen Wind in deine Küche – mit einem Kühlschrank im modernen Look, der sich nahtlos in deine Küche einfügt und mit anderen Geräten stilvoll harmoniert. Das minimalistische Design zeichnet sich durch seine flachen Türen, die eingelassenen Türgriffe, ein integriertes Display, ein übersichtliches Weinregal und graue Lebensmittelboxen* aus.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="rc_teaser rc_teaser--right js_rc_teaser" data-qa="rc_image-teaser-container">
+                <figure class="rc_teaser__figure">
+                    <picture>
+                        <source media="(max-width: 767px)" srcset="/product-richcontent/images&#x2F;flixmedia_8806092536593_hl4_mobile.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <source media="(min-width: 768px)" srcset="/product-richcontent/images&#x2F;flixmedia_8806092536593_hl4_desktop.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <img src="/product-richcontent/images&#x2F;flixmedia_8806092536593_hl4_desktop.jpg" alt="Cleveres Design für mehr Lagerfläche"
+                             class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                    </picture>
+                </figure>
+                <div class="rc_teaser__container">
+                    <div class="rc_teaser__text">
+                        <h2 class="rc_teaser__headline pl_headline100" data-qa="rc_image-teaser-headline">Cleveres Design für mehr Lagerfläche</h2>
+                        <p class="pl_copy100" data-qa="rc_image-teaser-text">So schaffen wir noch mehr Platz für deine Lebensmittel, ohne dabei die Leistung des Kühlschranks zu beeinträchtigen. Im Unterschied zu herkömmlichen Belüftungskanälen ist die Kühlöffnung in der Rückwand völlig flach, sodass du mehr Lagerfläche bei gleicher Kühlwirkung nutzen kannst.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="rc_teaser rc_teaser--left js_rc_teaser" data-qa="rc_image-teaser-container">
+                <figure class="rc_teaser__figure">
+                    <picture>
+                        <source media="(max-width: 767px)" srcset="/product-richcontent/images&#x2F;flixmedia_8806092536593_hl5_mobile.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <source media="(min-width: 768px)" srcset="/product-richcontent/images&#x2F;flixmedia_8806092536593_hl5_desktop.jpg"
+                                class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                        <img src="/product-richcontent/images&#x2F;flixmedia_8806092536593_hl5_desktop.jpg" alt="Einfache und leicht zugängliche Bedienung"
+                             class="rc_teaser_img" data-qa="rc_image-teaser-srcset">
+                    </picture>
+                </figure>
+                <div class="rc_teaser__container">
+                    <div class="rc_teaser__text">
+                        <h2 class="rc_teaser__headline pl_headline100" data-qa="rc_image-teaser-headline">Einfache und leicht zugängliche Bedienung</h2>
+                        <p class="pl_copy100" data-qa="rc_image-teaser-text">Die leicht zugänglichen Bedienknöpfe befinden sich im Inneren unten und sind auch von einem Rollstuhl aus zu erreichen. Dies kann die Steuerung des Kühlschranks für viele Menschen mit Bewegungseinschränkungen vereinfachen.</p>
+                    </div>
+                </div>
+            </div>
+    <script class="js_prd_tracking_add2Basket" type="application/json" data-qa="rc_tracking-add2Basket">
+        {
+            "product_DetailInformation": "richcontent",
+            "product_RichContentProvider": "flixmedia,displayed"
+        }
+    </script>
+</div>
+
+            </div>
+            <head><script defer="defer" src="/product-richcontent/ft5.richcontent-tracking.1ba9e5c71e4ac83f4b1f.min.js"></script></head>
+    </div>
+
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/manufacturer-content-SR4K6SHF.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/manufacturer-content-V2ACGY4U.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/manufacturer-content-V2ACGY4U.css" crossorigin="anonymous"/></noscript>
+                <div class="pl_block pdp_details js_pdp_details">
+        <h2 class="pl_headline200 pl_mb50">Details</h2>
+        <div class="pl_text-expander pl_copy100 pdp_details__text-expander js_pdp_details__text-expander" lang="de">
+                <div class="pdp_details__characteristics-html"><table class="dv_characteristicsTable"><caption>Hinweise</caption><tr><td class="left"><span>Bestellhinweis</span></td><td>Bitte beachten Sie vor einer Bestellung die Verpackungsmaße des Gerätes und ob dieses bis zum Aufstellort transportiert werden kann. Bei Fragen wenden Sie sich gerne an unsere Produktberatung.</td></tr></table> <table class="dv_characteristicsTable"><caption>Top-Feature</caption><tr><td class="left"><span>Top-Features</span></td><td>NoFrost Plus<br />Space Max<br />Metal Cooling<br />Festwasseranschluss notwendig!</td></tr></table> <table class="dv_characteristicsTable"><caption>Produktdetails</caption><tr><td class="left"><span>Farbe Front</span></td><td>edelstahl</td></tr><tr><td class="left"><span>Farbe Seitenteile</span></td><td>silberfarben</td></tr></table> <table class="dv_characteristicsTable"><caption>Leistung &amp; Verbrauch</caption><tr><td class="left"><span>Modellbezeichnung</span></td><td>RS6GA884CSL</td></tr><tr><td class="left"><span>Energieeffizienzklasse (Skala)</span></td><td>C (A bis G)</td></tr><tr><td class="left"><span>Jährlicher Energieverbrauch</span></td><td>225 kWh</td></tr><tr><td class="left"><span>Frostfrei</span></td><td>ja, NoFrost im Gefrierteil</td></tr><tr><td class="left"><span>Gefriervermögen in 24 Stunden</span></td><td>15 kg</td></tr><tr><td class="left"><span>Klimaklasse</span></td><td>SN-N-ST-T</td></tr><tr><td class="left"><span>Rauminhalte der Kühlfächer</span></td><td>409 l</td></tr><tr><td class="left"><span>Rauminhalte der Tiefkühlfächer</span></td><td>226 l</td></tr><tr><td class="left"><span>Luftschallemissionen</span></td><td>35 dB(A)</td></tr></table> <table class="dv_characteristicsTable"><caption>Betriebskosten</caption><tr><td class="left"><span>Energiekosten / Jahr</span></td><td>67,5 €</td></tr></table> <table class="dv_characteristicsTable"><caption>Ausstattung</caption><tr><td class="left"><span>Display mit Temperaturanzeige</span></td><td>innen liegend</td></tr><tr><td class="left"><span>Festwasseranschluss nötig</span></td><td>ja</td></tr><tr><td class="left"><span>Warnsignal</span></td><td>Tür offen</td></tr><tr><td class="left"><span>Zusatzausstattung</span></td><td>Wasserspender<br />Eisbereiter</td></tr></table> <table class="dv_characteristicsTable"><caption>Ausstattung &amp; Funktionen Kühlteil</caption><tr><td class="left"><span>Anzahl Ablageflächen</span></td><td>5</td></tr><tr><td class="left"><span>Anzahl Türablagen</span></td><td>5</td></tr><tr><td class="left"><span>Anzahl Kühlschubladen</span></td><td>4</td></tr><tr><td class="left"><span>Art Innenbeleuchtung</span></td><td>LED-Innenbeleuchtung</td></tr></table> <table class="dv_characteristicsTable"><caption>Ausstattung &amp; Funktionen Gefrierteil</caption><tr><td class="left"><span>Anzahl Gefrierschubladen</span></td><td>2</td></tr><tr><td class="left"><span>Anzahl offene Gefrierfächer</span></td><td>4</td></tr></table> <table class="dv_characteristicsTable"><caption>Informationen zum Einbau</caption><tr><td class="left"><span>Einbauart</span></td><td>freistehend</td></tr></table> <table class="dv_characteristicsTable"><caption>Maße &amp; Gewicht</caption><tr><td class="left"><span>Höhe</span></td><td>178 cm</td></tr><tr><td class="left"><span>Breite</span></td><td>91,2 cm</td></tr><tr><td class="left"><span>Tiefe</span></td><td>73,5 cm</td></tr><tr><td class="left"><span>Gewicht</span></td><td>123 kg</td></tr></table> <table class="dv_characteristicsTable"><caption>Technische Daten</caption><tr><td class="left"><span>Türanschlag wechselbar</span></td><td>nein</td></tr><tr><td class="left"><span>Spannung</span></td><td>220-240 V</td></tr></table></div>
+            <div class="pl_text-expander__toggle">
+                <a class="pl_link100--primary pl_text-expander__link js_pl_text-expander__link"></a>
+            </div>
+        </div>
+    </div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/details-5SQY3X2Y.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/details-YT4QQ23U.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/details-YT4QQ23U.css" crossorigin="anonymous"/></noscript>
+            
+<link rel="preload" crossorigin="anonymous" href="/product-assets/care-details-GAFGMSSC.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/care-details-35N7QLPR.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/care-details-35N7QLPR.css" crossorigin="anonymous"/></noscript>
+                <div class="pl_block pdp_manufacturer-content-btn js_pdp_manufacturer-content-btn"
+         data-provider-name="FLIXMEDIA"
+         data-brand-name="Samsung"
+         data-ean="8806092536593"
+         data-ft5-view-tracking='{"product_BrandContent": "view"}'
+         >
+        <span class="pl_button100--secondary pdp_manufacturer-content-btn__inner"
+              data-ft5-click-tracking='{"product_BrandContent": "open"}'>
+                <img src="https://i.otto.de/i/otto/1c317aaf7751f8b652912956fea2ae60?$ov_brandlogo$"
+                     srcset=" https://i.otto.de/i/otto/1c317aaf7751f8b652912956fea2ae60?$ov_brandlogo_retina$ 2x"
+                     alt="Samsung" class="pdp_manufacturer-content-btn__logo">
+            <span class="pdp_manufacturer-content-btn__text bold">Weitere Artikelinformationen <br>von Samsung</span>
+        </span>
+    </div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/manufacturer-content-btn-3RJVSPTY.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/manufacturer-content-btn-TZKWPTRE.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/manufacturer-content-btn-TZKWPTRE.css" crossorigin="anonymous"/></noscript>
+                <div class="pdp_sustainability js_pdp_sustainability pl_block pl_copy100" data-variation-id="">
+        <h2 class="pl_headline100">Warum ist dieser Artikel nachhaltig?</h2>
+            <div class="pdp_sustainability__category pl_copy75 pl_mt150 js_pdp_sustainability__detail-link">
+                <svg class="pdp_sustainability__category-icon pdp_sustainability__category-icon--clickable pl_icon"
+                     role="img">
+                    <use xlink:href="/assets-static/icons/pl_icon_sustainable-energy-efficient.svg#pl_icon_sustainable-energy-efficient"/>
+                </svg>
+                <div class="pdp_sustainability__category-description pdp_sustainability__category-description--clickable pl_pl100">Energieeffiziente Nutzung</div>
+            </div>
+        <div class="pdp_sustainability__details-link pl_mt75">
+            <span class="pl_link100--primary js_pdp_sustainability__detail-link">Details</span>
+        </div>
+        <div class="pdp_sustainability__statement pl_mt100">
+            Nachhaltigkeit ist für uns kein Trend, sondern eine Selbstverständlichkeit.
+            Gehe den Weg mit uns und erfahre mehr über
+            <span class="pl_link100--primary ub64e" data-ub64e="L3Nob3BwYWdlcy9uYWNoaGFsdGlna2VpdA&#x3D;&#x3D;"><span>Nachhaltigkeit bei OTTO</span></span>.
+        </div>
+    </div>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/sustainability-TEGQHXDW.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/sustainability-AQLRH6ZY.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/sustainability-AQLRH6ZY.css" crossorigin="anonymous"/></noscript>
+        </div>
+        <div class="pl_grid-col-12 pl_grid-col-lg-4 pl_grid-col-lg--no-vertical-gap pl_grid-col-lg--fill-remaining-space-with-block-color">
+            
+<link rel="preload" crossorigin="anonymous" href="/product-assets/article-services-W5HQPYF4.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/article-services-HTRSTHT6.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/article-services-HTRSTHT6.css" crossorigin="anonymous"/></noscript>
+            <div class="pl_block pl_block--no-gap-lg pdp_product-advisor"
+     data-ft5-view-tracking='{
+        "product_OnlineAdvice": "onlineadvice_refrigerator",
+        "product_OnlineAdviceActivity": "view"
+     }'
+     data-ft5-click-tracking='{
+        "product_OnlineAdvice": "onlineadvice_refrigerator",
+        "product_OnlineAdviceActivity": "click"
+     }'
+>
+    <h3 class="pl_headline100 pl_mb150">Welches Kühlgerät passt am besten zu mir?</h3>
+
+    <div class="pdp_product-advisor__item">
+        <span class="pl_link100--primary js_openInPaliLayer ub64e"
+           data-ub64e="L3Nob3BwYWdlcy9kZXRhaWx2aWV3X3NlcnZpY2VsYXllcl9vbmxpbmVhZHZpY2VfcmVmcmlnZXJhdG9y"
+           data-layer-width="700px">
+            <span>Interaktiven Berater starten</span>
+        </span>
+    </div>
+</div>
+
+                <div class="pl_block pl_block--no-gap-lg dcs_important-information">
+        <h3 class="pl_headline100 pl_mb150">Wichtige Informationen:</h3>
+        <ul class="dcs_important-information__list">
+                <li class="dcs_important-information__list-item">
+                    <span class="pl_link100--primary dcs_important-information__link js_openInPaliLayer ub64e" data-ub64e="L3Nob3BwYWdlcy9jb25zdWx0aW5nZGV0YWlsX2Rpc3Bvc2FsX25vdGU&#x3D;">
+                        <span>
+                            <svg class="pl_icon dcs_important-information__icon" role="img"><use xlink:href="/assets-static/icons/pl_icon_disposal.svg#pl_icon_disposal" /></svg>
+                            Entsorgungshinweis
+                        </span>
+                    </span>
+                </li>
+                <li class="dcs_important-information__list-item">
+                    <a class="pl_link100--primary dcs_important-information__link" target="_blank" href="https://d.otto.de/files/bf35abd2-0715-516f-bf7b-2ca72b9fb8ac.pdf">
+                        <svg class="pl_icon dcs_important-information__icon" role="img"><use xlink:href="/assets-static/icons/pl_icon_pdf.svg#pl_icon_pdf" /></svg>
+                        Bedienungsanleitung (PDF)
+                    </a>
+                </li>
+        </ul>
+    </div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/important-information-U6H2HYV5.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/important-information-U6H2HYV5.css" crossorigin="anonymous"/></noscript>
+            <div class="pl_block pl_block--no-gap-lg js_pdp_share-btn pl_hidden" data-is-valid-variation="true">
+    <button class="pl_button100--secondary js_pdp_share-btn__button"
+            data-ft5-click-tracking='{ "social_Action": "share" }'
+    >
+        <svg class="pl_icon" role="img">
+            <use class="js_pdp_share-btn__icon-use" xlink:href="/assets-static/icons/pl_icon_share-ios.svg#pl_icon_share-ios"/>
+        </svg>
+        Teilen
+    </button>
+</div>
+
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/share-btn-SHU35MCQ.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+        </div>
+        <!-- Bottom SECTION C -->
+        <div class="pl_grid-col-12">
+                <div class="pl_block pl_block--full-bleed dcs_product-consulting">
+        <link href="/shoppages/static/assets/sho.shoppages.assets-public.c2691b52.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/shoppages/static/assets/sho.shoppages.assets-public.c2691b52.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" crossorigin="anonymous" href="/shoppages/static/assets/sho.shoppages.assets-public.21298cd5.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>    <div data-title="" data-callback="o_shoppages.layer.init">
+        <div class="shoppages shoppagesFragment">
+                <div id="6141e83f6a3bbf22834a8475" class="sp_js_contentElement sp_textBlock sp_plainText" data-qa="textBlock"
+                   data-content-element-type="Textblock" data-content-element-name="dcs_product_consulting_whitegoods">
+<div class="pl_grid-content100 pl_copy100"> 
+ <div class="pl_grid-container"> 
+  <div class="pl_grid-col-12 pl_grid-col-lg-4"> 
+   <div class="pl_headline100 pl_mb50">
+    Produktberatung
+   </div> Wir beraten dich gerne:
+  </div> 
+  <div class="pl_grid-col-12 pl_grid-col-lg-4"> 
+   <div class="dcs_product-consulting__text">
+    <span class="dcs_product-consulting__icon">t</span> <span class="sp_hideWhenLarge pl_link100--primary ub64e" data-ub64e="dGVsOis0OTQwMzYwMzMzMzA=">040 - 3603 3330</span> <span class="sp_hideWhenNotLarge">040 - 3603 3330</span> 
+    <br>oder <span class="js_openInPopup pl_link100--primary ub64e" data-ub64e="L3VzZXIvY2FsbGJhY2tQb3B1cD9zZWxlY3RlZFRvcGljPTIwMiZzb3VyY2U9c2l0ZQ==">kostenloser Rückruf in den nächsten 30 Minuten</span>
+    <br><span>(Mo.-Fr. 8-22 Uhr, Sa. 9-19 Uhr)</span>
+   </div> 
+  </div> 
+  <div class="pl_grid-col-12 pl_grid-col-lg-4"> 
+   <div class="dcs_product-consulting__text">
+    <span class="dcs_product-consulting__icon">B</span> <span class="js_openInPopup pl_link100--primary ub64e" data-ub64e="L2t1bmRlbmNoYXQvcG9wdXAuaHRtbD9jYXQ9T3R0b19DSEFUX0hhdXNoYWx0c2VsZWt0cm8=">Jetzt chatten</span> 
+    <br><span>(Mo.-Fr. 8-22 Uhr, Sa. 9-19 Uhr)</span>
+   </div> 
+   <div class="dcs_product-consulting__text">
+    <span class="dcs_product-consulting__icon">e</span> <span class="js_openInPopup pl_link100--primary ub64e" data-ub64e="L3VzZXIvY29udGFjdEZvcm0/c2VsZWN0ZWRUb3BpYz0yMDI=">haushaltselektro@otto.de</span>
+   </div> 
+  </div> 
+ </div> 
+</div>
+</div>
+
+
+
+    
+        </div>
+    </div>
+    
+
+    </div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/product-consulting-62ZS3DP6.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/product-consulting-62ZS3DP6.css" crossorigin="anonymous"/></noscript>
+            <div class="pl_block pl_block--transparent pl_block--no-padding pdp_reco-sponsored pdp_reco-sponsored--e549-active js_pdp_reco-sponsored" data-variation-id="1524535294"></div>
+<link rel="stylesheet" href="/spa-formicary/assets/ft7bcn.spa-formicary.spa_formicary_assets.7935b393.css" crossorigin="anonymous" integrity="sha256-IQzbUIGIxvC+RmQ1n3QFAF9eiKwlozE/v/tnQ5ByB8c=">
+
+<link rel="modulepreload" href="/spa-formicary/assets/ft7bcn.spa-formicary.spa_formicary_assets.module.18c96fd4.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/spa-formicary/assets/ft7bcn.spa-formicary.spa_formicary_assets.nomodule.22c7d8e1.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<script>
+    window.o_spa_formicary = window.o_spa_formicary || {};
+    window.o_spa_formicary.api = window.o_spa_formicary.api || {};
+    window.o_spa_formicary.private = window.o_spa_formicary.private || {};
+    window.o_spa_formicary.private.jlineup = window.o_spa_formicary.private.jlineup || {};
+
+    window.o_spa_formicary.private.delegate = function (originalFunction) {
+        return function () {
+            var passedArguments = arguments;
+            return new Promise(function (resolve, reject) {
+                o_global.eventLoader.onAllScriptsExecuted(10, function () {
+                    window.o_spa_formicary.private[originalFunction].apply(null, passedArguments).then(resolve).catch(reject);
+                });
+            });
+        };
+    };
+
+    window.o_spa_formicary.private.delegateAndWrap = function (originalFunction) {
+        return function () {
+            var passedArguments = arguments;
+            return new Promise(function (resolve) {
+                o_global.eventLoader.onAllScriptsExecuted(10, function () {
+                    var result = window.o_spa_formicary.private[originalFunction].apply(null, passedArguments);
+                    resolve(result);
+                });
+            });
+        };
+    };
+
+    window.o_spa_formicary.api.initializeCinema = window.o_spa_formicary.private.delegateAndWrap('initializeCinema');
+    window.o_spa_formicary.api.loadSponsoredArticlesForDetailView = window.o_spa_formicary.private.delegate('loadSponsoredArticlesForDetailView');
+</script>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/reco-sponsored-R3UBMRPW.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/reco-sponsored-HR556DNU.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/reco-sponsored-HR556DNU.css" crossorigin="anonymous"/></noscript>
+                    <div class="pl_block pl_block--transparent pl_block--no-padding pdp_reco-alternative pdp_reco-alternative--e549-active js_pdp_reco-alternative" data-variation-id="1524535294"></div>
+
+  <link rel="preload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.3afc4579.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.3afc4579.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.module.46bea43c.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.nomodule.a87b68b8.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+
+<div style="display:none;" id="reco_cinema__toggle-state" data-toggle-state="{&quot;SHOW_DEALS&quot;:true,&quot;CSR&quot;:false,&quot;USE_OPAL_RELATIONSHIPS&quot;:true,&quot;TESLA_COLDSTART&quot;:false,&quot;USE_TESLA_ARTHURDENT&quot;:true,&quot;USE_TESLA_META&quot;:true,&quot;SHOW_DETAILVIEW_ONLY&quot;:false,&quot;DISPLAY_LAST_SEEN_ARTICLES&quot;:true,&quot;USE_TESLA_HITCHHIKER&quot;:true,&quot;WISHLIST_RECO_REDESIGN&quot;:true,&quot;RECO_REDESIGN&quot;:true}">
+</div>
+<script>
+  window.o_reco = window.o_reco || {};
+  window.o_reco.api = window.o_reco.api || {};
+  window.o_reco.private = window.o_reco.private || {};
+  window.o_reco.private.toggleState = JSON.parse(document.getElementById('reco_cinema__toggle-state').dataset.toggleState);
+
+  window.o_reco.private.delegate = function (originalFunction) {
+    return function () {
+      var passedArguments = arguments;
+      return new Promise(function (resolve, reject) {
+        o_global.eventLoader.onAllScriptsExecuted(10, function () {
+          window.o_reco.private[originalFunction].apply(null, passedArguments).then(resolve).catch(reject);
+        });
+      });
+    };
+  };
+
+  window.o_reco.private.delegateAndWrap = function (originalFunction) {
+    return function () {
+      var passedArguments = arguments;
+      return new Promise(function (resolve) {
+        o_global.eventLoader.onAllScriptsExecuted(10, function () {
+          var result = window.o_reco.private[originalFunction].apply(null, passedArguments);
+          resolve(result);
+        });
+      });
+    };
+  };
+
+  window.o_reco.api.initializeCinema = window.o_reco.private.delegateAndWrap('initializeCinema');
+  window.o_reco.api.initializeExpandableCinema = window.o_reco.private.delegateAndWrap('initializeExpandableCinema');
+  window.o_reco.api.loadRecommendationsForDetailView = window.o_reco.private.delegateAndWrap('asyncLoadRecommendationsForDetailView');
+
+  window.o_reco.api.loadRecommendationsForOrderOverview = window.o_reco.private.delegate('loadRecommendationsForOrderOverview');
+  window.o_reco.api.loadRecommendationsForWishlist = window.o_reco.private.delegate('loadRecommendationsForWishlist');
+  window.o_reco.api.loadRecommendationsForEntryPage =
+          window.o_reco.private.toggleState["CSR"] ?
+                  window.o_reco.private.delegateAndWrap('loadRecommendationsForEntryPageCsr') :
+                  window.o_reco.private.delegate('loadRecommendationsForEntryPage');
+  window.o_reco.api.loadBounceLayerCinema = window.o_reco.private.delegateAndWrap('loadBounceLayerCinema');
+
+  o_global.eventQBus.emit("ft6bcn.reco.init", ".reco.cinema.needsInitialization");
+</script>
+
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/reco-alternative-7BEZZ7LX.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/reco-alternative-KN75277F.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/reco-alternative-KN75277F.css" crossorigin="anonymous"/></noscript>
+            
+    <style>@charset "UTF-8";.cr_aggregation{display:inline-block;margin-top:8px}.cr_aggregation__starsWithAmount{cursor:pointer;text-decoration:none}.cr_aggregation__button{display:inline;margin-left:8px;width:auto}.cr_aggregation__amount,.cr_aggregation__label{text-decoration:underline}.cr_aggregation__label-icon{font-style:normal;vertical-align:bottom}.cr_aspectFilter{margin-top:32px}@media (min-width:48em){.cr_aspectFilter--old-{margin-top:16px}}.cr_aspectFilter__headline{font-size:14px;font-size:.875rem;line-height:1.4285714286em}.cr_aspectFilter__headline--old-design{font-weight:700}.cr_aspectFilter__buttons{overflow:hidden}.cr_aspectButton{-webkit-tap-highlight-color:transparent;background:#f3f1ec;background:-webkit-linear-gradient(180deg,#fefefe,#f3f1ec);background:linear-gradient(180deg,#fefefe,#f3f1ec);border:1px solid #c4c4c4;border-radius:3px;color:#333;cursor:pointer;float:left;font-size:12px;font-size:.75rem;height:31px;line-height:1.5em;margin:8px 8px 0 0;max-width:300px;outline:0 none;padding:5px 9px;text-align:center;text-decoration:none;vertical-align:baseline;white-space:nowrap}.cr_aspectButton:hover{background:#fefefe;color:#d5281e}.cr_aspectButton:last-of-type{margin:8px 16px 0 0}.cr_aspectButton--selected{border-color:#9e9e9e;cursor:auto}.cr_aspectButton--selected,.cr_aspectButton--selected:hover{background:#fff;background:-webkit-linear-gradient(180deg,#d7d5cf,#fff);background:linear-gradient(180deg,#d7d5cf,#fff);font-weight:700}.cr_aspectButton--selected:hover{color:inherit}.cr_aspectButton__text{display:inline-block;margin-right:4px;max-width:235px;overflow:hidden;text-overflow:ellipsis;vertical-align:bottom;white-space:nowrap}.cr_aspectDeselectLink{float:left;line-height:31px;margin-top:8px}.cr_histogram__row{display:table-row}.cr_histogram__row--clickable{cursor:pointer}.cr_histogram__row--clickable .cr_histogram__amount span{text-decoration:underline}.cr_histogram__row--selected .cr_histogram__amount,.cr_histogram__row--selected .cr_histogram__label{font-weight:700}.cr_histogram__row--selected .cr_bar{border:1px solid #777}.cr_histogram__row--selected .cr_bar__fill{background-color:#9e9e9e}.cr_histogram__row--selected .cr_histogram__amount span{text-decoration:none}@media (min-width:48em){.cr_histogram__row--selected .cr_histogram__deselect{display:table-cell}}.cr_histogram__amount,.cr_histogram__label,.cr_histogram__percent{display:table-cell;padding-top:12px;vertical-align:top}.cr_histogram__row:first-child .cr_histogram__amount,.cr_histogram__row:first-child .cr_histogram__deselect,.cr_histogram__row:first-child .cr_histogram__label,.cr_histogram__row:first-child .cr_histogram__percent{padding-top:0}.cr_histogram__amount,.cr_histogram__deselect,.cr_histogram__label{font-size:14px;font-size:.875rem;line-height:1.4285714286em;line-height:20px}.cr_histogram__amount,.cr_histogram__label,.cr_histogram__percent{padding-right:8px}.cr_bar{border:1px solid #c4c4c4;-moz-border-radius:2px;-webkit-border-radius:2px;border-radius:2px;height:20px;width:170px}.cr_bar__fill{background-color:#e6e6e6;height:100%}.cr_histogram__deselect{display:none;padding-top:12px;vertical-align:top}.cr_filterIndicator{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:16px 0 0}@media (min-width:48em){.cr_filterIndicator{display:inline-block;line-height:38px}}.cr_filterIndicator__deselect{white-space:nowrap}@media (min-width:48em){.cr_filterIndicator__deselect{display:none}}.cr_landingPage .cr_reviewHeadline__row--FEATURE_2065 .cr_reviewHeadline__starsWithAmount>*{display:inline-block;vertical-align:middle}@media (min-width:48em){.cr_landingPage .cr_histogram--old-design{float:left}.cr_landingPage .cr_aspectFilter--old-design{margin-left:480px}}.cr_landingPage .cr_filterWrapper{margin:16px 0 0;overflow:hidden}.cr_landingPage .cr_filterWrapper--old-design{margin:8px 0 0}.cr_landingPage .cr_priceAmount--reduced{color:#f00020}.cr_landingPage .cr_priceNote{display:block}.cr_landingPage .cr_productVariationImage{max-height:74px;max-width:74px}.cr_landingPage .cr_variationImage{display:inline;float:left;padding:0 0 0 8px}@media (min-width:28em){.cr_landingPage .cr_variationImage{padding:0 8px}}.cr_landingPage .cr_priceAndMoreVariationsLink{float:left}.cr_landingPage .cr_headLink{text-decoration:none}.cr_loadingSpinner{margin-bottom:8px;text-align:center}.cr_loadingSpinner__loader{display:inline-block}@media (min-width:48em){.cr_minimal .cr_histogram--old-design{float:left}.cr_minimal .cr_aspectFilter--old-design{margin-left:360px}}.cr_minimal .cr_reviewList{margin:32px 0 24px}.cr_minimal .cr_filterWrapper{margin:16px 0 0;overflow:hidden}.cr_minimal .cr_filterWrapper--old-design{margin:8px 0 0}.cr_moreReviewsButton{max-width:350px}.cr_paging{margin-bottom:8px;overflow:hidden;text-align:center}@media (min-width:48em){.cr_paging{float:right;width:310px}}.cr_paging__button{width:auto}.cr_paging__button--first,.cr_paging__button--prev{float:left;margin-left:8px}.cr_paging__button--last,.cr_paging__button--next{float:right;margin-right:8px}.cr_paging__currentPage{font-size:14px;font-size:.875rem;line-height:1.4285714286em;line-height:30px}.cr_reportReviewLayer{font-size:14px;font-size:.875rem;line-height:1.4285714286em;overflow:hidden}.cr_reportReviewLayer--success .cr_reportReviewLayer__surveyWrapper{display:none}.cr_reportReviewLayer--success .cr_reportReviewLayer__successWrapper{display:block}.cr_reportReviewLayer__error{display:none;margin-bottom:16px}.cr_reportReviewLayer__request{font-weight:700;margin:0}.cr_reportReviewLayer__survey{margin-top:10px}.cr_reportReviewLayer__textarea{margin-top:8px}.cr_reportReviewLayer__disclaimer,.cr_reportReviewLayer__feedbackIndication,.cr_reportReviewLayer__guidelines{font-size:12px;font-size:.75rem;line-height:1.5em}.cr_reportReviewLayer__feedbackIndication{margin:8px 0 0}.cr_reportReviewLayer__feedbackIndication--success{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:16px 0 0}.cr_reportReviewLayer__disclaimer,.cr_reportReviewLayer__guidelines{display:block;margin-top:8px}@media (min-width:48em){.cr_reportReviewLayer__disclaimer{float:left;line-height:40px;margin-top:16px}}.cr_reportReviewLayer__button{margin-top:16px}@media (min-width:48em){.cr_reportReviewLayer__button{float:right;max-width:160px}}.cr_reportReviewLayer__successWrapper{display:none}.cr_reviewHeadline{position:relative}.cr_reviewHeadline__headline{margin-top:16px}.cr_reviewHeadline__headline--FEATURE_2065{font-family:OttoSansThin,OTTOSans,Arial,Helvetica,sans-serif;font-size:22px;font-size:1.375rem;line-height:1.2727272727em;margin-top:24px}@media (min-width:48em){.cr_reviewHeadline__headline--FEATURE_2065{font-size:26px;font-size:1.625rem;line-height:1.2307692308em}}.cr_reviewHeadline__recommendation{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:8px 0 0}.cr_reviewHeadline__recommendation.cr_reviewHeadline__recommendation--FEATURE_2065{margin:12px 0 0}.cr_reviewHeadline__row{overflow:hidden}.cr_reviewHeadline__starsWithAmount{float:left;margin-top:19px;white-space:nowrap}.cr_reviewHeadline__row--FEATURE_2065 .cr_reviewHeadline__starsWithAmount{margin-top:16px}.cr_reviewHeadline__row--FEATURE_2065 a.cr_reviewHeadline__starsWithAmount{cursor:pointer;text-decoration:none}.cr_reviewHeadline__amount{margin:0 8px 0 4px;vertical-align:text-bottom}.cr_reviewHeadline__row--FEATURE_2065 .cr_reviewHeadline__amount{margin:4px}.cr_reviewHeadline__label{text-decoration:underline;vertical-align:text-bottom}.cr_reviewHeadline__label-icon{font-style:normal;vertical-align:baseline}.cr_reviewHeadline__amount--clickable{cursor:pointer;text-decoration:underline}.cr_reviewHeadline__submitReviewButton{margin-top:8px;width:auto}.cr_reviewHeadline__row--FEATURE_2065 .cr_reviewHeadline__submitReviewButton{margin-top:0}.cr_reviewHeadline__submitReviewButton--old{margin-top:16px}.cr_reviewHeadline__submitReviewButton--floating{margin:12px 0 0}@media (min-width:48em){.cr_reviewHeadline__submitReviewButton--floating{margin:0;position:absolute;right:0;top:0}}.cr_reviewHeadline__submitReviewStar{margin-right:2px}.cr_reviewHeadline__submitReview{display:inline-block;float:right;margin-top:16px}.cr_reviewHeadline__noReviews{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:8px 0 0}.cr_reviewHeadline__submitReview--noReviews{float:none;margin:8px 0}#cr_reviewErrorContainer{display:none;margin-bottom:8px}#cr_js_topReviews{overflow:hidden}.cr_reviewList{margin:16px 0 24px;position:relative}@media (min-width:48em){.cr_reviewList{margin:24px 0 32px}}.cr_review{font-size:14px;font-size:.875rem;line-height:1.4285714286em}.cr_review__stars{margin-right:8px}.cr_review__stars--error{color:#f00020}.cr_review__title{display:inline;font-size:14px;font-size:.875rem;font-weight:700;line-height:1.4285714286em}.cr_review__helpfulSummary{display:block;font-size:12px;font-size:.75rem;line-height:1.5em;margin-top:2px}@media (min-width:48em){.cr_review__helpfulSummary--SandM{display:none}}.cr_review__helpfulSummary--LandXL{display:none}@media (min-width:48em){.cr_review__helpfulSummary--LandXL{display:block}}.cr_review__text{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin:12px 0 0}.cr_review__reviewer{display:block;font-size:12px;font-size:.75rem;line-height:1.5em;margin-top:12px}.cr_review__reviewerName{font-weight:700}.cr_review__partner{display:block;font-size:12px;font-size:.75rem;line-height:1.5em}.cr_review__partnerName{font-weight:700}.cr_review__dimensions{display:block}.cr_review__dimensions,.cr_review__helpfulSubmit{font-size:12px;font-size:.75rem;line-height:1.5em}.cr_review__helpfulSubmit{display:inline-block;margin:8px 0 0}.cr_review__verifiedPurchase{margin-top:2px}.cr_review__verifiedPurchaseText{color:#50cc7f;font-size:12px;font-size:.75rem;line-height:1.5em}.cr_review__verifiedPurchaseIcon{fill:#50cc7f;vertical-align:middle}.cr_review__verifiedPurchaseInfo{font-size:14px;font-size:.875rem;line-height:1.4285714286em}.cr_review__verifiedPurchaseInfoText{color:#50cc7f}.cr_review__verifiedPurchaseInfoIcon{fill:#50cc7f;height:14px;vertical-align:text-bottom;width:14px}.cr_helpfulSubmit{margin-left:4px;white-space:nowrap}.cr_helpfulSubmit__button{display:inline-block;width:auto}.cr_helpfulSubmit__button:first-child{margin-right:4px}.cr_reportReviewLink{display:inline-block;font-size:12px;font-size:.75rem;line-height:1.5em;margin-top:12px;white-space:nowrap}@media (min-width:28em){.cr_reportReviewLink{display:inline;margin-left:12px;margin-top:0}}.cr_review__line{margin:16px 0!important}@media (min-width:48em){.cr_review__line{margin:24px 0!important}}.cr_bi-review:before{display:inline-block;float:left;font-family:OttoIcons,Arial,Helvetica,sans-serif;font-size:20px;font-size:1.25rem}.cr_bi-review>*{margin-left:28px}.cr_bi-review .cr_reportReviewLink,.cr_bi-review .cr_review__helpfulSubmit{display:none}.cr_bi-review.cr_review--expanded .cr_reportReviewLink,.cr_bi-review.cr_review--expanded .cr_review__helpfulSubmit{display:inline-block}.cr_bi-review--positive:before{color:#417505;content:"↑"}.cr_bi-review--negative:before{color:#ba0019;content:"↓"}.cr_bi-review--neutral:before{content:"→"}.cr_review__text--afterOccurrence,.cr_review__text--beforeOccurrence{display:none}.cr_review--expanded .cr_review__text--afterOccurrence,.cr_review--expanded .cr_review__text--beforeOccurrence{display:inline}.cr_review__highlightedWord{font-weight:700}.cr_review__highlightedWord--negative{color:#ba0019}.cr_review__highlightedWord--positive{color:#417505}.cr_review__moreLink:after{content:"...Mehr"}.cr_review--expanded .cr_review__moreLink:after{content:"...Weniger"}.cr_aspectHeader{margin-top:24px;overflow:hidden}.cr_aspectHeader__name{display:inline-block;font-size:16px;font-size:1rem;font-weight:700;line-height:1.375em;margin-right:9px;vertical-align:middle}.cr_aspectTypeDistribution{cursor:default;display:inline-block;vertical-align:middle}.cr_aspectTypeDistribution__item{display:inline-block;font-size:16px;font-size:1rem;font-weight:700;line-height:1.375em;line-height:26px;vertical-align:middle}.cr_aspectTypeDistribution__item:not(:last-child){margin-right:10px}.cr_aspectTypeDistribution__icon{font-size:20px;font-style:normal;font-weight:400;margin-right:-3px;vertical-align:bottom}.cr_aspectTypeDistribution__icon--positive{color:#417505}.cr_aspectTypeDistribution__icon--negative{color:#ba0019}.cr_sortingForm{display:block;margin-top:16px}@media (min-width:28em){.cr_sortingForm--old-design{text-align:right}}@media (min-width:48em){.cr_sortingForm--old-design{display:inline-block;float:right}}.cr_sortingForm__label{font-size:14px;font-size:.875rem;line-height:1.4285714286em;margin-right:8px}.cr_sortingForm__select{display:inline-block;width:auto}.cr_filterIndicatorAndSortingWrapper{overflow:hidden}.reviewSubmitLayer a.overlay{color:#777;display:inline-block;margin-top:16px}.reviewSubmitLayer .label{margin-bottom:4px}.reviewSubmitLayer .reviewContent p{margin-top:15px}.reviewSubmitLayer .reviewContent .cr_reviewImage img{height:164px;width:164px}.reviewSubmitLayer .reviewContent .cr_reviewDimensions{flex:1;vertical-align:top}.reviewSubmitLayer .reviewContent .cr_reviewImageContainer{display:flex}.reviewSubmitLayer .reviewContent .cr_reviewTextContainer{margin-bottom:12px!important}.reviewSubmitLayer .reviewContent .recommended{margin:8px 0}.reviewSubmitLayer .reviewContent .radio-option{margin-right:40px}.reviewSubmitLayer .reviewContent .star-empty{background-image:url(/assets-static/icons/pl_icon_rating-empty.svg)}.reviewSubmitLayer .reviewContent .star-empty,.reviewSubmitLayer .reviewContent .star-filled{background-position:0;background-repeat:no-repeat;background-size:24px;cursor:pointer;padding:14px 38px 14px 0}.reviewSubmitLayer .reviewContent .star-filled{background-image:url(/assets-static/icons/pl_icon_rating-filled.svg)}.reviewSubmitLayer .reviewContent .left{float:left}.reviewSubmitLayer .reviewContent .right{float:right}.reviewSubmitLayer .reviewContent form{float:left;margin:0 0 15px}@media (min-width:48em){.reviewSubmitLayer .reviewContent .selectBoxWrapper{width:50%}.reviewSubmitLayer .reviewContent .selectBoxWrapper:nth-child(2n){padding-left:4px}.reviewSubmitLayer .reviewContent .selectBoxWrapper:nth-child(odd){padding-right:4px}.reviewSubmitLayer .reviewContent .footer button{width:auto}}</style>
+
+
+<div class="pl_block pdp_product-reviews js_pdp_product-reviews" data-variation-id="1524535294" data-product-id="1524534276">
+    <!-- workaround with request parameter as long as old architecture is online -->
+    <section id="cr_js_topReviews">
+    
+    
+    
+
+    <h2 class="pl_headline200">Kundenbewertungen</h2>
+    <p class="cr_reviewHeadline__noReviews">Für diesen Artikel wurde noch keine Bewertung abgegeben.</p>
+    <button class="js_submitReview p_btn50--3rd cr_reviewHeadline__submitReviewButton"
+            data-href="/product/products/reviews/submitLayer"
+            data-tracking-information="open_bottom_first">
+        <i class="cr_reviewHeadline__submitReviewStar">o</i>&nbsp;Erste Bewertung abgeben
+    </button>
+
+    <div class="cr_review__verifiedPurchaseInfo pl_mt150">Wir setzen auf den&nbsp;
+        <svg class="cr_review__verifiedPurchaseInfoIcon pl_icon50" role="img"><use xlink:href="/assets-static/icons/pl_icon_check50.svg#pl_icon_check50"></use></svg>
+        <span class="cr_review__verifiedPurchaseInfoText">Verifizierten Kauf</span>:<br>Bewertungen können nur noch von Kunden veröffentlicht werden, die den Artikel <b>bestellt und erhalten</b> haben.
+    </div>
+
+    
+    <script src="/product-customerreview/js/product-customerreview1.279.5682.min.js"></script>
+
+    <script id="tmplReviewFormLayer" type="x-tmpl-mustache">
+<div class="reviewContent pl_m150">
+    <div class="pl_headline100 pl_mb100">Deine Bewertung für diesen Artikel</div>
+    <form id="js_cr_reviewSubmitForm" class="p_form">
+
+        <div class="pl_headline50" data-qa="cr_review-form-layer-product-name">{{ product.name }}</div>
+        <div class="pl_mt150 cr_reviewImageContainer">
+            <div class="cr_reviewImage" data-qa="cr_review-form-layer-product-image">
+                <img src="{{ product.imageUrl }}" data-product-image-fallback-url="{{ product.imageFallbackUrl }}"/>
+            </div>
+            <div class="cr_reviewDimensions pl_pl100">
+                <ul>
+                    {{# product.dimensions }}
+                        <li class="pl_copy100">{{ displayName }}: <b>{{ value }}</b></li>
+                    {{/ product.dimensions }}
+                </ul>
+            </div>
+        </div>
+
+        <div id="cr_reviewErrorContainer" class="pl_mt100 pl_banner pl_banner--error qs_submitResult">
+            
+            <span>
+                <ul class="js-review-errorContainer-list"></ul>
+            </span>
+        </div>
+
+
+        <div class="cr_reviewRatingContainer pl_mt175">
+            <span class="pl_headline50">
+                <label for="cr_reviewRating" data-qa="cr_review-rating-label">
+                    <strong>Wie viele Sterne vergibst du?</strong>
+                </label>
+            </span>
+            <div class="js-starSelection pl_mt100">
+                <div class="js-stars">
+                    <span data-message="Sehr schlecht" class="star-empty js-star pl_icon100"></span>
+                    <span data-message="Schlecht" class="star-empty js-star pl_icon100"></span>
+                    <span data-message="Mittelmäßig" class="star-empty js-star pl_icon100"></span>
+                    <span data-message="Gut" class="star-empty js-star pl_icon100"></span>
+                    <span data-message="Sehr gut" class="star-empty js-star pl_icon100"></span>
+                </div>
+                <div class="js-message pl_copy100" data-qa="cr_review-rating-message">Bitte wählen</div>
+                <input
+                    id="cr_reviewRating"
+                    class="js-review-rating"
+                    type="hidden"
+                    name="rating"
+                    data-required-message="Bitte wähle eine Bewertung zwischen 1 und 5 Sternen."
+                    value=""
+                />
+            </div>
+        </div>
+
+        <div class="cr_recommendationContainer pl_mt150">
+            <div class="pl_headline50"><strong>Würdest du diesen Artikel weiterempfehlen?</strong></div>
+            <div class="pl_mt100">
+                <div class="pl_radio pl_mr150 left">
+                    <input class="pl_radio__button" type="radio" id="recommended_0" name="recommended" value="true"/>
+                    <label class="pl_radio__label" for="recommended_0">Ja</label>
+                </div>
+
+                <div class="pl_radio">
+                    <input class="pl_radio__button" type="radio" id="recommended_1" name="recommended" value="false"/>
+                    <label class="pl_radio__label" for="recommended_1">Nein</label>
+                </div>
+            </div>
+        </div>
+
+        <div class="pl_mt150 cr_reviewHeadingContainer">
+            <div class="pl_headline50 pl_mb100">
+                <label for="cr_reviewTitle" data-qa="cr_review-rating-title"><strong>Verfasse deine Bewertung:</strong></label>
+            </div>
+
+            <div class="js-pl_input pl_input">
+                <input
+                    class="pl_input__field js-pl_counter"
+                    id="cr_reviewTitle"
+                    placeholder="Überschrift für deine Bewertung (optional)"
+                    type="text"
+                    extraClass="js-pl_counter"
+                    value=""
+                    maxlength="46"
+                    name="title"
+                />
+
+                <label for="cr_reviewTitle" class="js-pl_label pl_label">
+                    Überschrift für deine Bewertung (optional)
+                </label>
+
+                <small class="pl_input__note">Zum Beispiel: Ein toller Artikel, der Spaß macht!</small>
+            </div>
+        </div>
+
+        <div class="pl_textarea cr_reviewTextContainer" data-qa="cr_review-text-container">
+            <textarea
+                class="pl_textarea__element js-pl_counter"
+                id="cr_reviewText"
+                placeholder="Beschreibe bitte in kurzen Sätzen einige Vor- und Nachteile des Artikels und wie du ihn verwendest."
+                extraClass="js-pl_counter"
+                data-minlength="50"
+                maxlength="4000"
+                name="text"
+                data-required-message="Bitte fülle den Bewertungstext aus."
+                data-minlength-message="Der Bewertungstext sollte mindestens 50 Zeichen lang sein."
+            ></textarea>
+
+            <label class="js-pl_label pl_label" for="cr_reviewText">
+                Deine ausführliche Bewertung
+            </label>
+
+            <small class="pl_textarea__note">
+                Beschreibe bitte in kurzen Sätzen einige Vor-und Nachteile des Artikels und wie du ihn verwendest.
+            </small>
+        </div>
+
+        <a class="js_openInPaliLayer pl_link100--primary" href="/shoppages/kundenbewertung_richtlinien" data-contentclass="richtlinien">Richtlinien für Bewertungen</a>
+
+        <div class="cr_reviewCustomerData pl_mt150" data-qa="cr_review-form-layer-customer-name">
+            <div class="pl_headline50"><strong>Deine Angaben</strong> (werden mit der Bewertung veröffentlicht)</div>
+
+            <div class="pl_radio pl_mt100">
+               <input class="pl_radio__button" checked="checked" type="radio" id="name_0" name="anonymous" value="false"/>
+               <label class="pl_radio__label" for="name_0">{{ user.firstName }} {{ user.lastNameAbbr }}. aus {{user.city}}</label>
+            </div>
+
+            <div class="pl_radio pl_mt75">
+                <input class="pl_radio__button" type="radio" id="name_1" name="anonymous" value="true"/>
+                <label class="pl_radio__label" for="name_1">{{ user.anonymousSalutation }} aus {{ user.city }}</label>
+            </div>
+        </div>
+
+        <div class="pl_copy100 pl_mt175">
+            Mit Absenden erkennst du die
+            <a class="js_openInPaliLayer pl_link100--primary" href="/shoppages/kundenbewertung_datenschutz" data-contentclass="datenschutz">
+                Datenschutz- und Einsendebedingungen
+            </a>
+            an.
+        </div>
+
+        <div class="pl_mt175">
+            <button class="pl_button100--primary" type="submit" data-qa="cr_reviewSubmitButton">
+                <span>Absenden</span>
+            </button>
+        </div>
+    </form>
+</div>
+
+
+</script>
+    <script type="text/javascript">
+    let isNewArch = true;
+    /*<![CDATA[*/
+    (() => {
+        o_global.eventLoader.onLoad(0, function () {
+
+            if (isNewArch) {
+                o_global.eventQBus.on('ft5.product-reviews.variationChange', (eventPayload) => {
+                    const reviewFormLayer = new o_cr.widgets.ReviewFormLayer(document.getElementById('cr_js_topReviews'));
+                    reviewFormLayer.initNewArch(eventPayload);
+                });
+            } else {
+                const reviewFormLayer = new o_cr.widgets.ReviewFormLayer(document.getElementById('cr_js_topReviews'));
+                reviewFormLayer.initOldArch();
+                o_global.eventQBus.emitModuleLoaded('ft5.customerreview.reviewFormLayer');
+            }
+
+        });
+    })();
+    /*]]>*/
+</script>
+
+</section>
+
+</div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/product-reviews-OUZOUNYL.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+            
+<link rel="preload" crossorigin="anonymous" href="/product-assets/expert-reviews-4YIKSPWD.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/expert-reviews-4YIKSPWD.css" crossorigin="anonymous"/></noscript>
+            <div class="pl_block pl_block--transparent pl_block--no-padding pdp_reco-complementary pdp_reco-complementary--e549-active js_pdp_reco-complementary" data-variation-id="1524535294"></div>
+
+  <link rel="preload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.3afc4579.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.3afc4579.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.module.46bea43c.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.nomodule.a87b68b8.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+
+<div style="display:none;" id="reco_cinema__toggle-state" data-toggle-state="{&quot;SHOW_DEALS&quot;:true,&quot;CSR&quot;:false,&quot;USE_OPAL_RELATIONSHIPS&quot;:true,&quot;TESLA_COLDSTART&quot;:false,&quot;USE_TESLA_ARTHURDENT&quot;:true,&quot;USE_TESLA_META&quot;:true,&quot;SHOW_DETAILVIEW_ONLY&quot;:false,&quot;DISPLAY_LAST_SEEN_ARTICLES&quot;:true,&quot;USE_TESLA_HITCHHIKER&quot;:true,&quot;WISHLIST_RECO_REDESIGN&quot;:true,&quot;RECO_REDESIGN&quot;:true}">
+</div>
+<script>
+  window.o_reco = window.o_reco || {};
+  window.o_reco.api = window.o_reco.api || {};
+  window.o_reco.private = window.o_reco.private || {};
+  window.o_reco.private.toggleState = JSON.parse(document.getElementById('reco_cinema__toggle-state').dataset.toggleState);
+
+  window.o_reco.private.delegate = function (originalFunction) {
+    return function () {
+      var passedArguments = arguments;
+      return new Promise(function (resolve, reject) {
+        o_global.eventLoader.onAllScriptsExecuted(10, function () {
+          window.o_reco.private[originalFunction].apply(null, passedArguments).then(resolve).catch(reject);
+        });
+      });
+    };
+  };
+
+  window.o_reco.private.delegateAndWrap = function (originalFunction) {
+    return function () {
+      var passedArguments = arguments;
+      return new Promise(function (resolve) {
+        o_global.eventLoader.onAllScriptsExecuted(10, function () {
+          var result = window.o_reco.private[originalFunction].apply(null, passedArguments);
+          resolve(result);
+        });
+      });
+    };
+  };
+
+  window.o_reco.api.initializeCinema = window.o_reco.private.delegateAndWrap('initializeCinema');
+  window.o_reco.api.initializeExpandableCinema = window.o_reco.private.delegateAndWrap('initializeExpandableCinema');
+  window.o_reco.api.loadRecommendationsForDetailView = window.o_reco.private.delegateAndWrap('asyncLoadRecommendationsForDetailView');
+
+  window.o_reco.api.loadRecommendationsForOrderOverview = window.o_reco.private.delegate('loadRecommendationsForOrderOverview');
+  window.o_reco.api.loadRecommendationsForWishlist = window.o_reco.private.delegate('loadRecommendationsForWishlist');
+  window.o_reco.api.loadRecommendationsForEntryPage =
+          window.o_reco.private.toggleState["CSR"] ?
+                  window.o_reco.private.delegateAndWrap('loadRecommendationsForEntryPageCsr') :
+                  window.o_reco.private.delegate('loadRecommendationsForEntryPage');
+  window.o_reco.api.loadBounceLayerCinema = window.o_reco.private.delegateAndWrap('loadBounceLayerCinema');
+
+  o_global.eventQBus.emit("ft6bcn.reco.init", ".reco.cinema.needsInitialization");
+</script>
+
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/reco-complementary-XSERL5VU.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/reco-complementary-AMHOQZBH.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/reco-complementary-AMHOQZBH.css" crossorigin="anonymous"/></noscript>
+            <div class="dcs_link-boxes pl_block">
+    <div class="nav_link-boxes"><h2 class="nav-linkbox-headline pl_headline100">Mehr entdecken</h2><div class="nav-brand-different"><h3 class="pl_headline50">Kühlschränke anderer Marken</h3><ul class="nav-link-list"><li class="nav-separable-link"><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/side-by-side-kuehlschraenke/?marke=siemens" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_other_brands&quot;}">Siemens Side-by-Side-Kühlschränke</a></li><li class="nav-separable-link"><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/side-by-side-kuehlschraenke/?marke=lg" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_other_brands&quot;}">LG Side-by-Side-Kühlschränke</a></li><li class="nav-separable-link"><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/side-by-side-kuehlschraenke/?marke=bosch" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_other_brands&quot;}">Bosch Side-by-Side-Kühlschränke</a></li><li class="nav-separable-link"><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/side-by-side-kuehlschraenke/?marke=hanseatic" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_other_brands&quot;}">Hanseatic Side-by-Side-Kühlschränke</a></li><li class="nav-separable-link"><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/side-by-side-kuehlschraenke/?marke=midea" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_other_brands&quot;}">Midea Side-by-Side-Kühlschränke</a></li><li class="nav-separable-link"><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/side-by-side-kuehlschraenke/?marke=beko" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_other_brands&quot;}">Beko Side-by-Side-Kühlschränke</a></li></ul></div><div class="nav-brand-all"><h3 class="pl_headline50">Ähnliche Kategorien</h3><ul class="nav-link-list"><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/kuehl-gefrierkombinationen/" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Kühl-Gefrierkombinationen</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/side-by-side-kuehlschraenke/" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Side-by-Side-Kühlschränke</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/einbaukuehlschraenke/" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Einbaukühlschränke</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/minikuehlschraenke/" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Mini-Kühlschränke</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/retrokuehlschraenke/" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Retro-Kühlschränke</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/unterbaukuehlschraenke/" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Unterbaukühlschränke</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/weinkuehlschraenke/" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Weinkühlschränke</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/side-by-side-kuehlschraenke/?ausstattung=mit-festwasseranschluss" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Festwasseranschluss Side-by-Side-Kühlschränke</a></li></ul><ul class="nav-link-list-right"><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/getraenkekuehlschraenke/" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Getränkekühlschränke</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/standkuehlschraenke/" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Standkühlschränke</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/side-by-side-kuehlschraenke/?farbe=schwarz" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Schwarzer Side-by-Side-Kühlschrank</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/kuehl-gefrierkombinationen/?farbe=schwarz" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Schwarze Kühl-Gefrierkombination</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/?thema=einbaugeraete" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Einbaugeräte</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/kuehl-gefrierkombinationen/?reduziert" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Günstige Kühl-Gefrierkombinationen</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/side-by-side-kuehlschraenke/?reduziert" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Günstige Side-by-Side-Kühlschränke</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/einbaukuehlschraenke/?nischenhoehe=123-cm" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_gen&quot;}">Einbaukühlschrank 122 cm</a></li></ul></div><div class="nav-brand-same"><h3 class="pl_headline50">Mehr von Samsung</h3><ul class="nav-link-list"><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/?marke=samsung" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_same_brand&quot;}">Samsung Kühlschränke</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/geschirrspueler/?marke=samsung" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_same_brand&quot;}">Samsung Geschirrspüler</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/kuehl-gefrierkombinationen/?marke=samsung" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_same_brand&quot;}">Samsung Kühl-Gefrierkombinationen</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/side-by-side-kuehlschraenke/?marke=samsung" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_same_brand&quot;}">Samsung Side-by-Side-Kühlschränke</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/?ausstattung=eisbereiter&amp;marke=samsung" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_same_brand&quot;}">Samsung Kühlschrank mit Eiswürfelspender</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/?ausstattung=nofrost&amp;marke=samsung" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_same_brand&quot;}">Samsung Kühlschranke mit NoFrost</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/kuehlschraenke/?farbe=schwarz&amp;marke=samsung" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_same_brand&quot;}">Schwarze Samsung Kühlschränke</a></li><li><a class="pl_link100--secondary ts-link" href="/haushalt/geschirrspueler/einbaugeschirrspueler/?marke=samsung" data-ts-link="{&quot;san_Navigation&quot;:&quot;sim_cat_same_brand&quot;}">Samsung Einbaugeschirrspüler</a></li></ul></div><div class="nav-static"><link rel="preload" href="/nav-tyson/static/compiled/nav.tyson.link_boxes.be992ea6.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous" /><link rel="stylesheet" href="/nav-tyson/static/compiled/nav.tyson.link_boxes.be992ea6.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous" /></div></div>
+</div>
+        </div>
+    </div>
+</div>
+    <div class="pdp_sustainability-sheet js_pdp_sustainability-sheet" style="display: none;">
+        <div class="js_pdp_sustainability-sheet-inner">
+            <div class="pdp_sustainability-sheet__intro pl_copy100">
+                Dieser Artikel ist mit folgenden Nachhaltigkeitssiegeln ausgezeichnet:
+            </div>
+                <div class="pdp_sustainability-sheet__label pl_copy100 pl_mt150">
+                    <figure class="pdp_sustainability-sheet__label-figure">
+                        <img class="pdp_sustainability-sheet__label-image" src="https://i.otto.de/i/otto/energieverbrauchskennzeichnung_teat" alt="Energieeffizientes Gerät">
+                        <figcaption class="pdp_sustainability-sheet__label-name pl_headline100 pl_pl100">Energieeffizientes Gerät
+                        </figcaption>
+                    </figure>
+                    <div class="pdp_sustainability-sheet__label-description pl_mt100">
+                        Energieeffiziente Haushalts- und TV-Geräte spielen für den Klimaschutz eine wichtige Rolle: Je besser die Effizienz, desto mehr Strom wird gespart. Dieses Gerät ist also energiesparend und daher umweltfreundlich. 
+
+Seit dem 01.03.21 gibt es ein neues EU-Energielabel (Skala A-G), das schrittweise eingeführt wird und effiziente Geräte, wie bspw. Waschmaschinen und Kühlschränke kennzeichnet. Backöfen, Trockner und Dunstabzugshauben werden noch mit dem alten EU-Energielabel, das in der Regel die Skala A+++ bis D umfasst, gekennzeichnet. 
+                    </div>
+                        <div class="pdp_sustainability-sheet__category pl_copy75 pl_mt100">
+                            <svg class="pdp_sustainability-sheet__category-icon pl_icon" role="img">
+                                <use xlink:href="/assets-static/icons/pl_icon_sustainable-energy-efficient.svg#pl_icon_sustainable-energy-efficient"/>
+                            </svg>
+                            <span class="pdp_sustainability-sheet__category-description pl_pl100">Energieeffiziente Nutzung</span>
+                        </div>
+                </div>
+        </div>
+    </div>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/sustainability-sheet-ZR5KKX5J.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/sustainability-sheet-N2GLLQR4.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/sustainability-sheet-N2GLLQR4.css" crossorigin="anonymous"/></noscript>
+<div class="js_pdp_ui-aggregator" data-variation-id="1524535294" hidden></div>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/ui-aggregator-ENRGMEEM.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<div id="dcs_tracking-data" data-ft5-view-tracking='{ "product_VariationId":"1524535294" }' data-variation-id="1524535294" class="js_pdp_tracking_component"></div>
+<link rel="preload" crossorigin="anonymous" href="/product-assets/tracking-AX4AOIET.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+
+<link rel="preload" crossorigin="anonymous" href="/product-assets/pdp-frame-O742IZDJ.css" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" type="text/css" href="/product-assets/pdp-frame-O742IZDJ.css" crossorigin="anonymous"/></noscript></div>
+
+<div class="js_tracking" data-track="true"></div>
+<script id="productDataJson" type="application/json">
+        {"id":"1524534276","offerId":null,"brand":"Samsung","brandImageId":"1c317aaf7751f8b652912956fea2ae60","variations":{"1524535294":{"id":"1524535294","name":"Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit","productId":"1524534276","links":null,"images":[{"id":"02f85090-393a-5bd1-b56a-bac9f66295f7","width":1636,"height":2903,"mainImage":true,"initializeImage":true,"selected":true,"number":1,"index":0},{"id":"e1f3b715-0081-5df1-9d50-14c19bc476e8","width":1638,"height":2908,"mainImage":false,"initializeImage":false,"selected":false,"number":2,"index":1},{"id":"5d309975-6917-5f9e-b206-a1c99e83411c","width":3543,"height":2884,"mainImage":false,"initializeImage":false,"selected":false,"number":3,"index":2},{"id":"0d7df4bc-0c08-519f-bb54-ca8a99a2d13b","width":3543,"height":2362,"mainImage":false,"initializeImage":false,"selected":false,"number":4,"index":3},{"id":"155d2ba9-677e-58b3-a93e-6cce63af7783","width":2809,"height":2901,"mainImage":false,"initializeImage":false,"selected":false,"number":5,"index":4},{"id":"5aff029b-a3b2-53e3-b00a-c5336433eb79","width":1477,"height":2901,"mainImage":false,"initializeImage":false,"selected":false,"number":6,"index":5},{"id":"34dd8fd5-3c23-5708-b534-5b890bb19d0c","width":3543,"height":2362,"mainImage":false,"initializeImage":false,"selected":false,"number":7,"index":6},{"id":"e276d855-1d88-5a8e-a51e-29c0a36e0ac2","width":2809,"height":2901,"mainImage":false,"initializeImage":false,"selected":false,"number":8,"index":7},{"id":"c7854689-1dfb-569a-af70-4fab73f0a3e0","width":3372,"height":2949,"mainImage":false,"initializeImage":false,"selected":false,"number":9,"index":8},{"id":"680e6942-55a5-5b3b-a063-8c2228edb6a1","width":3543,"height":2362,"mainImage":false,"initializeImage":false,"selected":false,"number":10,"index":9},{"id":"b349c22c-0a41-5221-bd2f-d2a160c59c41","width":1528,"height":2906,"mainImage":false,"initializeImage":false,"selected":false,"number":11,"index":10},{"id":"d65789ee-743a-51c0-8d1c-e184bc5ebe82","width":2809,"height":2901,"mainImage":false,"initializeImage":false,"selected":false,"number":12,"index":11},{"id":"ca35c0f9-7c14-5e06-b94f-b90295a71763","width":3543,"height":2362,"mainImage":false,"initializeImage":false,"selected":false,"number":13,"index":12}],"availability":{"limitation":null,"limited":false,"orderable":true,"buyable":true,"status":"available","displayName":"lieferbar - in 2-3 Werktagen bei dir","displayNameNotOrderable":"bald zurück","avgDeliveryTime":"2.5","minDeliveryTime":"2.0","maxDeliveryTime":"3.0","avgDeliveryTimeRegionalDiff":null,"showCoronaDeliveryDelayInfo":false},"businessModel":"OTTO","deliveryInfo":{"shippingFlags":["VERSAND_24H_SPEDITION","VERSAND_WUNSCHTERMIN","SPEDITION"],"nextPossibleDeliveryDate":"Mittwoch bei Bestellung bis 13 Uhr"},"dimensions":{"dimension":[]},"articleNumber":"61094760","promotionNumber":"22","skuSuffix":null,"retailer":{"id":"0","name":"OTTO","isOtto":true},"patternSample":null,"customDimensions":{"dimension":[]},"customMeasureType":null,"assortmentCode":"665","articleNumberWithPromotion":"6109476022","description":null,"htmlCharacteristics":null,"sellingPoints":{"sellingPoint":["Nutzinhalt: 635 Liter","No Frost – nie wieder abtauen!","Metal Cooling","Festwasseranschluss notwendig!","Space Max"]},"sale":true,"businessCategory":{"value":"HAUSHALTSELEKTRO","group":"ELECTRONIC_DIGITAL"},"companyId":0,"mainImageRelativeHeight":177,"seoImageUrlCurrent":"https:#ft5_slash##ft5_slash#i.otto.de#ft5_slash#i#ft5_slash#otto#ft5_slash#02f85090-393a-5bd1-b56a-bac9f66295f7#ft5_slash#samsung-side-by-side-rs6ga884csl-178-cm-hoch-91-2-cm-breit.jpg?$formatz$","energyEfficiency":{"base64DataSheetUrl":"aHR0cHM6Ly9kLm90dG8uZGUvZmlsZXMvOWQ1ZTMyYWMtYTMwNC01YzhhLTg3NzgtNjYwZGZiZjg5MmU5LnBkZg==","showNewEnergyLabelInfoLayer":true,"energyEfficiencyClasses":[{"category":null,"component":null,"slugifiedComponent":null,"energyLabel":{"color":"lightGreen","letter":"C","plus":null},"scaleUniform":true,"colorHexcode":null,"encodedDocumentUrl":null,"images":null,"imageList":["https:#ft5_slash##ft5_slash#i.otto.de#ft5_slash#i#ft5_slash#otto#ft5_slash#365a4ef4-8cc5-5818-9f58-93efe1645fe6"]}]},"energyEfficiencyClass":null,"downloadableDocuments":[{"dataUrl":"https:#ft5_slash##ft5_slash#d.otto.de#ft5_slash#files#ft5_slash#bf35abd2-0715-516f-bf7b-2ca72b9fb8ac.pdf","displayName":"Bedienungsanleitung","type":"BEDIENUNGSANLEITUNG"}],"displayPrice":{"comparativePriceAdvantage":"31","hasSuggestedRetailPrice":true,"comparativePriceAmount":"2.899,00","priceAmount":199900,"formattedPriceAmount":"1.999,00","techPriceAmount":"1999.00","priceDifferenceToFirstVariation":null,"customMeasureType":null,"normPrice":null,"installments":{"amount":"54,80","count":48},"hasMoreExpensiveAvailableVariation":false},"expertReviews":null,"detailIcons":{"cut":[],"care":[],"quality":[]},"consultingDetails":[{"displayName":"Entsorgungshinweis","name":"DISPOSAL_NOTE","contentUrl":"#ft5_slash#shoppages#ft5_slash#consultingdetail_disposal_note"}],"deal":{"name":"Topmarken reduziert_Haushalt","contentUrl":null,"iconUrl":null,"highlight":null},"ean":"8806092536593","moin":"M00N9C00WK","cashback":null,"manufacturerContent":{"provider":"FLIXMEDIA","id":"8806092536593"},"score":null,"richContentUrl":"#ft5_slash#product-richcontent#ft5_slash#flixmedia_8806092536593.html","sustainable":true,"sustainability":{"categories":{"ENERGIEEFFIZIENTE_NUTZUNG":true},"detailsUrl":"#ft5_slash#product#ft5_slash#sustainability#ft5_slash#layerContent?labels=%5B%7B%22id%22%3A%22ENERGIEEFFIZIENTES_GERAET%22%7D%5D","encodedStatementUrl":"L3Nob3BwYWdlcy9uYWNoaGFsdGlna2VpdA=="},"benefits":null,"hazmat":false,"title":"Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit online kaufen | OTTO","dimensionCount":0}},"sortedVariationIds":["1524535294"],"distinctDimensions":[],"htmlCharacteristics":"<table class=\"dv_characteristicsTable\"><caption>Hinweise<#ft5_slash#caption><tr><td class=\"left\"><span>Bestellhinweis<#ft5_slash#span><#ft5_slash#td><td>Bitte beachten Sie vor einer Bestellung die Verpackungsmaße des Gerätes und ob dieses bis zum Aufstellort transportiert werden kann. Bei Fragen wenden Sie sich gerne an unsere Produktberatung.<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table> <table class=\"dv_characteristicsTable\"><caption>Top-Feature<#ft5_slash#caption><tr><td class=\"left\"><span>Top-Features<#ft5_slash#span><#ft5_slash#td><td>NoFrost Plus<br #ft5_slash#>Space Max<br #ft5_slash#>Metal Cooling<br #ft5_slash#>Festwasseranschluss notwendig!<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table> <table class=\"dv_characteristicsTable\"><caption>Produktdetails<#ft5_slash#caption><tr><td class=\"left\"><span>Farbe Front<#ft5_slash#span><#ft5_slash#td><td>edelstahl<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Farbe Seitenteile<#ft5_slash#span><#ft5_slash#td><td>silberfarben<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table> <table class=\"dv_characteristicsTable\"><caption>Leistung &amp; Verbrauch<#ft5_slash#caption><tr><td class=\"left\"><span>Modellbezeichnung<#ft5_slash#span><#ft5_slash#td><td>RS6GA884CSL<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Energieeffizienzklasse (Skala)<#ft5_slash#span><#ft5_slash#td><td>C (A bis G)<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Jährlicher Energieverbrauch<#ft5_slash#span><#ft5_slash#td><td>225 kWh<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Frostfrei<#ft5_slash#span><#ft5_slash#td><td>ja, NoFrost im Gefrierteil<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Gefriervermögen in 24 Stunden<#ft5_slash#span><#ft5_slash#td><td>15 kg<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Klimaklasse<#ft5_slash#span><#ft5_slash#td><td>SN-N-ST-T<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Rauminhalte der Kühlfächer<#ft5_slash#span><#ft5_slash#td><td>409 l<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Rauminhalte der Tiefkühlfächer<#ft5_slash#span><#ft5_slash#td><td>226 l<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Luftschallemissionen<#ft5_slash#span><#ft5_slash#td><td>35 dB(A)<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table> <table class=\"dv_characteristicsTable\"><caption>Betriebskosten<#ft5_slash#caption><tr><td class=\"left\"><span>Energiekosten #ft5_slash# Jahr<#ft5_slash#span><#ft5_slash#td><td>67,5 €<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table> <table class=\"dv_characteristicsTable\"><caption>Ausstattung<#ft5_slash#caption><tr><td class=\"left\"><span>Display mit Temperaturanzeige<#ft5_slash#span><#ft5_slash#td><td>innen liegend<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Festwasseranschluss nötig<#ft5_slash#span><#ft5_slash#td><td>ja<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Warnsignal<#ft5_slash#span><#ft5_slash#td><td>Tür offen<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Zusatzausstattung<#ft5_slash#span><#ft5_slash#td><td>Wasserspender<br #ft5_slash#>Eisbereiter<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table> <table class=\"dv_characteristicsTable\"><caption>Ausstattung &amp; Funktionen Kühlteil<#ft5_slash#caption><tr><td class=\"left\"><span>Anzahl Ablageflächen<#ft5_slash#span><#ft5_slash#td><td>5<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Anzahl Türablagen<#ft5_slash#span><#ft5_slash#td><td>5<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Anzahl Kühlschubladen<#ft5_slash#span><#ft5_slash#td><td>4<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Art Innenbeleuchtung<#ft5_slash#span><#ft5_slash#td><td>LED-Innenbeleuchtung<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table> <table class=\"dv_characteristicsTable\"><caption>Ausstattung &amp; Funktionen Gefrierteil<#ft5_slash#caption><tr><td class=\"left\"><span>Anzahl Gefrierschubladen<#ft5_slash#span><#ft5_slash#td><td>2<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Anzahl offene Gefrierfächer<#ft5_slash#span><#ft5_slash#td><td>4<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table> <table class=\"dv_characteristicsTable\"><caption>Informationen zum Einbau<#ft5_slash#caption><tr><td class=\"left\"><span>Einbauart<#ft5_slash#span><#ft5_slash#td><td>freistehend<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table> <table class=\"dv_characteristicsTable\"><caption>Maße &amp; Gewicht<#ft5_slash#caption><tr><td class=\"left\"><span>Höhe<#ft5_slash#span><#ft5_slash#td><td>178 cm<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Breite<#ft5_slash#span><#ft5_slash#td><td>91,2 cm<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Tiefe<#ft5_slash#span><#ft5_slash#td><td>73,5 cm<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Gewicht<#ft5_slash#span><#ft5_slash#td><td>123 kg<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table> <table class=\"dv_characteristicsTable\"><caption>Technische Daten<#ft5_slash#caption><tr><td class=\"left\"><span>Türanschlag wechselbar<#ft5_slash#span><#ft5_slash#td><td>nein<#ft5_slash#td><#ft5_slash#tr><tr><td class=\"left\"><span>Spannung<#ft5_slash#span><#ft5_slash#td><td>220-240 V<#ft5_slash#td><#ft5_slash#tr><#ft5_slash#table>","description":"<p>Der Side-by-Side Kühlschrank »RS6GA884CSL« von Samsung hat eine hohe Funktionalität sowie die Energieeffizienz-Klassifizierung C (Skala Energieeffizienz-Klassifizierung Einheitsskala (A bis G)) und ist freistehend. Die Maße des Side-by-Side Kühlschranks liegen bei 91,2 x 178 x 73,5 cm (B#ft5_slash#H#ft5_slash#T). Durch die No Frost-Funktion muss das Gerät nie wieder abgetaut werden. Das Gerät verfügt auch über einen Wasserspender. Durch den Festwasseranschluss ist ganz ohne Nachfüllen immer genug gekühltes Wasser auf Lager. Zwei Gefrierschubladen und vier Gemüseschubladen stehen zur Verfügung, um Nahrungsmittel zu verstauen. Die Temperatur im Gerät wird auf dem innen installierten Display angezeigt. Auf fünf Ablageflächen ist im Side-by-Side Kühlschrank viel Platz für Lebensmittel. Die fünf Türablagen ermöglichen eine übersichtliche Lagerung. Bei offen stehender Tür meldet dies der Side-by-Side Kühlschrank mit einem Warnsignal. Den Überblick behält man außerdem durch die LED-Innenbeleuchtung. Wer auf der Suche ist nach einem Gerät, das ausreichend Platz für Lebensmittel bietet, der trifft mit dem »RS6GA884CSL« von Samsung eine gute Wahl.<#ft5_slash#p>","variationTree":null,"gratisInformationValue":null,"hasOptions":true}
+</script>
+
+<script id="productSettings" type="application/json">
+    {"CONFIG_ENABLE_MANUFACTURER_CONTENT":"true","FEATURE_1236_ONLINE_ADVICE_ONEX":"true","FEATURE_INCLUDE_JSON_LD":"true","FEATURE_1178_CR_RENDERS_REVIEW_FORM":"true","CONFIG_PRODUCT_COMPARISON":"true","FEATURE_WISHLIST_VIA_API":"true","FEATURE_1165_VERIFIED_PURCHASE":"true","FEATURE_1186_SHOW_RED_PRICE_ON_ACTIVE_BENEFIT":"true","FEATURE_NEW_SPONSORED_PRODUCTS_ENDPOINT":"true","FEATURE_NEW_PDP_FRAME":"true","FEATURE_1340_ENABLE_SHARING_ON_ALL_DEVICES":"true","FEATURE_747_PBKBASED_TABLESIZE":"true","FEATURE_934_ADD_LINK_TO_SUSTAINABLE_BADGE":"true","ONEX_USE_CHALLENGER_SCORE_RANKING":"true","FEATURE_1395_SEND_BENEFIT_SLOTS_COMPLETE_EVENT":"true","CONFIG_SHOW_VIDEOS_LINK":"true","FEATURE_1119_SHOW_NEW_EEK_LABEL_LAYER":"true","FEATURE_1311_ENABLE_ONEX_E497_SHOW_CO2_NEUTRAL_SHIPPING":"true","FEATURE_1447_OTTO_UP_REDIRECT":"true"}
+</script>
+
+<script id="js_prd_imageConfig" type="application/json">
+    {"imageServerPath":"https:\/\/i.otto.de\/i\/otto\/","presets":{"brandLogoRetina":"?$ov_brandlogo_retina$","colorDimension":"?$articlecolorthumbsmall$","patternSampleStoff":"?$stanze_stoff$","patternSampleLeder":"?$stanze_leder$","mainImage":{"S":"?h=900&w=1200&qlt=40&fmt.options=interlaced&unsharp=0,1,0.6,7&sm=clamp","XL":"?h=520&w=551&sm=clamp","L":"?h=520&w=481&sm=clamp","M":"?h=1200&w=1800&qlt=40&fmt.options=interlaced&unsharp=0,1,0.6,7&sm=clamp"},"thumbnail":"?$001PICT36$","patternSampleHolz":"?$stanze_holz$","mainImageReviewSubmit":"?$001PICT31$","mainImageMiniDetailView":"?$001PICT30$","productDetails":"?$ov_quality_details_retina$","brandLogo":"?$ov_brandlogo$","soldOut":"?$001PICT25$"},"fallbackImageId":"lh_platzhalter_ohne_abbildung"}
+</script>
+
+    <script id="productStaticAssetUrls" type="application/json">
+{"reviewSubmitLayerUnverified":{"js":"/product/static/assets/ft5.detailview.reviewSubmitLayerUnverified.cc2739b1.js"},"body":{"js":"/product/static/assets/ft5.detailview.body.f1427b2e.js"},"head":{"css":"/product/static/assets/ft5.detailview.head.6b642614.css"},"order":{"css":"/product/static/assets/ft5.detailview.order.89635da4.css","js":"/product/static/assets/ft5.detailview.order.a6239390.js"},"installmentsCalculator":{"css":"/product/static/assets/ft5.detailview.installmentsCalculator.370e8860.css"},"photoswipe":{"js":"/product/static/assets/ft5.detailview.photoswipe.ddc8d4bc.js"},"dummy":{"css":"/product/static/assets/ft5.detailview.dummy.3dd5d4e0.css"},"submitReview":{"css":"/product/static/assets/ft5.detailview.submitReview.5040ecb0.css"},"reviewSubmitLayer":{"js":"/product/static/assets/ft5.detailview.reviewSubmitLayer.adfef318.js"}}    </script>
+                    <div class="clear"></div>
+                </div>
+                <div class="clear"></div>
+                <footer class="prd_footer">
+                    <link href="/shoppages/static/assets/sho.shoppages.assets-public.c2691b52.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/shoppages/static/assets/sho.shoppages.assets-public.c2691b52.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" crossorigin="anonymous" href="/shoppages/static/assets/sho.shoppages.assets-public.21298cd5.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>  <div class="sp_footerNormal" style="visibility:hidden;">
+        <div class="pl_grid-content pl_mb25">
+          <div class="pl_grid-container pl_block--full-bleed">
+            <div class="pl_grid-col-12">
+                  <div class="user_system_rwd">
+<link href="/user/assets/ft4.user.newsletter-snippet.f445ce0c.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/user/assets/ft4.user.newsletter-snippet.f445ce0c.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" crossorigin="anonymous" href="/user/assets/ft4.user.newsletter-snippet.d387de48.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>        <div id="us_id_newsletterSnippet" class="us_newsletterSnippet">
+        </div>
+    </div>
+
+            </div>
+          </div>
+        </div>
+      <div class="pl_grid-content pl_mb25 sp_first_row">
+        <div class="pl_grid-container pl_block">
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 sp_first_column" style="align-self: center">
+            <div class="pl_grid-content">
+              <div class="pl_grid-container pl_pr50" style="display: flex;">
+                <div>
+                  <svg class="pl_icon100 pl_mr100 sp_mein_konto_logo" role="img" style="vertical-align: middle;">
+                    <use xlink:href="/assets-static/icons/pl_icon_person.svg#pl_icon_person"/>
+                  </svg>
+                </div>
+                <span class="ts-link ub64e pl_link100--secondary sp_mein_konto_link sp_mein_konto_text"
+                      data-ub64e="L3VzZXIvYWNjb3VudE92ZXJ2aWV3P2VudHJ5UG9pbnQ9Zm9vdGVy"
+                      data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_MeinKonto&quot;}"
+                >
+                Mein Konto
+              </span>
+              </div>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 sp_second_column" style="align-self: center">
+            <div class="pl_grid-content">
+              <div class="pl_grid-container pl_pr50" style="display: flex;">
+                    <div>
+                      <svg class="pl_icon100 pl_mr100 sp_geschenkgutscheine_logo" role="img" style="vertical-align: middle;">
+                        <use xlink:href="/assets-static/icons/pl_icon_voucher.svg#pl_icon_voucher"/>
+                      </svg>
+                    </div>
+                    <span class="ts-link ub64e pl_link100--secondary sp_geschenkgutscheine_link"
+                          data-ub64e="L3Avb3R0by1nZXNjaGVua2d1dHNjaGVpbi12b24tMTAtMjUwLWV1cm8tMTAwNjM0MTQz"
+                          data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Geschenkgutscheine&quot;}"
+                    >
+                    Geschenkgutscheine
+                  </span>
+              </div>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 sp_third_column" style="align-self: center">
+            <div class="pl_grid-content">
+              <div class="pl_grid-container pl_pr50" style="display: flex;">
+                <div>
+                  <svg class="pl_icon100 pl_mr100 sp_lobUndKritik_logo" role="img" style="vertical-align: middle;">
+                    <use xlink:href="/assets-static/icons/pl_icon_feedback.svg#pl_icon_feedback"/>
+                  </svg>
+                </div>
+                <span class="ts-link ub64e pl_link100--secondary sp_js_track_feedback sp_lobUndKritik_link"
+                      data-ub64e="L2NvbnRhY3QtZmVlZGJhY2svZmVlZGJhY2s="
+                      data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_LobUndKritikBig&quot;}"
+                >
+                Lob &amp; Kritik
+              </span>
+              </div>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 sp_fourth_column">
+            <div class="pl_block--no-padding">
+            <span class="ts-link ub64e pl_link--primary sp_shop_link"
+                  data-ub64e="aHR0cHM6Ly9laGktc2llZ2VsLmRlL3ZlcmJyYXVjaGVyL3Nob3BzLW1pdC1zaWVnZWwvemVydGlmaXppZXJ0ZS1zaG9wcy96ZXJ0aWZpa2F0L2M3MWUyNGM5ZmRmNjgxMGQxYjY5NDc5YzcxMDk5YjJmLw=="
+                  data-target="_blank"
+                  data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Shop&quot;}">
+              <svg class="pl_logo sp_shop_logo" role="img" height="40" width="40">
+                <use xlink:href="/assets-static/icons/pl_logo_ehi.svg#pl_logo_ehi"/>
+              </svg>
+            </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="pl_grid-content pl_block pl_mb25 sp_second_row">
+        <div class="pl_grid-container">
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 sp_first_column">
+            <div class="pl_headline100">
+              <a class="ts-link pl_link sp_color_black100" href="/shoppages/service/"
+                 style="text-decoration: none;"
+                 data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Otto-Service&quot;}">
+                <span style="all: unset;">Service</span></a>
+            </div>
+            <div class="pl_mb50 pl_mt100 pl_copy100 sp_color_black100 sp_questions">
+              Wir sind gerne für dich da.
+            </div>
+            <div class="pl_mb50 sp_phoneNumber">
+              <a class="ts-link pl_link100--secondary" href="tel:+494036033603"
+                 data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_ServiceHotline&quot;}">
+            <span style="all: unset;">
+              040 - 3603 3603
+            </span>
+              </a>
+            </div>
+            <div class="pl_mb50 pl_copy100">
+              <a class="ts-link pl_link100--secondary sp_callback_link" href="/contact-callback/callback"
+                 data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_RueckrufService&quot;}">
+            <span style="all: unset;">
+              Kostenloser Rückrufservice
+            </span>
+              </a>
+            </div>
+            <div class="pl_mb175 pl_copy100">
+              <a class="ts-link js_openInPopup pl_link100--secondary sp_contactform_link"
+                 href="/user/contactForm" target="_blank" rel="noopener noreferrer"
+                 data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Kontakt&quot;}">
+                service@otto.de
+              </a>
+            </div>
+            <div class="pl_mb150 sp_logos_container">
+              <div class="sp_logo_appStore pl_mb100">
+                <a class="ts-link sp_apple-app-store-badge_link"
+                   href="https://frj4.adj.st/www.otto.de/extern/?page=%2F&amp;otto_deep_link=https%3A%2F%2Fwww.otto.de&amp;adjust_t=ne03zg_ig5rmn&amp;adjust_deeplink=otto%3A%2F%2Fwww.otto.de%2Fextern%2F%3Fpage%3D%252F&amp;adjust_fallback=https%3A%2F%2Fwww.otto.de%2Fapp&amp;adjust_redirect_macos=https%3A%2F%2Fwww.otto.de%2Fapp"
+                   rel="noopener noreferrer"
+                   data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_AppStoreApple&quot;}">
+                  <img class="sp_apple-app-store-badge_logo"
+                       src="/assets-static/icons/pl_logo_app-store.svg#pl_logo_app-store" width="120"
+                       height="40" alt="App Store">
+                </a>
+              </div>
+              <div class="sp_logo_playStore">
+                <a class="ts-link sp_google-play-badge_link"
+                   href="https://frj4.adj.st/www.otto.de/extern/?page=%2F&amp;otto_deep_link=https%3A%2F%2Fwww.otto.de&amp;adjust_t=ne03zg_ig5rmn&amp;adjust_deeplink=otto%3A%2F%2Fwww.otto.de%2Fextern%2F%3Fpage%3D%252F&amp;adjust_fallback=https%3A%2F%2Fwww.otto.de%2Fapp&amp;adjust_redirect_macos=https%3A%2F%2Fwww.otto.de%2Fapp"
+                   rel="noopener noreferrer"
+                   data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_AppStoreAndroid&quot;}">
+                  <img class="sp_google-play-badge_logo"
+                       src="/assets-static/icons/pl_logo_play-store.svg#pl_logo_play-store" width="135"
+                       height="40" alt="Play Store">
+                </a>
+              </div>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 sp_second_column">
+        <span class="pl_headline100 sp_color_black100">
+          Zahlungsarten
+        </span>
+            <div class="pl_mb50 pl_mt100">
+              <span class="ts-link ub64e pl_link100--secondary sp_sepa_link"
+                    data-ub64e="L3Nob3BwYWdlcy9wYXltZW50IzVkYTliZWNmNmYxYzIxMzUxY2RlNTZiMQ=="
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Sepa&quot;}">
+                  <svg class="pl_logo sp_sepa_logo" role="img" viewBox="0 0 106 40" height="16">
+                    <use xlink:href="/assets-static/icons/pl_logo_sepa.svg#pl_logo_sepa">
+                    </use>
+                  </svg>
+              </span>
+            </div>
+            <div class="pl_mb50">
+              <span class="ts-link ub64e pl_link100--secondary sp_credit_cards"
+                    data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3BheW1lbnQjNTEyMjAxNGJlNGIwNThlZWRlNzMxNTY5"
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Kreditkarten&quot;}">&nbsp;
+                <svg class="pl_logo sp_visa_logo" role="img" viewBox="0 0 124 40" height="12">
+                  <use xlink:href="/assets-static/icons/pl_logo_visa.svg#pl_logo_visa">
+                  </use>
+                </svg>
+                <svg class="pl_logo sp_mastercard_logo" role="img" viewBox="0 0 65 40" height="16">
+                  <use xlink:href="/assets-static/icons/pl_logo_mastercard.svg#pl_logo_mastercard">
+                  </use>
+                </svg>
+                <svg class="pl_logo sp_amex_logo" role="img" viewBox="0 0 40 40" height="16">
+                  <use xlink:href="/assets-static/icons/pl_logo_amex.svg#pl_logo_amex">
+                  </use>
+                </svg>
+              </span>
+            </div>
+            <div class="pl_mb50">
+              <span class="ts-link ub64e pl_link100--secondary sp_paypal_link"
+                    data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3BheW1lbnQjNTgyZGJlZGMzMjIzZTg1OTMyYTNiMjUy"
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_PayPal&quot;}">
+                <svg class="pl_logo sp_paypal_logo" role="img" viewBox="0 0 164 40" height="16">
+                  <use xlink:href="/assets-static/icons/pl_logo_paypal.svg#pl_logo_paypal">
+                  </use>
+                </svg>
+              </span>
+            </div>
+            <div class="pl_mb50">
+          <span class="ts-link ub64e pl_link100--secondary sp_paydirekt_link" data-target="_self"
+                data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3BheW1lbnQjNTlkYzg2M2YxNjgwMDUwMDAxYjU5NGZm"
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_PayDirekt&quot;}">
+            <svg class="pl_logo sp_paydirekt_logo" role="img" viewBox="0 0 175 80" height="32">
+              <use xlink:href="/assets-static/icons/pl_logo_giropay_paydirekt.svg#pl_logo_giropay_paydirekt">
+              </use>
+            </svg>
+          </span>
+            </div>
+            <div class="pl_mb50 pl_copy100">
+              <span class="ts-link ub64e pl_link100--secondary sp_invoice_link"
+                    data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3BheW1lbnQjNTExZTYwZGJlNGIwMzkyOGFlOGMyNmVm"
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Rechnung&quot;}">
+                Rechnung
+              </span>
+            </div>
+            <div class="pl_mb50 pl_copy100 sp_ratepay_link">
+          <span class="ts-link ub64e pl_link100--secondary"
+                data-ub64e="L3Nob3BwYWdlcy9scF9tb25hdHNyYXRlbg=="
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Ratenzahlung&quot;}">
+            <span style="all: unset;">
+              Ratenzahlung*
+            </span>
+          </span>
+            </div>
+                <div class="pl_mb50 pl_copy100 sp_ratepay_insurance_link">
+                <span class="ts-link ub64e pl_link100--secondary"
+                      data-ub64e="L3Nob3BwYWdlcy9vcnM="
+                      data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_RatenschutzVersicherung&quot;}">
+                  <span style="all: unset;">
+                    Ratenschutz-Versicherung*
+                  </span>
+                </span>
+                </div>
+            <div class="pl_mb50 pl_copy100">
+                <span class="ts-link ub64e pl_link100--secondary sp_payment_pause_link"
+                      data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3BheW1lbnQjNTExZTU1ZjRlNGIwYmQ4ODRjNTgyZjFl"
+                      data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Zahlpause&quot;}">
+                  Zahlpause*
+                </span>
+            </div>
+            <div class="pl_mb25 pl_copy100">
+                <span class="ts-link ub64e pl_link100--secondary sp_prepayment_link"
+                      data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3BheW1lbnQjNTEyMjA2ZWZlNGIwMzkyOGFlOGMyNmYw"
+                      data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Vorkasse&quot;}">
+                  Vorkasse
+                </span>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 sp_third_column sp_about_headline">
+        <span class="pl_headline100 sp_color_black100 ">
+          Über uns
+        </span>
+            <div class="pl_mb50 pl_mt100 pl_copy100 sp_sustainability_link">
+              <span class="ts-link ub64e pl_link100--secondary"
+                    data-ub64e="L3Nob3BwYWdlcy9uYWNoaGFsdGlna2VpdA=="
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Nachhaltigkeit&quot;}">
+                Nachhaltigkeit
+              </span>
+            </div>
+            <div class="pl_mb50 pl_copy100 sp_company_link">
+              <span class="ts-link ub64e pl_link100--secondary"
+                    data-ub64e="L3VudGVybmVobWVu"
+                    data-target="_blank"
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Unternehmen&quot;}">
+                Unternehmen
+              </span>
+            </div>
+            <div class="pl_mb50 pl_copy100 sp_newsroom_link">
+              <span class="ts-link ub64e pl_link100--secondary"
+                    data-ub64e="L25ld3Nyb29t"
+                    data-target="_blank"
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Newsroom&quot;}">
+                Newsroom
+              </span>
+            </div>
+            <div class="pl_mb150 pl_copy100 sp_jobs_link">
+          <span class="ts-link ub64e pl_link100--secondary" data-ub64e="L2pvYnM=" data-target="_blank"
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Jobs&quot;}">
+            <span style="all: unset;">
+              Jobs
+            </span>
+          </span>
+            </div>
+            <div class="pl_mb100">
+          <span class="pl_headline100 sp_color_black100 sp_blogs_headline">
+            Blogs
+          </span>
+            </div>
+            <div class="pl_mb100">
+              <a class="ts-link pl_link--primary sp_blogs_updated_link"
+                 href="https://www.otto.de/updated/" target="_blank" rel="noopener noreferrer"
+                 data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_UpdatedBlog&quot;}">
+                <svg class="pl_logo sp_blogs_updated_logo" role="img" viewBox="0 0 231 40" height="16">
+                  <use xlink:href="/assets-static/icons/pl_logo_updated.svg#pl_logo_updated">
+                  </use>
+                </svg>
+              </a>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 sp_fourth_column">
+            <span class="pl_headline100 sp_color_black100 sp_marketplace_headline">
+              Verkaufen bei OTTO
+            </span>
+            <div class="pl_mb150 pl_mt100 pl_copy100">
+              <span class="ts-link ub64e pl_link100--secondary sp_otto_market_link"
+                data-ub64e="aHR0cHM6Ly93d3cub3R0by5tYXJrZXQv" data-target="_blank"
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_OttoMarket&quot;}">
+                <svg class="pl_logo sp_otto_market_logo" role="img" viewBox="0 0 385 40" height="16">
+                  <use xlink:href="/assets-static/icons/pl_logo_market.svg#pl_logo_market">
+                  </use>
+                </svg>
+              </span>
+            </div>
+            <span class="pl_headline100 sp_color_black100 sp_partner_headline">
+              OTTO Partner
+            </span>
+            <div class="pl_mb50 pl_mt100 pl_copy100">
+              <span class="ts-link ub64e pl_link100--secondary sp_finanz_plus_link"
+                data-ub64e="L3Nob3BwYWdlcy92ZXJzaWNoZXJ1bmdlbg==" data-target="_blank"
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_OttoFinanzPlus&quot;}">
+                <svg class="pl_logo sp_finanz_plus_logo" role="img" viewBox="0 0 78 40" height="24">
+                  <use xlink:href="/assets-static/icons/pl_logo_finanzplus.svg#pl_logo_finanzplus">
+                  </use>
+                </svg>
+              </span>
+            </div>
+            <div class="pl_mb50 pl_copy100">
+          <span class="ts-link ub64e pl_link100--secondary sp_otto_retail_media_link"
+                data-ub64e="aHR0cHM6Ly93d3cub3R0b3JldGFpbC5tZWRpYQ==" data-target="_blank"
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_OttoRetailMedia&quot;}">
+            <svg class="pl_logo sp_otto_retail_media_logo" role="img" viewBox="0 0 387 40" height="16">
+              <use xlink:href="/assets-static/icons/pl_logo_retailmedia.svg#pl_logo_retailmedia">
+              </use>
+            </svg>
+          </span>
+            </div>
+            <div class="pl_mb50 pl_copy100 sp_shopping_more_link">
+              <span class="ts-link ub64e pl_link100--secondary"
+                    data-ub64e="L3Nob3BwYWdlcy9zaG9wcGluZy1tb3Jl"
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_ShoppingMore&quot;}">
+                Shopping&amp;more
+              </span>
+            </div>
+            <div class="pl_mb50 pl_copy100 sp_fotoservice_link">
+          <span class="ts-link ub64e pl_link100--secondary"
+                data-ub64e="L3RlY2huaWsva2FtZXJhL2Nld2UtZm90b3NlcnZpY2U="
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_OttoFotoservice&quot;}">
+            <span style="all: unset;">
+              OTTO Fotoservice
+            </span>
+          </span>
+            </div>
+            <div class="pl_mb50 pl_copy100 sp_affiliate_link">
+          <span class="ts-link ub64e pl_link100--secondary"
+                data-ub64e="aHR0cHM6Ly93d3cub3R0by1wYXJ0bmVycHJvZ3JhbW0uZGU=" data-target="_blank"
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Affiliate&quot;}">
+            <span style="all: unset;">
+              OTTO Affiliate
+            </span>
+          </span>
+            </div>
+            <div class="pl_mb75 pl_copy100 sp_cgi_link">
+          <span class="ts-link ub64e pl_link100--secondary"
+                data-ub64e="aHR0cHM6Ly9jZ2lieW90dG8uZGUvZGUv" data-target="_blank"
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_OttoCgi&quot;}">
+            <svg class="pl_logo" role="img" viewBox="0 0 254 40" height="16">
+              <use xlink:href="/assets-static/icons/pl_logo_cgi.svg#pl_logo_cgi">
+              </use>
+            </svg>
+          </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="pl_block pl_mb25 pl_grid-content sp_usps_row">
+        <div class="pl_grid-container sp_usps_container">
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 pl_my50 pl_pr50">
+            <div class="sp_usp_container1">
+              <svg class="pl_icon100 pl_mr100 sp_usp_checkmark1" role="img" style="vertical-align: middle;">
+                <use xlink:href="/assets-static/icons/pl_icon_check.svg#pl_icon_check"></use>
+              </svg>
+              <span class="ts-link ub64e pl_link100--secondary sp_usp_description1"
+                    data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3BheW1lbnQjNTExZTYwZGJlNGIwMzkyOGFlOGMyNmVm"
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_SichererKaufAufRechnung&quot;}">
+                Sicherer Kauf auf Rechnung
+              </span>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 pl_pr50 pl_my50">
+            <div class="sp_usp_container2">
+              <svg class="pl_icon100 pl_mr100 sp_usp_checkmark2" role="img" style="vertical-align: middle;">
+                <use xlink:href="/assets-static/icons/pl_icon_check.svg#pl_icon_check"></use>
+              </svg>
+              <span class="ts-link ub64e pl_link100--secondary sp_usp_description2"
+                    data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3J1ZWNrc2VuZHVuZw=="
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_30TageRueckgabegarantie&quot;}">
+                <span style="all: unset;">
+                  Kostenlose Rücksendung
+                </span>
+              </span>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 pl_pr50 pl_my50">
+            <div class="sp_usp_container3">
+              <svg class="pl_icon100 pl_mr100 sp_usp_checkmark3" role="img" style="vertical-align: middle;">
+                <use xlink:href="/assets-static/icons/pl_icon_check.svg#pl_icon_check"></use>
+              </svg>
+              <span class="ts-link ub64e pl_link100--secondary sp_usp_description3"
+                    data-ub64e="L3Nob3BwYWdlcy9zZXJ2aWNlL3BheW1lbnQjNTExZTViOTZlNGIwMzkyOGFlOGMyNmVl"
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_EinfacheRatenzahlung&quot;}">
+                Einfache Ratenzahlung*
+              </span>
+            </div>
+          </div>
+          <div class="pl_grid-col-12 pl_grid-col-lg-3 pl_pr50 pl_my50">
+            <div class="sp_usp_container4">
+              <svg class="pl_icon100 pl_mr100 sp_usp_checkmark4" role="img" style="vertical-align: middle;">
+                <use xlink:href="/assets-static/icons/pl_icon_check.svg#pl_icon_check"></use>
+              </svg>
+              <span class="ts-link ub64e pl_link100--secondary sp_usp_description4"
+                    data-ub64e="L3Nob3BwYWdlcy9vcnM="
+                    data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_RatenschutzVersicherungUSP&quot;}">
+                <span style="all: unset;">
+                  Ratenschutz-Versicherung*
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    <div class="pl_block pl_mb25 sp_fourth_row">
+      <div class="sp_social_container" style="text-align: center;">
+          <span class="ts-link ub64e pl_mx50 pl_link--secondary sp_pinterest_link"
+                data-ub64e="aHR0cHM6Ly9kZS5waW50ZXJlc3QuY29tL290dG9kZS8="
+                data-target="_blank"
+                data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Pinterest&quot;}">
+            <svg class="pl_logo sp_pinterest_logo" role="img" height="24" width="24">
+              <use xlink:href="/assets-static/icons/pl_logo_pinterest.svg#pl_logo_pinterest"/>
+            </svg>
+          </span>
+        <span class="ts-link ub64e pl_mx50 pl_link--secondary sp_facebook_link"
+              data-ub64e="aHR0cHM6Ly93d3cuZmFjZWJvb2suY29tL090dG8="
+              data-target="_blank"
+              data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Facebook&quot;}">
+            <svg class="pl_logo sp_facebook_logo" role="img" height="24" width="24">
+              <use xlink:href="/assets-static/icons/pl_logo_facebook.svg#pl_logo_facebook"/>
+            </svg>
+          </span>
+        <span class="ts-link ub64e pl_mx50 pl_link--secondary sp_twitter_link"
+              data-ub64e="aHR0cHM6Ly90d2l0dGVyLmNvbS9vdHRvX2Rl"
+              data-target="_blank"
+              data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Twitter&quot;}">
+            <svg class="pl_logo sp_twitter_logo" role="img" height="24" width="24">
+              <use xlink:href="/assets-static/icons/pl_logo_twitter.svg#pl_logo_twitter"/>
+            </svg>
+          </span>
+        <span class="ts-link ub64e pl_mx50 pl_link--secondary sp_youtube_link"
+              data-ub64e="aHR0cDovL3d3dy55b3V0dWJlLmNvbS9vdHRv"
+              data-target="_blank"
+              data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_YoutTube&quot;}">
+            <svg class="pl_logo sp_youtube_logo" role="img" height="24" width="24">
+              <use xlink:href="/assets-static/icons/pl_logo_youtube.svg#pl_logo_youtube"/>
+            </svg>
+          </span>
+        <span class="ts-link ub64e pl_mx50 pl_link--secondary sp_instagram_link"
+              data-ub64e="aHR0cHM6Ly93d3cuaW5zdGFncmFtLmNvbS9vdHRvX2RlLw=="
+              data-target="_blank"
+              data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Instagram&quot;}">
+            <svg class="pl_logo sp_instagram_logo" role="img" height="24" width="24">
+              <use xlink:href="/assets-static/icons/pl_logo_instagram.svg#pl_logo_instagram"/>
+            </svg>
+          </span>
+      </div>
+    </div>
+      <div class="pl_grid-content sp_imprint_row pl_pt50 pl_px100">
+        <div class="pl_grid-container" style="text-align: center;">
+          <div class="pl_grid-col-12 pl_my50 sp_legal_links_container">
+            <ul>
+              <li>
+                <a class="ts-link pl_link100--secondary sp_js_footerCookieBanner footerCookieBanner"
+                   href="#" target="_blank" rel="noopener noreferrer"
+                   data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_CookieBanner&quot;}">Cookie-Einstellungen</a>
+              </li>
+              <li>
+                <a class="ts-link pl_link100--secondary sp_agb_link" href="/shoppages/service/agb"
+                   rel="noopener noreferrer"
+                   data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_AGB&quot;}">
+                  AGB
+                </a>
+              </li>
+              <li>
+                <a class="ts-link pl_link100--secondary sp_privacy_link" href="/shoppages/service/datenschutz"
+                   rel="noopener noreferrer"
+                   data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Datenschutz&quot;}">
+                  Datenschutz
+                </a>
+              </li>
+              <li>
+                <a class="ts-link pl_link100--secondary sp_imprint_link" href="/shoppages/service/impressum"
+                   rel="noopener noreferrer"
+                   data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_Impressum&quot;}">Impressum</a>
+              </li>
+              <li>
+                <span class="ts-link ub64e sp_link pl_link100--secondary sp_js_track_feedback sp_feedback_link"
+                      data-ub64e="L2NvbnRhY3QtZmVlZGJhY2svZmVlZGJhY2s="
+                      data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_LobUndKritikBig&quot;}">Lob &amp; Kritik</span>
+              </li>
+            </ul>
+          </div>
+          <div class="pl_grid-col-12 pl_copy100 pl_my50 sp_finePrint_row1">
+            Preisangaben inkl. gesetzl. MwSt. und zzgl.
+            <a class="ts-link pl_link100--secondary" href="/shoppages/service/lieferung#533173e9e4b08cc160e21a34"
+               data-ts-link="{&quot;ot_Origin&quot; : &quot;footer_ServiceUndVersandkosten&quot;}">
+              Service- und Versandkosten
+            </a>
+          </div>
+          <div class="pl_grid-col-12 pl_copy100 pl_my50 sp_finePrint_row2">
+            * Bonität vorausgesetzt, gegen Aufpreis
+          </div>
+      <div class="pl_grid-col-12 pl_mt175 pl_mb75 sp_ottoLogo">
+        <svg class="pl_logo--grey" role="img" style="height: 40px;">
+          <use xlink:href="/assets-static/icons/pl_logo_slogan.svg#pl_logo_slogan"/>
+        </svg>
+      </div>
+        </div>
+      </div>
+  </div>
+
+                    <div class="us_js_esiAjax"
+     data-url="/user/sessionMaintenance"
+     data-eventtype="load"
+     data-priority="24"
+     data-qa="user_session_maintenance">
+</div>
+<link href="/user/assets/ft4.user.public.b850da79.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/user/assets/ft4.user.public.b850da79.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" crossorigin="anonymous" href="/user/assets/ft4.user.public.cda2922c.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+
+<div id="us_js_id_loginAreaFooter">
+    <div id="us_js_id_loginAreaContentToRemove" class="user_system_rwd">
+        <div class="us_hide">
+            <div id="us_js_id_loginAreaContentToReplaceHeader">
+                <div class="us_loginAreaContainerWithName" data-qa="user_login_area_header_container"
+                     id="us_id_loginAreaContainerWithName">
+                    <div class="us_loginArea us_js_loginAreaMenuHandle ub64e" id="us_id_loginArea" data-qa="user_login_area_header" data-ub64e="amF2YXNjcmlwdDp2b2lkKDApOw==">
+<span class="us_loginAreaIcon p_icons" data-qa="user_login_area_icon">
+Θ
+</span>
+                        <span class="us_iconSubtitle us_js_loginAreaIconSubtitle"
+                              data-qa="user_login_area_icon_subtitle"
+                              data-loggedin="false"
+                              data-login-state="UNKNOWN_VISITOR" >
+                                        <span class="us_js_loginAreaIconSubtitleMyAccount"
+                                              data-qa="user_loginAreaIconSubtitleMyAccount">Mein Konto</span>
+                                    </span>
+                    </div>
+                    <div class="clear"></div>
+                </div>
+
+                <div class="us_loginMenu" id="us_id_loginAreaMenu" data-qa="user_login_area_menu">
+    <button id="us_id_closeLoginMenuButton" class="us_closeLoginMenuButton p_symbolBtn100--4th" type="button"
+            data-qa="user_login_area_menu_close">
+        <i>x</i>
+    </button>
+    <ul>
+        <ul class="us_loginAreaMenuItems  us_bottomLine">
+            <li class="login_area_overview_link">
+            <span class="ub64e p_link100--2nd" data-ub64e="L3VzZXIvYWNjb3VudE92ZXJ2aWV3P2VudHJ5UG9pbnQ9bG9naW5BcmVh"
+                  data-qa="user_login_area_menu_myaccount">
+Mein Konto            </span>
+            </li>
+            <li class="login_area_menu_link">
+            <span class="ub64e p_link100--2nd" data-ub64e="L215YWNjb3VudC9vcmRlcnM/ZW50cnlQb2ludD1sb2dpbkFyZWE="
+                  data-qa="user_login_area_menu_myorders">
+Meine Bestellungen            </span>
+            </li>
+            <li class="login_area_menu_link">
+            <span class="ub64e p_link100--2nd" data-ub64e="L3VzZXIvaW52b2ljZXM/ZW50cnlQb2ludD1sb2dpbkFyZWE="
+                  data-qa="user_login_area_menu_myinvoices">
+Meine Rechnungen            </span>
+            </li>
+            <li class="login_area_menu_link">
+            <span class="user_js_show_more_login_area_links p_link100--2nd"
+                  data-qa="user_login_area_menu_show_more_links">
+mehr...            </span>
+            </li>
+
+                <li class="login_area_menu_link login_area_menu_hide_link">
+            <span class="user_js_more_login_area_links_follow p_link100--2nd" data-ub64e="L3VzZXIvbXlib29raW5ncz9lbnRyeVBvaW50PWxvZ2luQXJlYQ=="
+                  data-qa="user_login_area_menu_mybookings">
+Meine Konto-Buchungen            </span>
+                </li>
+            <li class="login_area_menu_link login_area_menu_hide_link">
+            <span class="user_js_more_login_area_links_follow p_link100--2nd"
+                  data-ub64e="L215YWNjb3VudC9teWRhdGE/ZW50cnlQb2ludD1sb2dpbkFyZWE="
+                  data-qa="user_login_area_menu_mydata">
+Meine persönlichen Daten            </span>
+            </li>
+            <li class="login_area_menu_link login_area_menu_hide_link">
+            <span class="user_js_more_login_area_links_follow p_link100--2nd" data-ub64e="L215YWNjb3VudC9hZGRyZXNzZXM/ZW50cnlQb2ludD1sb2dpbkFyZWE="
+                  data-qa="user_login_area_menu_myaddresses">
+Meine Anschriften            </span>
+            </li>
+            <li class="login_area_menu_link login_area_menu_hide_link">
+            <span class="user_js_more_login_area_links_follow p_link100--2nd" data-ub64e="L3VzZXIvbXlzZXR0aW5ncz9lbnRyeVBvaW50PWxvZ2luQXJlYQ=="
+                  data-qa="user_login_area_menu_mysettings">
+Meine Einstellungen            </span>
+            </li>
+        </ul>
+            <li class="login_area_menu_button">
+            <span class="ub64e p_btn100--1st" data-ub64e="L3VzZXIvbG9naW4/ZW50cnlQb2ludD1sb2dpbkFyZWE=" data-qa="user_login_area_login">
+Anmelden            </span>
+            </li>
+                <li class="login_area_register_link">
+                <span class="p_link100--1st ub64e" data-ub64e="L3VzZXIvcmVnaXN0ZXI/ZW50cnlQb2ludD1sb2dpbkFyZWE="
+                      data-qa="user_login_area_register">
+Neu bei OTTO? Jetzt registrieren                </span>
+                </li>
+    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+
+
+
+
+                </footer>
+            </div>
+                
+    <div id="wato_onsite_advert" class="infoContainer av_anchor"></div>
+    
+    <link rel="stylesheet" href="/wato-onsite/assets/ft7bcn.wato.onsite.534a0894.css" crossorigin="anonymous" integrity="sha256-eVb/QxnlL2Wnvy9HetHxvf4IeYz3bYlmCDD+q4KAZlQ=">
+
+<link rel="modulepreload" href="/wato-onsite/assets/ft7bcn.wato.onsite.module.7cd1b263.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/wato-onsite/assets/ft7bcn.wato.onsite.nomodule.76d54cc3.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+
+                    <script id="avJson" type="application/json">
+                        {
+                            "id":"1524534276",
+                            "brand":"Samsung",
+                            "classificationGroup": "KUEHLSCHRANK",
+                            "businessCategory": {"group":"ELECTRONIC_DIGITAL", "value":"HAUSHALTSELEKTRO"},
+                            "retailPrice":"199900",
+                            "placementId":"SKYSCRAPER_PDP"
+                        }
+                    </script>
+        </div>
+        
+<script src="/assets-static/global-resources/assets.global-resources.body.nomodule.c9330900.js" crossorigin="anonymous" integrity="sha256-ePVFKi1ce9sU3247s2137nCEt9CWObF+oOVoBpvA7HA="></script>
+<link rel="modulepreload" href="/assets-static/global-resources/assets.global-resources.bodyasync.module.4b41a647.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/assets-static/global-resources/assets.global-resources.bodyasync.nomodule.914c3843.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<script src="/tracking-bct/tracking.bct.bct.3fc84c9d.js" integrity="sha256-8SVSvFBkJB3ncUcHIPmnosxkcAsZkkIwu4dx6Tz257E=" crossorigin="anonymous"></script>
+<link rel="preload" href="/apps-assets/apps.global.assets.6780b120.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/apps-assets/apps.global.assets.6780b120.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/apps-assets/apps.global.assets.module.af559819.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/apps-assets/apps.global.assets.nomodule.598410b8.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<section class="cookieBanner cookieBanner__bottom" id="cookieBanner" style="display: none" xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html"><div class="cookieBanner__container"><div class="cookieBanner__wrapper"><a href="/suche/Kekse/" class="cookieBanner__iconLink ts-link" data-ts-link='{"ot_CookieBannerIcon" : "cookiesearch"}'><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24"><style>.st1 {
+                        fill: #dedede
+                    }
+
+                    .st4 {
+                        fill: none;
+                        stroke: #dedede;
+                        stroke-width: .2;
+                        stroke-miterlimit: 10
+                    }</style><symbol id="bg_4" viewBox="0 -24 24 24"><path fill="#fff" d="M.1-23.9h23.8V-.1H.1z"/><path class="st1" d="M23.8-.2v-23.6H.2V-.2h23.6m.2.2H0v-24h24V0z"/><path class="st1" d="M21.795-2.205v-19.6H2.205v19.6h19.59m.2.2H2.006v-20h19.99v20z" opacity=".4"/><g><defs><path id="SVGID_1_" d="M0-24h24V0H0z"/></defs><clipPath id="SVGID_2_"><use xlink:href="#SVGID_1_" overflow="visible"/></clipPath><g opacity=".4" clip-path="url(#SVGID_2_)"><path class="st4" d="M0-12h24M12-24V0"/></g></g></symbol><path fill="none" d="M0 0h24v24H0z" id="Ebene_2"/><g id="test6"><circle cx="19.5" cy="11.5" r=".5"/><circle cx="10.5" cy="11.5" r=".5"/><circle cx="14.5" cy="16.5" r=".5"/><circle cx="10.5" cy="17.5" r=".5"/><circle cx="18.5" cy="6.5" r=".5"/><circle cx="19.25" cy="4.75" r=".75"/><circle cx="6.25" cy="9.75" r=".75"/><circle cx="8.25" cy="11.75" r=".75"/><circle cx="13.25" cy="17.75" r=".75"/><path d="M9.5 7C8.673 7 8 7.673 8 8.5S8.673 10 9.5 10 11 9.327 11 8.5 10.327 7 9.5 7zm0 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1z"/><circle cx="18.5" cy="8.5" r=".75"/><circle cx="20.25" cy="6.5" r=".75"/><path d="M19.791 14.099c-.006.002-.599.154-1.038.154-1.103 0-2-.898-2-2 0-.287.258-1.045.441-1.386.094-.16.107-.451.008-.609-.188-.299-.525-.272-.702-.258-.827 0-1.5-.673-1.5-1.5 0-.852.59-1.583 1.12-1.706a.5.5 0 0 0 .1-.938c-.006-.003-.72-.365-.72-.856 0-.254.073-.567.164-.698a.498.498 0 0 0-.218-.745c-1.196-.502-2.48-.566-3.466-.566-4.962 0-9 4.037-9 9s4.038 9 9 9c3.298 0 6.334-1.767 7.734-4.503.339-.662.667-1.713.68-1.757a.5.5 0 1 0-.604-.633zm-.968 1.934c-1.23 2.405-3.916 3.958-6.843 3.958-4.41 0-8-3.589-8-8s3.59-8 8-8c1.093 0 1.907.096 2.612.317A2.8 2.8 0 0 0 14.5 5c0 .53.271.943.565 1.236A2.9 2.9 0 0 0 14 8.5c0 1.23.893 2.255 2.064 2.462-.162.425-.311.94-.311 1.291 0 1.789 1.584 3.184 3.413 2.975a7.96 7.96 0 0 1-.343.805z"/></g></svg></a><div class="cookieBanner__scrollable"><div class="p_headline100 cookieBanner__headline">Cookies erlauben?</div><div class="cookieBanner__info"><a href="#datennutzungen" id="otto_partner" class="p_link--1st ts-link" data-ts-link='{"ot_CookieBanner" : "otto_partner"}'>OTTO und acht Partner brauchen</a> Deine Zustimmung (Klick auf &bdquo;OK&rdquo;) bei vereinzelten <a href="/datenschutz/#block43" id="data_usage" class="p_link--1st">Datennutzungen</a>, um Informationen auf einem Ger&auml;t zu speichern und/oder abzurufen (IP-Adresse, Nutzer-ID, Browser-Informationen, Ger&auml;te-Kennungen). Die Datennutzung erfolgt f&uuml;r personalisierte Anzeigen und Inhalte, Anzeigen- und Inhaltsmessungen sowie um Erkenntnisse &uuml;ber Zielgruppen und Produktentwicklungen zu gewinnen. Mehr Infos zur Einwilligung (inkl. Widerrufsm&ouml;glichkeit) und zu Einstellungsm&ouml;glichkeiten gibt’s jederzeit <a href="/datenschutz/#block43" id="info_agreement" class="p_link--1st">hier</a>. Mit Klick auf den Link &quot;Cookies ablehnen&quot; kannst Du Deine Einwilligung jederzeit ablehnen.<div class="p_headline100 cookieBanner__headline headline_data_usage_head"><a id="datennutzungen">Datennutzungen</a></div><div class="data_usage_text">OTTO arbeitet mit Partnern zusammen, die von Deinem Endger&auml;t abgerufene Daten (Trackingdaten) auch zu eigenen Zwecken (z.B. Profilbildungen) / zu Zwecken Dritter verarbeiten. Vor diesem Hintergrund erfordert nicht nur die Erhebung der Trackingdaten, sondern auch deren Weiterverarbeitung durch diese Anbieter einer Einwilligung. Die Trackingdaten werden erst dann erhoben, wenn Du auf den in dem Banner auf otto.de wiedergebenden Button &bdquo;OK&rdquo; anklickst. Bei den Partnern handelt es sich um die folgenden Unternehmen:<br>Meta Platforms Ireland Limited, Google Ireland Limited, Pinterest Europe Limited, Microsoft Ireland Operations Limited, OS Data Solutions GmbH & Co. KG, Otto Group Media GmbH, Str&ouml;er SSP GmbH, TikTok Information Technologies UK Limited (Ausschlie&szlig;lich bei App-Nutzung).<br>Weitere Informationen zu den Datenverarbeitungen durch diese Partner findest Du in der Datenschutzerkl&auml;rung auf otto.de. Die Informationen sind au&szlig;erdem &uuml;ber einen Link in dem Banner abrufbar.</div></div></div><div class="cookieBanner__footer"><button type="button" class="p_btn100--1st cookieBanner__button js_cookieBannerPermissionButton">OK</button> <span class="p_link--1st js_cookieBannerProhibitionButton">Cookies ablehnen</span> <a href="/datenschutz/#block43" id="more_info" class="p_link--1st cookieBanner__more_info">Mehr Informationen</a></div></div></div></section><link href="/user-cookie-banner/ft4.cookie-banner.bottom_assets.21e75f9e.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"><noscript><link rel="stylesheet" href="/user-cookie-banner/ft4.cookie-banner.bottom_assets.21e75f9e.css" crossorigin="anonymous"></noscript><link rel="preload" crossorigin="anonymous" href="/user-cookie-banner/ft4.cookie-banner.bottom_assets.c777e30d.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)">
+<link rel="preload" crossorigin="anonymous" href="/user-cmp/assets/ft4.user.cmp_stub.1c338b58.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+<link rel="preload" crossorigin="anonymous" href="/user-cmp/assets/ft4.user.cmp.d015eb57.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+
+
+    <link rel="preload" href="/benefit-detailview/ft9.benefit-detailview.app.0f44f865.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/benefit-detailview/ft9.benefit-detailview.app.0f44f865.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/benefit-detailview/ft9.benefit-detailview.app.module.495db2e1.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/benefit-detailview/ft9.benefit-detailview.app.nomodule.ecfca20a.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+        <link rel="preload" href="/up-teaser/ft9.up-teaser.detailview.5102dbe4.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/up-teaser/ft9.up-teaser.detailview.5102dbe4.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<script src="/up-teaser/ft9.up-teaser.detailview.nomodule.1ae6f9ca.js" crossorigin="anonymous" integrity="sha256-0vWpolOWFSojpNruPeE1NMzPsxQlry4h7J1o76towT0="></script>
+
+
+    <link href="/combo-combopromo/assets/ft3.combo.combopromo.4fe6207a.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/combo-combopromo/assets/ft3.combo.combopromo.4fe6207a.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" critical="critical" crossorigin="anonymous" href="/combo-combopromo/assets/ft3.combo.combopromo.562bb0dd.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+
+    
+  <link rel="preload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.3afc4579.css" as="style" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+
+<noscript>
+  <link rel="stylesheet" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.3afc4579.css" onload="invokePreload.onStyleLoad(this)" crossorigin="anonymous">
+</noscript>
+
+<link rel="modulepreload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.module.46bea43c.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/reco-core/assets/ft6bcn.reco-core.reco_assets.nomodule.a87b68b8.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+
+
+<div style="display:none;" id="reco_cinema__toggle-state" data-toggle-state="{&quot;SHOW_DEALS&quot;:true,&quot;CSR&quot;:false,&quot;USE_OPAL_RELATIONSHIPS&quot;:true,&quot;TESLA_COLDSTART&quot;:false,&quot;USE_TESLA_ARTHURDENT&quot;:true,&quot;USE_TESLA_META&quot;:true,&quot;SHOW_DETAILVIEW_ONLY&quot;:false,&quot;DISPLAY_LAST_SEEN_ARTICLES&quot;:true,&quot;USE_TESLA_HITCHHIKER&quot;:true,&quot;WISHLIST_RECO_REDESIGN&quot;:true,&quot;RECO_REDESIGN&quot;:true}">
+</div>
+<script>
+  window.o_reco = window.o_reco || {};
+  window.o_reco.api = window.o_reco.api || {};
+  window.o_reco.private = window.o_reco.private || {};
+  window.o_reco.private.toggleState = JSON.parse(document.getElementById('reco_cinema__toggle-state').dataset.toggleState);
+
+  window.o_reco.private.delegate = function (originalFunction) {
+    return function () {
+      var passedArguments = arguments;
+      return new Promise(function (resolve, reject) {
+        o_global.eventLoader.onAllScriptsExecuted(10, function () {
+          window.o_reco.private[originalFunction].apply(null, passedArguments).then(resolve).catch(reject);
+        });
+      });
+    };
+  };
+
+  window.o_reco.private.delegateAndWrap = function (originalFunction) {
+    return function () {
+      var passedArguments = arguments;
+      return new Promise(function (resolve) {
+        o_global.eventLoader.onAllScriptsExecuted(10, function () {
+          var result = window.o_reco.private[originalFunction].apply(null, passedArguments);
+          resolve(result);
+        });
+      });
+    };
+  };
+
+  window.o_reco.api.initializeCinema = window.o_reco.private.delegateAndWrap('initializeCinema');
+  window.o_reco.api.initializeExpandableCinema = window.o_reco.private.delegateAndWrap('initializeExpandableCinema');
+  window.o_reco.api.loadRecommendationsForDetailView = window.o_reco.private.delegateAndWrap('asyncLoadRecommendationsForDetailView');
+
+  window.o_reco.api.loadRecommendationsForOrderOverview = window.o_reco.private.delegate('loadRecommendationsForOrderOverview');
+  window.o_reco.api.loadRecommendationsForWishlist = window.o_reco.private.delegate('loadRecommendationsForWishlist');
+  window.o_reco.api.loadRecommendationsForEntryPage =
+          window.o_reco.private.toggleState["CSR"] ?
+                  window.o_reco.private.delegateAndWrap('loadRecommendationsForEntryPageCsr') :
+                  window.o_reco.private.delegate('loadRecommendationsForEntryPage');
+  window.o_reco.api.loadBounceLayerCinema = window.o_reco.private.delegateAndWrap('loadBounceLayerCinema');
+
+  o_global.eventQBus.emit("ft6bcn.reco.init", ".reco.cinema.needsInitialization");
+</script>
+
+
+        <link rel="stylesheet" href="/spa-formicary/assets/ft7bcn.spa-formicary.spa_formicary_assets.7935b393.css" crossorigin="anonymous" integrity="sha256-IQzbUIGIxvC+RmQ1n3QFAF9eiKwlozE/v/tnQ5ByB8c=">
+
+<link rel="modulepreload" href="/spa-formicary/assets/ft7bcn.spa-formicary.spa_formicary_assets.module.18c96fd4.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<link rel="nomodulepreload" href="/spa-formicary/assets/ft7bcn.spa-formicary.spa_formicary_assets.nomodule.22c7d8e1.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)" crossorigin="anonymous">
+
+<script>
+    window.o_spa_formicary = window.o_spa_formicary || {};
+    window.o_spa_formicary.api = window.o_spa_formicary.api || {};
+    window.o_spa_formicary.private = window.o_spa_formicary.private || {};
+    window.o_spa_formicary.private.jlineup = window.o_spa_formicary.private.jlineup || {};
+
+    window.o_spa_formicary.private.delegate = function (originalFunction) {
+        return function () {
+            var passedArguments = arguments;
+            return new Promise(function (resolve, reject) {
+                o_global.eventLoader.onAllScriptsExecuted(10, function () {
+                    window.o_spa_formicary.private[originalFunction].apply(null, passedArguments).then(resolve).catch(reject);
+                });
+            });
+        };
+    };
+
+    window.o_spa_formicary.private.delegateAndWrap = function (originalFunction) {
+        return function () {
+            var passedArguments = arguments;
+            return new Promise(function (resolve) {
+                o_global.eventLoader.onAllScriptsExecuted(10, function () {
+                    var result = window.o_spa_formicary.private[originalFunction].apply(null, passedArguments);
+                    resolve(result);
+                });
+            });
+        };
+    };
+
+    window.o_spa_formicary.api.initializeCinema = window.o_spa_formicary.private.delegateAndWrap('initializeCinema');
+    window.o_spa_formicary.api.loadSponsoredArticlesForDetailView = window.o_spa_formicary.private.delegate('loadSponsoredArticlesForDetailView');
+</script>
+
+    <link rel="preload" critical="critical" crossorigin="anonymous" href="/order/statics/ft1.order-core.common-public.9b8d052b.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/><link href="/order/statics/ft1.order-core.addtobasket.81254ed8.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/order/statics/ft1.order-core.addtobasket.81254ed8.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" crossorigin="anonymous" href="/order/statics/ft1.order-core.addtobasket.ab2e4750.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>
+        <link rel="preload" crossorigin="anonymous" href="/product-richcontent/ft5-richcontent.css" as="style" onload="invokePreload.onStyleLoad(this)"/>
+        <noscript><link rel="stylesheet" href="/product-richcontent/ft5-richcontent.css" crossorigin="anonymous"/></noscript>
+<div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">
+
+    <div class="pswp__bg"></div>
+
+    <div class="pswp__scroll-wrap">
+
+        <div class="pswp__container">
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+        </div>
+
+        <div class="pswp__ui pswp__ui--hidden">
+
+            <div class="pswp__top-bar">
+
+                <div class="pswp__preloader">
+                    <div class="pswp__preloader__icn">
+                        <div class="pswp__preloader__cut">
+                            <div class="pswp__preloader__donut"></div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="pswp__counter"></div>
+                <button class="pswp__button pswp__button--close" title="schlie&slig;en (Esc)">x</button>
+
+                <button class="pswp__button pswp__button--share" title="Share">?</button>
+                <button class="pswp__button pswp__button--fs" title="Toggle fullscreen">?</button>
+
+            </div>
+
+            <div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap">
+                <div class="pswp__share-tooltip"></div>
+            </div>
+
+            <button class="pswp__button pswp__button--arrow--left" title="zurück (Pfeiltaste links)">&lt;</button>
+
+            <button class="pswp__button pswp__button--arrow--right" title="weiter (Pfeiltaste rechts)">&gt;</button>
+
+            <div class="pswp__top-bar pswp__bottom-bar">
+                <div class="pswp__zoom-controls">
+                    <span>Zoom</span>
+                    <button class="pswp__button pswp__button--zoom pswp__button--zoom-out" title="verkleinern">-</i></button>
+                    <button class="pswp__button pswp__button--zoom pswp__button--zoom-in" title="vergr;&ouml;&slig;ern">p</button>
+                </div>
+            </div>
+
+            <div class="pswp__caption">
+                <div class="pswp__caption__center"></div>
+            </div>
+        </div>
+
+    </div>
+    <svg class="pswp__pinch-icon hidden" preserveAspectRatio="xMidYMin slice" width="20%" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 90.79"><path d="M13.91 53.12l3.48 4.73L0 59.5l1.84-18.74 4.44 4.44 14-14 8.11 8.11-7.82 8.5-2.75.1h-.34q-3.28.39-3.43 2.8zm30.42 37.67h28.5a46.09 46.09 0 0 0 5-13.28 91.07 91.07 0 0 0 1.93-13.62 94.4 94.4 0 0 0 .1-11.2q-.29-4.78-.48-6a3.6 3.6 0 0 0-2.46-3.43q-2.27-.82-2.37-.14t-.34 3.77a33 33 0 0 1-.63 4.64q-.39 1.74-1.69 1.45t-1.19-1.5q-.1-.48 0-4.93t0-6.08q.1-1.55-3-2.9t-3.37.43q-.1 1.74-.29 6a17.58 17.58 0 0 1-.87 5.7q-.87 1.06-1.5.43a2.39 2.39 0 0 1-.72-1.13q-.1-.39 0-6.42l.1-6q-.1-4.25-3.19-4.49t-3.57.82q-.39 1.06-.48 6.76a64.79 64.79 0 0 1-.4 7.33q-.29 1.64-1.5 1.35t-1.21-.87v-3.77-7.58-8-4.88q0-2.32-2-2.61l-2-.29q-3.28 0-3.86 1.5L42 23.37l-.14 4.2q-.14 4.2-.29 9.56t-.34 10.38q-.19 5-.19 6.76-.1 3.28-1 4.1l-.87.82a6 6 0 0 1-3.57.87 7 7 0 0 1-2.51-.68 32.66 32.66 0 0 1-3.57-3.24l-2.8-2.75a6.67 6.67 0 0 0-4.2-1.64l-1.88.1q-2.32.1-2.22 1.45l.1 1.35zm5.7-73a4.19 4.19 0 0 0-2.75-1.21h-1.5q-4.64 0-5.94 2.12l-1.3 2.12-.1 1.16q-.1 1.16-.19 5.89L31 20.19l14-14-4.43-4.45L59.4 0l-1.84 18.74-4.44-4.44z"/></svg>
+</div><link rel="preload" crossorigin="anonymous" href="/product/static/assets/ft5.detailview.body.f1427b2e.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>        
+
+        <script type="text/javascript">
+        (function (loaderScript) {
+          "use strict";
+
+          var script, firstScript, parts, len, i, mpathyVersion;
+
+          function cookie(name) {
+            parts = document.cookie.split(/;\s*/);
+            len = parts.length;
+            name += '=';
+            for (i = 0; i < len; i += 1) {
+              if (parts[i].indexOf(name) !== -1) {
+                return parts[i].replace(name, '');
+              }
+            }
+          }
+
+          o_global.eventLoader.onLoad(99, function () {
+            if (o_global.mpathy.isEnabled()) {
+              if (cookie('trackingDisabled') !== "v1" && cookie('cb') !== undefined && cookie('cb') !== "0") {
+                mpathyVersion = cookie("mpathyVersion");
+                if (mpathyVersion !== undefined && /^[_0-9a-zA-Z/]*a2995_[0-9]+\.js$/.test(mpathyVersion)) {
+                  loaderScript = "//cdn.m-pathy.com/js/" + mpathyVersion;
+                }
+                script = document.createElement('script');
+                script.setAttribute('src', loaderScript);
+                script.setAttribute('type', 'text/javascript');
+                script.setAttribute('async', true);
+                script.setAttribute('crossorigin', 'anonymous');
+                firstScript = document.getElementsByTagName('script')[0];
+                firstScript.parentNode.insertBefore(script, firstScript);
+              }
+            }
+          });
+        }('//cdn.m-pathy.com/js/otto/a2995_2205301600.js'));
+        </script>
+
+<link href="/shoppages/static/assets/sho.shoppages.assets-public.c2691b52.css" rel="preload" crossorigin="anonymous" as="style" onload="invokePreload.onStyleLoad(this)"/><noscript><link rel="stylesheet" href="/shoppages/static/assets/sho.shoppages.assets-public.c2691b52.css" crossorigin="anonymous"/></noscript>
+<link rel="preload" crossorigin="anonymous" href="/shoppages/static/assets/sho.shoppages.assets-public.21298cd5.js" as="script" onload="invokePreload.onScriptLoad(this)" onerror="invokePreload.onScriptError(this)"/>    <div data-title="" data-callback="o_shoppages.layer.init">
+        <div class="shoppages shoppagesFragment">
+    
+        </div>
+    </div>
+    
+
+
+    </body>
+    </html>

--- a/extract/tests/otto/electronics-fridge-old-energy-label_test.py
+++ b/extract/tests/otto/electronics-fridge-old-energy-label_test.py
@@ -41,16 +41,16 @@ def test_otto_basic(requests_mock: Adapter) -> None:
         merchant=merchant,
         category=category,
         name="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, "
-             "mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie",
-        description= "Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, "
-                     "mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate "
-                     "Herstellergarantie für 333,00€ bei OTTO",
+        "mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie",
+        description="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, "
+        "mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate "
+        "Herstellergarantie für 333,00€ bei OTTO",
         brand="Privileg Family Edition",
         sustainability_labels=["certificate:UNKNOWN"],
         image_urls=[
-            'https://i.otto.mock/i/otto/19651738',
-            'https://i.otto.mock/i/otto/19651739',
-            'https://i.otto.mock/i/otto/19651740',
+            "https://i.otto.mock/i/otto/19651738",
+            "https://i.otto.mock/i/otto/19651739",
+            "https://i.otto.mock/i/otto/19651740",
         ],
         price=333.00,
         currency="EUR",

--- a/extract/tests/otto/electronics-fridge-old-energy-label_test.py
+++ b/extract/tests/otto/electronics-fridge-old-energy-label_test.py
@@ -1,0 +1,63 @@
+from requests_mock import Adapter
+
+from core.constants import TABLE_NAME_SCRAPING_OTTO
+from core.domain import Product
+from extract import extract_product
+
+from ..utils import read_test_html
+
+
+def test_otto_basic(requests_mock: Adapter) -> None:
+    label_html = """
+        <div class='prd_sustainabilityLayer__label'>
+            <div class='prd_sustainabilityLayer__caption'> unknown label name </div>
+            <div class='prd_sustainabilityLayer__description'> some description </div>
+            <div class='prd_sustainabilityLayer__licenseNumber'> some license </div>
+        </div>
+    """
+    requests_mock.register_uri("GET", "/product/sustainability/layerContent", text=label_html)
+
+    # original url: https://www.otto.de/p/privileg-family-edition-pyrolyse-backofen-pbwr6-op8v2-in-mit-2-fach-teleskopauszug-pyrolyse-selbstreinigung-50-monate-herstellergarantie-682285688/#variationId=682285928 # noqa
+    url = "https://www.otto.mock/"
+    timestamp = "2022-05-31 10:45:00"
+    merchant = "otto"
+    file_name = "electronics-fridge-old-energy-label.html"
+    category = "FRIDGE"
+    meta_information = {"family": "electronics"}
+
+    scraped_page = read_test_html(
+        timestamp=timestamp,
+        merchant=merchant,
+        file_name=file_name,
+        category=category,
+        meta_information=meta_information,
+        url=url,
+    )
+
+    actual = extract_product(TABLE_NAME_SCRAPING_OTTO, scraped_page)
+    expected = Product(
+        timestamp=timestamp,
+        url=url,
+        merchant=merchant,
+        category=category,
+        name="Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, "
+             "mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate Herstellergarantie",
+        description= "Privileg Family Edition Pyrolyse Backofen »PBWR6 OP8V2 IN«, "
+                     "mit 2-fach-Teleskopauszug, Pyrolyse-Selbstreinigung, 50 Monate "
+                     "Herstellergarantie für 333,00€ bei OTTO",
+        brand="Privileg Family Edition",
+        sustainability_labels=["certificate:UNKNOWN"],
+        image_urls=[
+            'https://i.otto.mock/i/otto/19651738',
+            'https://i.otto.mock/i/otto/19651739',
+            'https://i.otto.mock/i/otto/19651740',
+        ],
+        price=333.00,
+        currency="EUR",
+        color=None,
+        size=None,
+        gtin=8003437938573,
+        asin=None,
+    )
+    for attribute in expected.__dict__.keys():
+        assert actual.__dict__[attribute] == expected.__dict__[attribute]

--- a/extract/tests/otto/electronics-fridge_test.py
+++ b/extract/tests/otto/electronics-fridge_test.py
@@ -45,7 +45,7 @@ def test_otto_basic(requests_mock: Adapter) -> None:
         "00€. Nutzinhalt: 635 Liter, No Frost – nie wieder abtauen!, Metal Cooling "
         "bei OTTO",
         brand="Samsung",
-        sustainability_labels=["certificate:EU_ENERGY_LABEL_C", "certificate:UNKNOWN"],
+        sustainability_labels=["certificate:EU_ENERGY_LABEL_C"],
         image_urls=[
             "https://i.otto.mock/i/otto/02f85090-393a-5bd1-b56a-bac9f66295f7",
             "https://i.otto.mock/i/otto/e1f3b715-0081-5df1-9d50-14c19bc476e8",

--- a/extract/tests/otto/electronics-fridge_test.py
+++ b/extract/tests/otto/electronics-fridge_test.py
@@ -41,15 +41,15 @@ def test_otto_basic(requests_mock: Adapter) -> None:
         merchant=merchant,
         category=category,
         name="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit",
-        description= "Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit für 1.999,"
-                     "00€. Nutzinhalt: 635 Liter, No Frost – nie wieder abtauen!, Metal Cooling "
-                     "bei OTTO",
+        description="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit für 1.999,"
+        "00€. Nutzinhalt: 635 Liter, No Frost – nie wieder abtauen!, Metal Cooling "
+        "bei OTTO",
         brand="Samsung",
         sustainability_labels=["certificate:EU_ENERGY_LABEL_C", "certificate:UNKNOWN"],
         image_urls=[
             "https://i.otto.mock/i/otto/02f85090-393a-5bd1-b56a-bac9f66295f7",
             "https://i.otto.mock/i/otto/e1f3b715-0081-5df1-9d50-14c19bc476e8",
-            "https://i.otto.mock/i/otto/5d309975-6917-5f9e-b206-a1c99e83411c"
+            "https://i.otto.mock/i/otto/5d309975-6917-5f9e-b206-a1c99e83411c",
         ],
         price=1999.00,
         currency="EUR",

--- a/extract/tests/otto/electronics-fridge_test.py
+++ b/extract/tests/otto/electronics-fridge_test.py
@@ -1,0 +1,62 @@
+from requests_mock import Adapter
+
+from core.constants import TABLE_NAME_SCRAPING_OTTO
+from core.domain import Product
+from extract import extract_product
+
+from ..utils import read_test_html
+
+
+def test_otto_basic(requests_mock: Adapter) -> None:
+    label_html = """
+        <div class='prd_sustainabilityLayer__label'>
+            <div class='prd_sustainabilityLayer__caption'> unknown label name </div>
+            <div class='prd_sustainabilityLayer__description'> some description </div>
+            <div class='prd_sustainabilityLayer__licenseNumber'> some license </div>
+        </div>
+    """
+    requests_mock.register_uri("GET", "/product/sustainability/layerContent", text=label_html)
+
+    # original url: https://www.otto.de/p/samsung-side-by-side-rs6ga884csl-178-cm-hoch-91-2-cm-breit-1524534276/#variationId=1524535294 # noqa
+    url = "https://www.otto.mock/"
+    timestamp = "2022-05-31 10:45:00"
+    merchant = "otto"
+    file_name = "electronics-fridge.html"
+    category = "FRIDGE"
+    meta_information = {"family": "electronics"}
+
+    scraped_page = read_test_html(
+        timestamp=timestamp,
+        merchant=merchant,
+        file_name=file_name,
+        category=category,
+        meta_information=meta_information,
+        url=url,
+    )
+
+    actual = extract_product(TABLE_NAME_SCRAPING_OTTO, scraped_page)
+    expected = Product(
+        timestamp=timestamp,
+        url=url,
+        merchant=merchant,
+        category=category,
+        name="Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit",
+        description= "Samsung Side-by-Side RS6GA884CSL, 178 cm hoch, 91,2 cm breit für 1.999,"
+                     "00€. Nutzinhalt: 635 Liter, No Frost – nie wieder abtauen!, Metal Cooling "
+                     "bei OTTO",
+        brand="Samsung",
+        sustainability_labels=["certificate:EU_ENERGY_LABEL_C", "certificate:UNKNOWN"],
+        image_urls=[
+            "https://i.otto.mock/i/otto/02f85090-393a-5bd1-b56a-bac9f66295f7",
+            "https://i.otto.mock/i/otto/e1f3b715-0081-5df1-9d50-14c19bc476e8",
+            "https://i.otto.mock/i/otto/5d309975-6917-5f9e-b206-a1c99e83411c"
+        ],
+        price=1999.00,
+        currency="EUR",
+        color=None,
+        size=None,
+        gtin=8806092536593,
+        asin=None,
+    )
+    for attribute in expected.__dict__.keys():
+        assert actual.__dict__[attribute] == expected.__dict__[attribute]


### PR DESCRIPTION
This PR adds functionality to extract the (new) `EU_ENERGY_LABEL` for otto electronics categories. So far we have used just the private otto label `energieefiziente Nutzung` which was mapped to `OTHER`.

I implemented this in a seperate method and added also a separate `_LABEL_MAPPING_ENERGY` because the mapping relies just on one character, which identifies the level of the label e.g. `C` for `EU_ENERGY_LABEL_C` and this could lead to problems if the mapping would be combined with the original `_LABEL_MAPPING`.