### PR TITLE
Add a new date for the sustainability labels -

### DIFF
--- a/core/core/sustainability_labels/bootstrap_database.py
+++ b/core/core/sustainability_labels/bootstrap_database.py
@@ -36,7 +36,7 @@ def _get_localized_certificate_attribute(
 sustainability_labels = [
     SustainabilityLabel(
         id=certificate_id,
-        timestamp=datetime(2022, 10, 10),  # NOTE: Change me after updating sustainability labels
+        timestamp=datetime(2023, 1, 20),  # NOTE: Change me after updating sustainability labels
         name=_get_localized_certificate_attribute(certificate_information, "name"),
         description=_get_localized_certificate_attribute(certificate_information, "description"),
         cred_credibility=certificate_information.get("cred_credibility", None),


### PR DESCRIPTION
Since we added the 'certificate:UNAVAILABLE' we also need to update the green-db::sustainability_labels:: timestamp for the next DB bootstrap.