### PR TITLE
Add category specific label mappings

### DIFF
--- a/extract/extract/extractors/amazon_de.py
+++ b/extract/extract/extractors/amazon_de.py
@@ -97,7 +97,7 @@ def extract_amazon_de(parsed_page: ParsedPage) -> Optional[Product]:
                 ]
 
     sustainability_labels = sustainability_labels_to_certificates(
-        sustainability_texts, _LABEL_MAPPING
+        sustainability_texts, _LABEL_MAPPING, parsed_page.scraped_page.category
     )
 
     brand = _get_brand(soup, language)

--- a/extract/extract/extractors/otto_de.py
+++ b/extract/extract/extractors/otto_de.py
@@ -68,7 +68,9 @@ def extract_otto_de(parsed_page: ParsedPage) -> Optional[Product]:
     product_data = _get_product_data(parsed_page.beautiful_soup)
     parsed_url = urlparse(parsed_page.scraped_page.url)
 
-    sustainability_labels = _get_sustainability(product_data, parsed_url, parsed_page.scraped_page.category)
+    sustainability_labels = _get_sustainability(
+        product_data, parsed_url, parsed_page.scraped_page.category
+    )
     image_urls = _get_image_urls(product_data, parsed_url)[:NUM_IMAGE_URLS]
 
     try:
@@ -291,7 +293,9 @@ def _get_energy_labels(product_data: dict) -> List[str]:
     return [f"EU Energy label {letter}" for letter in energy_labels]
 
 
-def _get_sustainability(product_data: dict, parsed_url: ParseResult, product_category: str) -> Optional[List[str]]:
+def _get_sustainability(
+    product_data: dict, parsed_url: ParseResult, product_category: str
+) -> Optional[List[str]]:
     """
     Helper function that extracts the product's sustainability information.
 

--- a/extract/extract/extractors/otto_de.py
+++ b/extract/extract/extractors/otto_de.py
@@ -68,7 +68,7 @@ def extract_otto_de(parsed_page: ParsedPage) -> Optional[Product]:
     product_data = _get_product_data(parsed_page.beautiful_soup)
     parsed_url = urlparse(parsed_page.scraped_page.url)
 
-    sustainability_labels = _get_sustainability(product_data, parsed_url)
+    sustainability_labels = _get_sustainability(product_data, parsed_url, parsed_page.scraped_page.category)
     image_urls = _get_image_urls(product_data, parsed_url)[:NUM_IMAGE_URLS]
 
     try:
@@ -291,13 +291,14 @@ def _get_energy_labels(product_data: dict) -> List[str]:
     return [f"EU Energy label {letter}" for letter in energy_labels]
 
 
-def _get_sustainability(product_data: dict, parsed_url: ParseResult) -> Optional[List[str]]:
+def _get_sustainability(product_data: dict, parsed_url: ParseResult, product_category: str) -> Optional[List[str]]:
     """
     Helper function that extracts the product's sustainability information.
 
     Args:
         product_data (dict): Representation of the product data JSON
         parsed_url (ParseResult): Parsed URL
+        product_category (str): Product Category
 
     Returns:
         List[str]: Sorted `list` of found sustainability labels
@@ -315,5 +316,5 @@ def _get_sustainability(product_data: dict, parsed_url: ParseResult) -> Optional
         labels.update(_get_sustainability_info(sustainable_soup))
 
     return sustainability_labels_to_certificates(
-        list(labels.keys()) + energy_labels, _LABEL_MAPPING
+        list(labels.keys()) + energy_labels, _LABEL_MAPPING, product_category
     )

