### PR TITLE
Task/optimize otto scrapes disable unavailable for sustainabile products

### DIFF
--- a/core/core/domain.py
+++ b/core/core/domain.py
@@ -56,6 +56,7 @@ class ScrapedPage(BaseModel):
 
     page_type: PageType
     meta_information: Optional[dict]
+    original_URL: Optional[str]
 
     class Config:
         orm_mode = True

--- a/core/core/domain.py
+++ b/core/core/domain.py
@@ -56,7 +56,6 @@ class ScrapedPage(BaseModel):
 
     page_type: PageType
     meta_information: Optional[dict]
-    original_URL: Optional[str]
 
     class Config:
         orm_mode = True

--- a/core/core/domain.py
+++ b/core/core/domain.py
@@ -121,7 +121,6 @@ class SustainabilityLabel(BaseModel):
 
 # if you make an edge case decision, please document it here.
 class ProductCategory(str, Enum):
-
     # bags
     BACKPACK = "BACKPACK"
     BAG = "BAG"

--- a/database/database/connection.py
+++ b/database/database/connection.py
@@ -245,7 +245,6 @@ class GreenDB(Connection):
                 .filter(SustainabilityLabelsTable.timestamp == sustainability_labels[0].timestamp)
                 .first()
             ):
-
                 for label in sustainability_labels:
                     db_session.add(SustainabilityLabelsTable(**label.dict()))
 
@@ -280,7 +279,6 @@ class GreenDB(Connection):
                 of domain object representations
         """
         with self._session_factory() as db_session:
-
             sustainability_labels = db_session.query(SustainabilityLabelsTable).all()
             sustainability_labels_iterator = (
                 SustainabilityLabel.from_orm(sustainability_label)
@@ -572,7 +570,6 @@ class GreenDB(Connection):
            pd.DataFrame: Query results as `pd.Dataframe`.
         """
         with self._session_factory() as db_session:
-
             labels = self.get_sustainability_labels_subquery()
 
             all_unique = self.get_all_unique_products()
