### PR TITLE
Amazon abort scraping of alternate products

### DIFF
--- a/extract/extract/extractors/amazon_de.py
+++ b/extract/extract/extractors/amazon_de.py
@@ -190,11 +190,11 @@ def get_energy_label_level(soup: BeautifulSoup) -> Optional[str]:
         returned.
     """
 
-    targets = [soup.find(id="energyEfficiency").find("text")]
+    targets = [soup.find(id="energyEfficiency")]
 
     def parse_energy_efficiency(energy_efficiency: BeautifulSoup) -> Optional[str]:
         if energy_efficiency:
-            return "EU Energy label " + energy_efficiency.get_text().strip()
+            return "EU Energy label " + energy_efficiency.find("text").get_text().strip()
         return None
 
     return _handle_parse(targets, parse_energy_efficiency)

--- a/extract/extract/extractors/amazon_de.py
+++ b/extract/extract/extractors/amazon_de.py
@@ -237,13 +237,14 @@ def _get_image_urls(soup: BeautifulSoup) -> Optional[list[str]]:
             If nothing was found `None` or empty list is returned.
     """
     targets = [
-        soup.find("div", {"id": "altImages"}).find_all("img"),
+        soup.find_all("div", {"id": "altImages"}),
+        soup.find("div", {"class": "unrolledScrollBox"})
     ]
 
     def parse_image_urls(images: list[BeautifulSoup]) -> list[str]:
         image_urls = [
             str(image["src"])
-            for image in images
+            for image in images.find_all("img")
             if not image["src"].endswith(".gif")
             and "play-button-overlay" not in image["src"]
             and "play-icon-overlay" not in image["src"]

--- a/extract/extract/extractors/amazon_de.py
+++ b/extract/extract/extractors/amazon_de.py
@@ -238,7 +238,7 @@ def _get_image_urls(soup: BeautifulSoup) -> Optional[list[str]]:
     """
     targets = [
         soup.find("div", {"id": "altImages"}),
-        soup.find("div", {"class": "unrolledScrollBox"})
+        soup.find("div", {"class": "unrolledScrollBox"}),
     ]
 
     def parse_image_urls(images: list[BeautifulSoup]) -> list[str]:

--- a/extract/extract/extractors/amazon_de.py
+++ b/extract/extract/extractors/amazon_de.py
@@ -193,7 +193,7 @@ def get_energy_label_level(soup: BeautifulSoup) -> Optional[str]:
     targets = [soup.find(id="energyEfficiency")]
 
     def parse_energy_efficiency(energy_efficiency: BeautifulSoup) -> Optional[str]:
-        if energy_efficiency:
+        if energy_efficiency and energy_efficiency.find("text"):
             return "EU Energy label " + energy_efficiency.find("text").get_text().strip()
         return None
 

--- a/extract/extract/extractors/amazon_de.py
+++ b/extract/extract/extractors/amazon_de.py
@@ -241,7 +241,7 @@ def _get_image_urls(soup: BeautifulSoup) -> Optional[list[str]]:
         soup.find("div", {"class": "unrolledScrollBox"}),
     ]
 
-    def parse_image_urls(images: list[BeautifulSoup]) -> list[str]:
+    def parse_image_urls(images: BeautifulSoup) -> list[str]:
         image_urls = [
             str(image["src"])
             for image in images.find_all("img")

--- a/extract/extract/extractors/amazon_de.py
+++ b/extract/extract/extractors/amazon_de.py
@@ -237,7 +237,7 @@ def _get_image_urls(soup: BeautifulSoup) -> Optional[list[str]]:
             If nothing was found `None` or empty list is returned.
     """
     targets = [
-        soup.find_all("div", {"id": "altImages"}),
+        soup.find("div", {"id": "altImages"}),
         soup.find("div", {"class": "unrolledScrollBox"})
     ]
 

--- a/extract/extract/extractors/amazon_de.py
+++ b/extract/extract/extractors/amazon_de.py
@@ -89,12 +89,12 @@ def extract_amazon_de(parsed_page: ParsedPage) -> Optional[Product]:
     if repairability_index := get_repairability_index(soup):
         sustainability_texts.append(repairability_index)
 
-    for energy_label in ["Energielabel", "Energy Label"]:
-        if energy_label in sustainability_texts:
-            if label_with_level := get_energy_label_level(soup):
-                sustainability_texts = [
-                    label.replace(energy_label, label_with_level) for label in sustainability_texts
-                ]
+    if label_with_level := get_energy_label_level(soup):
+        # check and remove Energy label strings that are extracted from CPF section
+        for energy_label in ["Energielabel", "Energy Label"]:
+            if energy_label in sustainability_texts:
+                sustainability_texts.remove(energy_label)
+        sustainability_texts.append(label_with_level)  # add Energy label with level
 
     sustainability_labels = sustainability_labels_to_certificates(
         sustainability_texts, _LABEL_MAPPING, parsed_page.scraped_page.category

--- a/monitoring/monitoring/utils.py
+++ b/monitoring/monitoring/utils.py
@@ -326,6 +326,7 @@ def fetch_and_cache_product_families(_green_db: Callable[[], Any] = hash_greendb
         "WASHER",
         "DRYER",
         "SMARTPHONE",
+        "TV"
     ]
     return {
         "all_categories": all_categories,

--- a/monitoring/monitoring/utils.py
+++ b/monitoring/monitoring/utils.py
@@ -326,7 +326,7 @@ def fetch_and_cache_product_families(_green_db: Callable[[], Any] = hash_greendb
         "WASHER",
         "DRYER",
         "SMARTPHONE",
-        "TV"
+        "TV",
     ]
     return {
         "all_categories": all_categories,

--- a/scraping/scraping/middlewares.py
+++ b/scraping/scraping/middlewares.py
@@ -12,8 +12,8 @@ logger = getLogger(__name__)
 user_agents = get_json_data("user_agents.json")
 
 AMAZON_MAX_REQUESTS_BEFORE_BREAK = 250
-AMAZON_MINIMUM_BREAK_LENGTH = 60**2 * 8  # 8 hours
-AMAZON_MAXIMUM_BREAK_LENGTH = 60**2 * 16
+AMAZON_MINIMUM_BREAK_LENGTH = 60**2 * 4  # 4 hours
+AMAZON_MAXIMUM_BREAK_LENGTH = 60**2 * 8
 
 
 class AmazonSchedulerMiddleware(object):

--- a/scraping/scraping/spiders/amazon_de.py
+++ b/scraping/scraping/spiders/amazon_de.py
@@ -22,18 +22,20 @@ class AmazonSpider(BaseSpider):
             "scraping.middlewares.AmazonSchedulerMiddleware": 543,
             "scrapy.downloadermiddlewares.retry.RetryMiddleware": None,
         },
-        "DEFAULT_REQUEST_HEADERS": {'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',  # noqa
-                                    'Accept-Language': 'de,en-US;q=0.7,en;q=0.3',
-                                    'Accept-Encoding': 'gzip, deflate, br',
-                                    'DNT': '1',
-                                    'Connection': 'keep-alive',
-                                    'Upgrade-Insecure-Requests': '1',
-                                    'Sec-Fetch-Dest': 'document',
-                                    'Sec-Fetch-Mode': 'navigate',
-                                    'Sec-Fetch-Site': 'none',
-                                    'Sec-Fetch-User': '?1',
-                                    'Pragma': 'no-cache',
-                                    'Cache-Control': 'no-cache'},
+        "DEFAULT_REQUEST_HEADERS": {
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",  # noqa
+            "Accept-Language": "de,en-US;q=0.7,en;q=0.3",
+            "Accept-Encoding": "gzip, deflate, br",
+            "DNT": "1",
+            "Connection": "keep-alive",
+            "Upgrade-Insecure-Requests": "1",
+            "Sec-Fetch-Dest": "document",
+            "Sec-Fetch-Mode": "navigate",
+            "Sec-Fetch-Site": "none",
+            "Sec-Fetch-User": "?1",
+            "Pragma": "no-cache",
+            "Cache-Control": "no-cache",
+        },
     }
 
     def parse_SERP(self, response: SplashJsonResponse) -> Iterator[SplashRequest]:
@@ -48,14 +50,17 @@ class AmazonSpider(BaseSpider):
 
         # Abort scraping if SERP does not correspond to Climate Pledge Friendly (CPF) products
         # abort if amazon redirects to non-CPF SERP
-        if redirect_URLs := response.request.meta.get('redirect_urls'):
-            if ("p_n_cpf_eligible" in redirect_URLs[0] and "p_n_cpf_eligible" not in response.url):
-                logger.info(f"Abort Scraping of {response.url} as Amazon redirected to a non Climate Pledge Friendly alternative.")
+        if redirect_URLs := response.request.meta.get("redirect_urls"):
+            if "p_n_cpf_eligible" in redirect_URLs[0] and "p_n_cpf_eligible" not in response.url:
+                logger.info(
+                    f"Abort Scraping of {response.url} as Amazon redirected to a non Climate Pledge Friendly alternative."
+                )
                 return None
         # abort if non-CPF results are returned anyway
         if bool(response.css("div.widgetId\=correction-messages-aps-redirect").extract()):
             logger.info(
-                f"Abort Scraping of {response.url} as Amazon does not list Climate Pledge Friendly products.")
+                f"Abort Scraping of {response.url} as Amazon does not list Climate Pledge Friendly products."
+            )
             return None
 
         urls = response.css("div.a-row.a-size-base.a-color-base a::attr(href)").getall()
@@ -72,12 +77,12 @@ class AmazonSpider(BaseSpider):
                     url=strip_url(response.urljoin(url)),
                     callback=self.parse_PRODUCT,
                     meta={
-                             "request_meta_information": {
-                                 "price": price.encode("ascii", "ignore").decode()
-                             },
-                             "dont_merge_cookies": True,
-                         }
-                         | self.create_default_request_meta(response),
+                        "request_meta_information": {
+                            "price": price.encode("ascii", "ignore").decode()
+                        },
+                        "dont_merge_cookies": True,
+                    }
+                    | self.create_default_request_meta(response),
                     endpoint="execute",
                     priority=1,  # higher priority than SERP
                     args={  # passed to Splash HTTP API
@@ -100,7 +105,7 @@ class AmazonSpider(BaseSpider):
                 url=next_page,
                 callback=self.parse_SERP,
                 meta=self.create_default_request_meta(response, original_url=next_page)
-                     | {"dont_merge_cookies": True},
+                | {"dont_merge_cookies": True},
                 endpoint="execute",
                 args={  # passed to Splash HTTP API
                     "wait": self.request_timeout,

--- a/scraping/scraping/spiders/amazon_de.py
+++ b/scraping/scraping/spiders/amazon_de.py
@@ -50,9 +50,12 @@ class AmazonSpider(BaseSpider):
         self._save_SERP(response)
 
         # Abort scraping if SERP does not correspond to Climate Pledge Friendly (CPF) products
-        # abort if amazon redirects to non-CPF SERP or non-CPF results are returned anyway
-        if ("&page=" not in response.url and "Cp_n_cpf_eligible" not in response.url) \
-                or bool(response.css("div.widgetId\=correction-messages-aps-redirect").extract()):
+        # abort if amazon redirects to non-CPF SERP
+        if redirect_URLs := response.request.meta.get('redirect_urls'):
+            if ("p_n_cpf_eligible" in redirect_URLs[0] and "p_n_cpf_eligible" not in response.url):
+                return None
+        # abort if non-CPF results are returned anyway
+        if bool(response.css("div.widgetId\=correction-messages-aps-redirect").extract()):
             return None
 
         urls = response.css("div.a-row.a-size-base.a-color-base a::attr(href)").getall()

--- a/scraping/scraping/spiders/amazon_de.py
+++ b/scraping/scraping/spiders/amazon_de.py
@@ -48,6 +48,15 @@ class AmazonSpider(BaseSpider):
         """
         # Save HTML to database
         self._save_SERP(response)
+
+        # Abort scraping if SERP does not correspond to Climate Pledge Friendly products
+        # check if amazon redirects to non CPF alternative products
+        if "&page=" not in response.url and "Cp_n_cpf_eligible" not in response.url:
+            return None
+        # check if non-CPF results are returned without redirecting
+        if response.css("div.widgetId\=correction-messages-aps-redirect").extract():
+            return None
+
         urls = response.css("div.a-row.a-size-base.a-color-base a::attr(href)").getall()
         prices = response.css(
             "div.a-row.a-size-base.a-color-base span.a-price-whole::text"

--- a/scraping/scraping/spiders/amazon_de.py
+++ b/scraping/scraping/spiders/amazon_de.py
@@ -49,12 +49,10 @@ class AmazonSpider(BaseSpider):
         # Save HTML to database
         self._save_SERP(response)
 
-        # Abort scraping if SERP does not correspond to Climate Pledge Friendly products
-        # check if amazon redirects to non CPF alternative products
-        if "&page=" not in response.url and "Cp_n_cpf_eligible" not in response.url:
-            return None
-        # check if non-CPF results are returned without redirecting
-        if response.css("div.widgetId\=correction-messages-aps-redirect").extract():
+        # Abort scraping if SERP does not correspond to Climate Pledge Friendly (CPF) products
+        # abort if amazon redirects to non-CPF SERP or non-CPF results are returned anyway
+        if ("&page=" not in response.url and "Cp_n_cpf_eligible" not in response.url) \
+                or bool(response.css("div.widgetId\=correction-messages-aps-redirect").extract()):
             return None
 
         urls = response.css("div.a-row.a-size-base.a-color-base a::attr(href)").getall()

--- a/scraping/scraping/spiders/amazon_de.py
+++ b/scraping/scraping/spiders/amazon_de.py
@@ -50,9 +50,12 @@ class AmazonSpider(BaseSpider):
         # abort if amazon redirects to non-CPF SERP
         if redirect_URLs := response.request.meta.get('redirect_urls'):
             if ("p_n_cpf_eligible" in redirect_URLs[0] and "p_n_cpf_eligible" not in response.url):
+                logger.info(f"Abort Scraping of {response.url} as Amazon redirected to a non Climate Pledge Friendly alternative.")
                 return None
         # abort if non-CPF results are returned anyway
         if bool(response.css("div.widgetId\=correction-messages-aps-redirect").extract()):
+            logger.info(
+                f"Abort Scraping of {response.url} as Amazon does not list Climate Pledge Friendly products.")
             return None
 
         urls = response.css("div.a-row.a-size-base.a-color-base a::attr(href)").getall()

--- a/scraping/scraping/spiders/amazon_de.py
+++ b/scraping/scraping/spiders/amazon_de.py
@@ -22,21 +22,18 @@ class AmazonSpider(BaseSpider):
             "scraping.middlewares.AmazonSchedulerMiddleware": 543,
             "scrapy.downloadermiddlewares.retry.RetryMiddleware": None,
         },
-        "DEFAULT_REQUEST_HEADERS": {
-            "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",  # noqa
-            "accept-encoding": "deflate",
-            "accept-language": "de-DE,de;q=0.9",
-            "cache-control": "no-cache",
-            "pragma": "no-cache",
-            "sec-ch-ua": '" Not A;Brand";v="99", "Chromium";v="99", "Google Chrome";v="99"',
-            "sec-ch-ua-mobile": "?0",
-            "sec-ch-ua-platform": '"Windows"',
-            "sec-fetch-dest": "document",
-            "sec-fetch-mode": "navigate",
-            "sec-fetch-site": "none",
-            "sec-fetch-user": "?1",
-            "upgrade-insecure-requests": "1",
-        },
+        "DEFAULT_REQUEST_HEADERS": {'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',  # noqa
+                                    'Accept-Language': 'de,en-US;q=0.7,en;q=0.3',
+                                    'Accept-Encoding': 'gzip, deflate, br',
+                                    'DNT': '1',
+                                    'Connection': 'keep-alive',
+                                    'Upgrade-Insecure-Requests': '1',
+                                    'Sec-Fetch-Dest': 'document',
+                                    'Sec-Fetch-Mode': 'navigate',
+                                    'Sec-Fetch-Site': 'none',
+                                    'Sec-Fetch-User': '?1',
+                                    'Pragma': 'no-cache',
+                                    'Cache-Control': 'no-cache'},
     }
 
     def parse_SERP(self, response: SplashJsonResponse) -> Iterator[SplashRequest]:
@@ -72,12 +69,12 @@ class AmazonSpider(BaseSpider):
                     url=strip_url(response.urljoin(url)),
                     callback=self.parse_PRODUCT,
                     meta={
-                        "request_meta_information": {
-                            "price": price.encode("ascii", "ignore").decode()
-                        },
-                        "dont_merge_cookies": True,
-                    }
-                    | self.create_default_request_meta(response),
+                             "request_meta_information": {
+                                 "price": price.encode("ascii", "ignore").decode()
+                             },
+                             "dont_merge_cookies": True,
+                         }
+                         | self.create_default_request_meta(response),
                     endpoint="execute",
                     priority=1,  # higher priority than SERP
                     args={  # passed to Splash HTTP API
@@ -100,7 +97,7 @@ class AmazonSpider(BaseSpider):
                 url=next_page,
                 callback=self.parse_SERP,
                 meta=self.create_default_request_meta(response, original_url=next_page)
-                | {"dont_merge_cookies": True},
+                     | {"dont_merge_cookies": True},
                 endpoint="execute",
                 args={  # passed to Splash HTTP API
                     "wait": self.request_timeout,

--- a/scraping/scraping/spiders/amazon_de.py
+++ b/scraping/scraping/spiders/amazon_de.py
@@ -53,13 +53,15 @@ class AmazonSpider(BaseSpider):
         if redirect_URLs := response.request.meta.get("redirect_urls"):
             if "p_n_cpf_eligible" in redirect_URLs[0] and "p_n_cpf_eligible" not in response.url:
                 logger.info(
-                    f"Abort Scraping of {response.url} as Amazon redirected to a non Climate Pledge Friendly alternative."
+                    f"Abort Scraping of {response.url} as Amazon redirected to a non Climate "
+                    f"Pledge Friendly alternative."
                 )
                 return None
         # abort if non-CPF results are returned anyway
-        if bool(response.css("div.widgetId\=correction-messages-aps-redirect").extract()):
+        if bool(response.css(r"div.widgetId\=correction-messages-aps-redirect").extract()):  # noqa
             logger.info(
-                f"Abort Scraping of {response.url} as Amazon does not list Climate Pledge Friendly products."
+                f"Abort Scraping of {response.url} as Amazon does not list Climate Pledge "
+                f"Friendly products."
             )
             return None
 

--- a/scraping/scraping/spiders/zalando_de.py
+++ b/scraping/scraping/spiders/zalando_de.py
@@ -74,7 +74,7 @@ class ZalandoSpider(BaseSpider):
             )
 
         # Pagination: Parse next SERP 'recursively'
-        pagination = response.css('[class="DJxzzA PgtkyN"]::attr(href)').getall()
+        pagination = response.css('[class="DJxzzA OldB32"]::attr(href)').getall()
 
         if (is_first_page and pagination) or len(pagination) == 2:
             next_page = response.urljoin(pagination[-1])

--- a/scraping/scraping/start_scripts/amazon_eu.py
+++ b/scraping/scraping/start_scripts/amazon_eu.py
@@ -304,8 +304,8 @@ def household(country_code: str) -> List[dict]:
 
 def get_settings(country_code: str) -> List[dict]:
     return (
-        male(country_code)
+        electronics(country_code)
+        + male(country_code)
         + female(country_code)
-        + electronics(country_code)
         + household(country_code)
     )


### PR DESCRIPTION
Amazon sometimes does not return Climate Pledge Friendly (CPF) products, even though we query for those only.
They return alternate (non-CPF) products in that situation, which we are not interested in.

For example:
Amazon Womens Bathrobe original url:
https://www.amazon.de/s?bbn=1981827031&rh=n%3A1981827031%2Cp_n_cpf_eligible%3A22579885031
leads to this:
https://www.amazon.de/b?node=1983823031

Or amazon does redirect to CPF page, but returns non-CPF products anyhow, for example: 
Amazon Dryer original url:
https://www.amazon.co.uk/s?bbn=1391019031&rh=n%3A1391019031%2Cp_n_cpf_eligible%3A22579929031
is forwarded to: 
https://www.amazon.co.uk/s?keywords=Dryers&bbn=1391019031&rh=n%3A1391019031%2Cp_n_cpf_eligible%3A22579929031&c=ts&ts_id=1391019031

But the forwarded page says: "Showing results from All Departments. No results for Dryers in Large Appliances."

This PR aborts the Scraping of those pages and some other adjustments.