--- a/extract/extract/utils.py
+++ b/extract/extract/utils.py
@@ -117,12 +117,14 @@ def sustainability_labels_to_certificates(
                 result.update({certificate_string: CertificateType.UNKNOWN})  # type: ignore[attr-defined] # noqa
                 logger.info(f"unknown sustainability label: {certificate_string}")
 
-    # check extracted certificates for category-specific version
+    # assign (general) extracted certificates to a product category-specific version, if possible
     if product_category in _certificate_category_names.keys():
+        # loop over all extracted and stored labels and potential category synonyms
         for certificate_string, certificate in result.items():
             for label in SUSTAINABILITY_LABELS.keys():
                 for category_alt_name in _certificate_category_names.get(product_category, []):
-                    if re.search(f"^{certificate.value}.*{category_alt_name}$", label):
+                    # check for a product category-specific label
+                    if re.search(f"^{certificate.value}.*{category_alt_name}$", label): # type: ignore # noqa
                         result.update({certificate_string: label})
 
     return sorted(set(result.values()))  # type: ignore

--- a/extract/extract/utils.py
+++ b/extract/extract/utils.py
@@ -10,7 +10,7 @@ logger = getLogger(__name__)
 
 _certificate_category_names = {
     "LAPTOP": ["LAPTOPS", "NOTEBOOKS"],
-    "SMARTPHONE": ["SMARTPHONES", "MOBILE_PHONES"]
+    "SMARTPHONE": ["SMARTPHONES", "MOBILE_PHONES"],
 }
 
 
@@ -71,7 +71,9 @@ def get_product_from_JSON_LD(json_ld: List[Any], else_return: Any = {}) -> Any:
 
 
 def sustainability_labels_to_certificates(
-    certificate_strings: Iterable[str], certificate_mapping: dict, product_category=None,
+    certificate_strings: Iterable[str],
+    certificate_mapping: dict,
+    product_category: str = "",
 ) -> Optional[list[str]]:
     """
     Helper function that maps the extracted HTML span texts to certificates.
@@ -119,8 +121,8 @@ def sustainability_labels_to_certificates(
     if product_category in _certificate_category_names.keys():
         for certificate_string, certificate in result.items():
             for label in SUSTAINABILITY_LABELS.keys():
-                for category_alt_name in _certificate_category_names.get(product_category):
-                    if x := re.search(f"^{certificate.value}.*{category_alt_name}$", label):
+                for category_alt_name in _certificate_category_names.get(product_category, []):
+                    if re.search(f"^{certificate.value}.*{category_alt_name}$", label):
                         result.update({certificate_string: label})
 
     return sorted(set(result.values()))  # type: ignore

--- a/extract/extract/utils.py
+++ b/extract/extract/utils.py
@@ -124,7 +124,7 @@ def sustainability_labels_to_certificates(
             for label in SUSTAINABILITY_LABELS.keys():
                 for category_alt_name in _certificate_category_names.get(product_category, []):
                     # check for a product category-specific label
-                    if re.search(f"^{certificate.value}.*{category_alt_name}$", label): # type: ignore # noqa
+                    if re.search(f"^{certificate.value}.*{category_alt_name}$", label):  # type: ignore # noqa
                         result.update({certificate_string: label})
 
     return sorted(set(result.values()))  # type: ignore

--- a/extract/tests/amazon/chromebook_test.py
+++ b/extract/tests/amazon/chromebook_test.py
@@ -79,7 +79,7 @@ def test_amazon_electronics() -> None:
         "Applications pour tous les jours. Vous avez besoin de plus parce que vous "
         "faites plus.",
         brand="HP",
-        sustainability_labels=[CertificateType.EPEAT, CertificateType["FR_REPAIR_INDEX_4-5.9"]],  # type: ignore[attr-defined] # noqa
+        sustainability_labels=[CertificateType.EPEAT_LAPTOPS, CertificateType["FR_REPAIR_INDEX_4-5.9"]],  # type: ignore[attr-defined] # noqa
         price=209.0,
         currency=CurrencyType.EUR,
         image_urls=[

--- a/extract/tests/amazon/laptop_test.py
+++ b/extract/tests/amazon/laptop_test.py
@@ -46,7 +46,7 @@ def test_amazon_electronics() -> None:
         "1 Notebook 33 cm (13 Zoll), 2K (Intel Core i7-1160G7, 16 GB RAM, 1 TB SSD, "
         "Intel Iris Xe Graphics, Windows 10 Pro), Schwarz spanische QWERTY-Tastatur",
         brand="Lenovo",
-        sustainability_labels=[CertificateType.EPEAT],  # type: ignore[attr-defined]
+        sustainability_labels=[CertificateType.EPEAT_LAPTOPS],  # type: ignore[attr-defined]
         price=2998.0,
         currency=CurrencyType.EUR,
         image_urls=[


### PR DESCRIPTION
Covers the categories `LAPTOP` and `SMARTPHONE` corresponding labels. 
For example a SMARTPHONE product that was originally mapped to `TCO` is now mapped to `TCO_8_SMARTPHONES`.