@@ -631,7 +628,6 @@ class GreenDB(Connection):
            pd.DataFrame: Query results as `pd.Dataframe`.
         """
         with self._session_factory() as db_session:
-
             labels = self.get_sustainability_labels_subquery()
 
             credible_labels = [

--- a/extract/extract/extractors/otto_de.py
+++ b/extract/extract/extractors/otto_de.py
@@ -74,7 +74,7 @@ def extract_otto_de(parsed_page: ParsedPage) -> Optional[Product]:
 
     # Check if the SUSTAINABILITY_FILTER was in the URL
     orig_url = parsed_page.scraped_page.original_URL
-    assign_unavailable = orig_url and SUSTAINABILITY_FILTER not in orig_url
+    assign_unavailable = orig_url is not None and SUSTAINABILITY_FILTER not in orig_url
 
     sustainability_labels = _get_sustainability(
         product_data,

--- a/extract/extract/extractors/otto_de.py
+++ b/extract/extract/extractors/otto_de.py
@@ -2,10 +2,10 @@ import json
 from logging import getLogger
 from typing import List, Optional
 from urllib.parse import ParseResult, urlparse
-from bs4 import BeautifulSoup
-from pydantic import ValidationError
 
+from bs4 import BeautifulSoup
 from core.domain import CertificateType, Product
+from pydantic import ValidationError
 
 from ..parse import DUBLINCORE, JSON_LD, MICRODATA, ParsedPage
 from ..utils import (
@@ -73,7 +73,8 @@ def extract_otto_de(parsed_page: ParsedPage) -> Optional[Product]:
     parsed_url = urlparse(parsed_page.scraped_page.url)
 
     # Check if the SUSTAINABILITY_FILTER was in the URL
-    orig_url = parsed_page.scraped_page.meta_information.get("original_URL", None)
+    meta_info = parsed_page.scraped_page.meta_information
+    orig_url = meta_info.get("original_URL", None) if meta_info else None
     assign_unavailable = orig_url is not None and SUSTAINABILITY_FILTER not in orig_url
 
     sustainability_labels = _get_sustainability(

--- a/extract/extract/extractors/otto_de.py
+++ b/extract/extract/extractors/otto_de.py
@@ -4,8 +4,9 @@ from typing import List, Optional
 from urllib.parse import ParseResult, urlparse
 
 from bs4 import BeautifulSoup
-from core.domain import CertificateType, Product
 from pydantic import ValidationError
+
+from core.domain import CertificateType, Product
 
 from ..parse import DUBLINCORE, JSON_LD, MICRODATA, ParsedPage
 from ..utils import (

--- a/extract/extract/extractors/otto_de.py
+++ b/extract/extract/extractors/otto_de.py
@@ -73,7 +73,7 @@ def extract_otto_de(parsed_page: ParsedPage) -> Optional[Product]:
     parsed_url = urlparse(parsed_page.scraped_page.url)
 
     # Check if the SUSTAINABILITY_FILTER was in the URL
-    orig_url = parsed_page.scraped_page.original_URL
+    orig_url = parsed_page.scraped_page.meta_information.get("original_URL", None)
     assign_unavailable = orig_url is not None and SUSTAINABILITY_FILTER not in orig_url
 
     sustainability_labels = _get_sustainability(

--- a/extract/tests/amazon/washer_de_test.py
+++ b/extract/tests/amazon/washer_de_test.py
@@ -59,5 +59,4 @@ def test_amazon_electronics() -> None:
         asin="B08R3YHPK1",
     )
     for attribute in expected.__dict__.keys():
-
         assert actual.__dict__[attribute] == expected.__dict__[attribute]

--- a/extract/tests/otto/damen-pullover_sustainable_filter_test.py
+++ b/extract/tests/otto/damen-pullover_sustainable_filter_test.py
@@ -22,8 +22,8 @@ def test_otto_basic() -> None:
     category = "SWEATER"
     gender = GenderType.FEMALE
     consumer_lifestage = ConsumerLifestageType.ADULT
-    meta_information = {"family": "FASHION"}
     original_URL = f"{url}{SUSTAINABILITY_FILTER}"
+    meta_information = {"family": "FASHION", "original_URL": original_URL}
 
     scraped_page = read_test_html(
         timestamp=timestamp,
@@ -35,8 +35,7 @@ def test_otto_basic() -> None:
         gender=gender,
         consumer_lifestage=consumer_lifestage,
         meta_information=meta_information,
-        url=url,
-        original_URL=original_URL,
+        url=url
     )
 
     actual = extract_product(TABLE_NAME_SCRAPING_OTTO_DE, scraped_page)

--- a/extract/tests/otto/damen-pullover_sustainable_filter_test.py
+++ b/extract/tests/otto/damen-pullover_sustainable_filter_test.py
@@ -1,15 +1,10 @@
-from extract.extractors.otto_de import SUSTAINABILITY_FILTER
-from tests.utils import read_test_html
-
 from core.constants import TABLE_NAME_SCRAPING_OTTO_DE
-from core.domain import (
-    ConsumerLifestageType,
-    CountryType,
-    GenderType,
-)
+from core.domain import ConsumerLifestageType, CountryType, GenderType
 
 # TODO: This is a false positive of mypy
 from extract import extract_product  # type: ignore
+from extract.extractors.otto_de import SUSTAINABILITY_FILTER
+from tests.utils import read_test_html
 
 
 def test_otto_basic() -> None:
@@ -35,7 +30,7 @@ def test_otto_basic() -> None:
         gender=gender,
         consumer_lifestage=consumer_lifestage,
         meta_information=meta_information,
-        url=url
+        url=url,
     )
 
     actual = extract_product(TABLE_NAME_SCRAPING_OTTO_DE, scraped_page)

--- a/extract/tests/otto/damen-pullover_sustainable_filter_test.py
+++ b/extract/tests/otto/damen-pullover_sustainable_filter_test.py
@@ -1,11 +1,7 @@
 from tests.utils import read_test_html
 
 from core.constants import TABLE_NAME_SCRAPING_OTTO_DE
-from core.domain import (
-    ConsumerLifestageType,
-    CountryType,
-    GenderType,
-)
+from core.domain import ConsumerLifestageType, CountryType, GenderType
 
 # TODO: This is a false positive of mypy
 from extract import extract_product  # type: ignore

--- a/extract/tests/otto/damen-pullover_sustainable_filter_test.py
+++ b/extract/tests/otto/damen-pullover_sustainable_filter_test.py
@@ -2,12 +2,9 @@ from tests.utils import read_test_html
 
 from core.constants import TABLE_NAME_SCRAPING_OTTO_DE
 from core.domain import (
-    CertificateType,
     ConsumerLifestageType,
     CountryType,
-    CurrencyType,
     GenderType,
-    Product,
 )
 
 # TODO: This is a false positive of mypy

--- a/extract/tests/otto/damen-pullover_sustainable_filter_test.py
+++ b/extract/tests/otto/damen-pullover_sustainable_filter_test.py
@@ -1,0 +1,47 @@
+from extract.extractors.otto_de import SUSTAINABILITY_FILTER
+from tests.utils import read_test_html
+
+from core.constants import TABLE_NAME_SCRAPING_OTTO_DE
+from core.domain import (
+    CertificateType,
+    ConsumerLifestageType,
+    CountryType,
+    CurrencyType,
+    GenderType,
+    Product,
+)
+
+# TODO: This is a false positive of mypy
+from extract import extract_product  # type: ignore
+
+
+def test_otto_basic() -> None:
+    url = "https://www.otto.mock/"
+    timestamp = "2022-02-17 12:49:00"
+    source = "otto"
+    merchant = "otto"
+    country = CountryType.DE
+    file_name = "damen-pullover.html"
+    category = "SWEATER"
+    gender = GenderType.FEMALE
+    consumer_lifestage = ConsumerLifestageType.ADULT
+    meta_information = {"family": "FASHION"}
+    original_URL = f"{url}{SUSTAINABILITY_FILTER}"
+
+    scraped_page = read_test_html(
+        timestamp=timestamp,
+        source=source,
+        merchant=merchant,
+        country=country,
+        file_name=file_name,
+        category=category,
+        gender=gender,
+        consumer_lifestage=consumer_lifestage,
+        meta_information=meta_information,
+        url=url,
+        original_URL=original_URL,
+    )
+
+    actual = extract_product(TABLE_NAME_SCRAPING_OTTO_DE, scraped_page)
+
+    assert actual is None

--- a/extract/tests/otto/damen-pullover_sustainable_filter_test.py
+++ b/extract/tests/otto/damen-pullover_sustainable_filter_test.py
@@ -3,12 +3,9 @@ from tests.utils import read_test_html
 
 from core.constants import TABLE_NAME_SCRAPING_OTTO_DE
 from core.domain import (
-    CertificateType,
     ConsumerLifestageType,
     CountryType,
-    CurrencyType,
     GenderType,
-    Product,
 )
 
 # TODO: This is a false positive of mypy

--- a/extract/tests/otto/damen-pullover_sustainable_filter_test.py
+++ b/extract/tests/otto/damen-pullover_sustainable_filter_test.py
@@ -1,10 +1,18 @@
+from tests.utils import read_test_html
+
 from core.constants import TABLE_NAME_SCRAPING_OTTO_DE
-from core.domain import ConsumerLifestageType, CountryType, GenderType
+from core.domain import (
+    CertificateType,
+    ConsumerLifestageType,
+    CountryType,
+    CurrencyType,
+    GenderType,
+    Product,
+)
 
 # TODO: This is a false positive of mypy
 from extract import extract_product  # type: ignore
 from extract.extractors.otto_de import SUSTAINABILITY_FILTER
-from tests.utils import read_test_html
 
 
 def test_otto_basic() -> None:

--- a/extract/tests/otto/damen-pullover_test.py
+++ b/extract/tests/otto/damen-pullover_test.py
@@ -24,8 +24,7 @@ def test_otto_basic() -> None:
     category = "SWEATER"
     gender = GenderType.FEMALE
     consumer_lifestage = ConsumerLifestageType.ADULT
-    meta_information = {"family": "FASHION"}
-    original_URL = url
+    meta_information = {"family": "FASHION", "original_URL": url}
 
     scraped_page = read_test_html(
         timestamp=timestamp,
@@ -37,8 +36,7 @@ def test_otto_basic() -> None:
         gender=gender,
         consumer_lifestage=consumer_lifestage,
         meta_information=meta_information,
-        url=url,
-        original_URL=original_URL,
+        url=url
     )
 
     actual = extract_product(TABLE_NAME_SCRAPING_OTTO_DE, scraped_page)

--- a/extract/tests/otto/damen-pullover_test.py
+++ b/extract/tests/otto/damen-pullover_test.py
@@ -25,6 +25,7 @@ def test_otto_basic() -> None:
     gender = GenderType.FEMALE
     consumer_lifestage = ConsumerLifestageType.ADULT
     meta_information = {"family": "FASHION"}
+    original_URL = url
 
     scraped_page = read_test_html(
         timestamp=timestamp,
@@ -37,6 +38,7 @@ def test_otto_basic() -> None:
         consumer_lifestage=consumer_lifestage,
         meta_information=meta_information,
         url=url,
+        original_URL=original_URL,
     )
 
     actual = extract_product(TABLE_NAME_SCRAPING_OTTO_DE, scraped_page)

--- a/extract/tests/otto/damen-pullover_test.py
+++ b/extract/tests/otto/damen-pullover_test.py
@@ -36,7 +36,7 @@ def test_otto_basic() -> None:
         gender=gender,
         consumer_lifestage=consumer_lifestage,
         meta_information=meta_information,
-        url=url
+        url=url,
     )
 
     actual = extract_product(TABLE_NAME_SCRAPING_OTTO_DE, scraped_page)

--- a/extract/tests/otto/electronics-phone-nonsustainable_test.py
+++ b/extract/tests/otto/electronics-phone-nonsustainable_test.py
@@ -17,6 +17,7 @@ def test_otto_basic() -> None:
     file_name = "electronics-phone-nonsustainable.html"
     category = "SMARTPHONE"
     meta_information = {"family": "electronics"}
+    original_URL = url
 
     scraped_page = read_test_html(
         timestamp=timestamp,
@@ -27,6 +28,7 @@ def test_otto_basic() -> None:
         category=category,
         meta_information=meta_information,
         url=url,
+        original_URL=original_URL,
     )
 
     actual = extract_product(TABLE_NAME_SCRAPING_OTTO_DE, scraped_page)

--- a/extract/tests/otto/electronics-phone-nonsustainable_test.py
+++ b/extract/tests/otto/electronics-phone-nonsustainable_test.py
@@ -16,8 +16,7 @@ def test_otto_basic() -> None:
     country = CountryType.DE
     file_name = "electronics-phone-nonsustainable.html"
     category = "SMARTPHONE"
-    meta_information = {"family": "electronics"}
-    original_URL = url
+    meta_information = {"family": "electronics", "original_URL": url}
 
     scraped_page = read_test_html(
         timestamp=timestamp,
@@ -27,8 +26,7 @@ def test_otto_basic() -> None:
         file_name=file_name,
         category=category,
         meta_information=meta_information,
-        url=url,
-        original_URL=original_URL,
+        url=url
     )
 
     actual = extract_product(TABLE_NAME_SCRAPING_OTTO_DE, scraped_page)

--- a/extract/tests/otto/electronics-phone-nonsustainable_test.py
+++ b/extract/tests/otto/electronics-phone-nonsustainable_test.py
@@ -26,7 +26,7 @@ def test_otto_basic() -> None:
         file_name=file_name,
         category=category,
         meta_information=meta_information,
-        url=url
+        url=url,
     )
 
     actual = extract_product(TABLE_NAME_SCRAPING_OTTO_DE, scraped_page)

--- a/extract/tests/utils.py
+++ b/extract/tests/utils.py
@@ -15,7 +15,7 @@ def read_test_html(
     meta_information: dict,
     url: str = "dummy_url",
     gender: Optional[GenderType] = None,
-    consumer_lifestage: Optional[ConsumerLifestageType] = None
+    consumer_lifestage: Optional[ConsumerLifestageType] = None,
 ) -> ScrapedPage:
     path = TEST_DATA_DIR / merchant / "data" / file_name
     with open(path, encoding="utf-8") as f:
@@ -30,7 +30,7 @@ def read_test_html(
             gender=gender,
             consumer_lifestage=consumer_lifestage,
             page_type=PageType("PRODUCT"),
-            meta_information=meta_information
+            meta_information=meta_information,
         )
 
 

--- a/extract/tests/utils.py
+++ b/extract/tests/utils.py
@@ -15,8 +15,7 @@ def read_test_html(
     meta_information: dict,
     url: str = "dummy_url",
     gender: Optional[GenderType] = None,
-    consumer_lifestage: Optional[ConsumerLifestageType] = None,
-    original_URL: Optional[str] = None,
+    consumer_lifestage: Optional[ConsumerLifestageType] = None
 ) -> ScrapedPage:
     path = TEST_DATA_DIR / merchant / "data" / file_name
     with open(path, encoding="utf-8") as f:
@@ -31,8 +30,7 @@ def read_test_html(
             gender=gender,
             consumer_lifestage=consumer_lifestage,
             page_type=PageType("PRODUCT"),
-            meta_information=meta_information,
-            original_URL=original_URL,
+            meta_information=meta_information
         )
 
 

--- a/extract/tests/utils.py
+++ b/extract/tests/utils.py
@@ -16,6 +16,7 @@ def read_test_html(
     url: str = "dummy_url",
     gender: Optional[GenderType] = None,
     consumer_lifestage: Optional[ConsumerLifestageType] = None,
+    original_URL: Optional[str] = None,
 ) -> ScrapedPage:
     path = TEST_DATA_DIR / merchant / "data" / file_name
     with open(path, encoding="utf-8") as f:
@@ -31,6 +32,7 @@ def read_test_html(
             consumer_lifestage=consumer_lifestage,
             page_type=PageType("PRODUCT"),
             meta_information=meta_information,
+            original_URL=original_URL,
         )
 
 

--- a/scraping/scraping/spiders/_base.py
+++ b/scraping/scraping/spiders/_base.py
@@ -275,6 +275,7 @@ class BaseSpider(Spider):
             gender=response.meta.get("gender"),
             consumer_lifestage=response.meta.get("consumer_lifestage"),
             meta_information=meta_information,
+            original_URL=response.meta.get("original_URL"),
         )
 
         self.message_queue.add_scraping(table_name=self.table_name, scraped_page=scraped_page)

--- a/scraping/scraping/spiders/_base.py
+++ b/scraping/scraping/spiders/_base.py
@@ -276,7 +276,7 @@ class BaseSpider(Spider):
             category=response.meta.get("category"),
             gender=response.meta.get("gender"),
             consumer_lifestage=response.meta.get("consumer_lifestage"),
-            meta_information=meta_information
+            meta_information=meta_information,
         )
 
         self.message_queue.add_scraping(table_name=self.table_name, scraped_page=scraped_page)

--- a/scraping/scraping/spiders/_base.py
+++ b/scraping/scraping/spiders/_base.py
@@ -263,6 +263,8 @@ class BaseSpider(Spider):
         else:
             meta_information = response.meta.get("request_meta_information")
 
+        meta_information["original_URL"] = response.meta.get("original_URL", None)
+
         scraped_page = ScrapedPage(
             timestamp=self.timestamp,
             source=self.source,
@@ -274,8 +276,7 @@ class BaseSpider(Spider):
             category=response.meta.get("category"),
             gender=response.meta.get("gender"),
             consumer_lifestage=response.meta.get("consumer_lifestage"),
-            meta_information=meta_information,
-            original_URL=response.meta.get("original_URL"),
+            meta_information=meta_information
         )
 
         self.message_queue.add_scraping(table_name=self.table_name, scraped_page=scraped_page)

--- a/scraping/scraping/spiders/otto_de.py
+++ b/scraping/scraping/spiders/otto_de.py
@@ -18,6 +18,7 @@ class OttoSpider(BaseSpider):
     name = TABLE_NAME_SCRAPING_OTTO_DE
     source, _ = name.rsplit("_", 1)
     allowed_domains = ["otto.de"]
+    custom_settings = {"DOWNLOAD_DELAY": 4}
 
     def parse_SERP(self, response: SplashJsonResponse) -> Iterator[SplashRequest]:
 

--- a/scraping/scraping/spiders/otto_de.py
+++ b/scraping/scraping/spiders/otto_de.py
@@ -21,7 +21,6 @@ class OttoSpider(BaseSpider):
     custom_settings = {"DOWNLOAD_DELAY": 4}
 
     def parse_SERP(self, response: SplashJsonResponse) -> Iterator[SplashRequest]:
-
         # Save HTML to database
         self._save_SERP(response)
 
@@ -61,10 +60,8 @@ class OttoSpider(BaseSpider):
         ).getall()
 
         if len(pagination_list) > 0:
-
             pagination_info = json.loads(pagination_list[-1])
             if int(pagination_info["o"]) > response.meta.get("o", 0):
-
                 # Drop existing 'o' and 'l' parameters
                 url_parsed = urlparse(response.url)
                 queries = parse_qs(url_parsed.query, keep_blank_values=True)

--- a/scraping/scraping/spiders/zalando_de.py
+++ b/scraping/scraping/spiders/zalando_de.py
@@ -22,10 +22,8 @@ class ZalandoSpider(BaseSpider):
     def parse_SERP(
         self, response: SplashJsonResponse, is_first_page: bool = True
     ) -> Iterator[SplashRequest]:
-
         if original_URL := response.meta.get("original_URL"):
             if urlsplit(response.url).path.strip("/") != urlsplit(original_URL).path.strip("/"):
-
                 # If Zalando do not have results for a given filter,
                 # the will redirect to a page where results are found.
                 # Therefore, the URL path changes and we should return here

--- a/scraping/scraping/start_scripts/amazon_eu.py
+++ b/scraping/scraping/start_scripts/amazon_eu.py
@@ -60,7 +60,6 @@ def combine_results(
     gender: Optional[str] = None,
     consumer_lifestage: Optional[str] = None,
 ) -> List[dict]:
-
     country_code_to_url = {
         "fr": "https://www.amazon.fr",
         "de": "https://www.amazon.de",

--- a/scraping/scraping/start_scripts/otto_de.py
+++ b/scraping/scraping/start_scripts/otto_de.py
@@ -149,8 +149,6 @@ def electronics() -> List[dict]:
         "smartphone": ProductCategory.SMARTPHONE.value,
         "laptop": ProductCategory.LAPTOP.value,
         "tablet": ProductCategory.TABLET.value,
-        "audio/kopfhoerer": ProductCategory.HEADPHONES.value,
-        "fernseher": ProductCategory.TV.value,
     }
 
     results = []

--- a/start-job/scripts/main.py
+++ b/start-job/scripts/main.py
@@ -36,7 +36,6 @@ scrapy_config_parser.read("/green-db/scraping/scrapy.cfg")  # Repo gets cloned
 SCRAPYD_CLUSTER_TARGET = scrapy_config_parser.get("deploy:in-cluster", "url")
 
 if __name__ == "__main__":
-
     for merchant in MERCHANTS:
         command = (
             f"scrapyd-client -t {SCRAPYD_CLUSTER_TARGET} schedule -p scraping --arg "


### PR DESCRIPTION
Remove ProductCategory.HEADPHONES; ProductCategory.TV from otto (unnecessary for now); 
Add the original_URL in the core.domain::ScrapedPage; 
Update the tests in `extract` accordingly.

To address https://github.com/calgo-lab/green-db/issues/119 and https://github.com/calgo-lab/green-db/issues/126 - speed up the Otto scraping and avoid assiging the UNAVAILABLE label to products which are sustainable,  we propose the following solution.