### PR TITLE
Log the source when unknown sustainability labels/strings are found.

### DIFF
--- a/extract/extract/extractors/amazon_de.py
+++ b/extract/extract/extractors/amazon_de.py
@@ -98,7 +98,7 @@ def extract_amazon_de(parsed_page: ParsedPage) -> Optional[Product]:
         sustainability_texts.add(label_with_level)  # add Energy label with level
 
     sustainability_labels = sustainability_labels_to_certificates(
-        sustainability_texts, _LABEL_MAPPING, parsed_page.scraped_page.category
+        sustainability_texts, _LABEL_MAPPING, parsed_page.scraped_page.source, parsed_page.scraped_page.category,
     )
 
     brand = _get_brand(soup, language)

--- a/extract/extract/extractors/amazon_de.py
+++ b/extract/extract/extractors/amazon_de.py
@@ -98,7 +98,10 @@ def extract_amazon_de(parsed_page: ParsedPage) -> Optional[Product]:
         sustainability_texts.add(label_with_level)  # add Energy label with level
 
     sustainability_labels = sustainability_labels_to_certificates(
-        sustainability_texts, _LABEL_MAPPING, parsed_page.scraped_page.source, parsed_page.scraped_page.category,
+        sustainability_texts,
+        _LABEL_MAPPING,
+        parsed_page.scraped_page.source,
+        parsed_page.scraped_page.category,
     )
 
     brand = _get_brand(soup, language)

--- a/extract/extract/extractors/otto_de.py
+++ b/extract/extract/extractors/otto_de.py
@@ -303,5 +303,8 @@ def _get_sustainability(
         return [CertificateType.UNAVAILABLE]
 
     return sustainability_labels_to_certificates(
-        certificate_strings, _LABEL_MAPPING, parsed_page.scraped_page.source, parsed_page.scraped_page.category
+        certificate_strings,
+        _LABEL_MAPPING,
+        parsed_page.scraped_page.source,
+        parsed_page.scraped_page.category,
     )

--- a/extract/extract/extractors/otto_de.py
+++ b/extract/extract/extractors/otto_de.py
@@ -80,8 +80,7 @@ def extract_otto_de(parsed_page: ParsedPage) -> Optional[Product]:
 
     sustainability_labels = _get_sustainability(
         product_data,
-        parsed_page.beautiful_soup,
-        parsed_page.scraped_page.category,
+        parsed_page,
         assign_unavailable,
     )
     image_urls = _get_image_urls(product_data, parsed_url)[:NUM_IMAGE_URLS]
@@ -277,8 +276,7 @@ def _get_energy_labels(product_data: dict, beautiful_soup: BeautifulSoup) -> Lis
 
 def _get_sustainability(
     product_data: dict,
-    beautiful_soup: BeautifulSoup,
-    product_category: str,
+    parsed_page: ParsedPage,
     assign_unavailable: bool,
 ) -> Optional[List[str]]:
     """
@@ -286,16 +284,15 @@ def _get_sustainability(
 
     Args:
         product_data (dict): Representation of the product data JSON
-        beautiful_soup (BeautifulSoup): Parsed HTML of Product Website.
-        product_category (str): Product Category
+        parsed_page (ParsedPage): Intermediate representation of `ScrapedPage` domain object
         assign_unavailable (bool): Whether to assign the UNAVAILABLE label,
             Needed for Otto's "outdated" product pages, which are scraped as
             sustainable at first, but no Sustainable information was found during extraction.
     Returns:
         List[str]: Sorted `list` of found sustainability labels
     """
-    energy_labels = _get_energy_labels(product_data, beautiful_soup)
-    other_labels = _get_sustainability_info(beautiful_soup)
+    energy_labels = _get_energy_labels(product_data, parsed_page.beautiful_soup)
+    other_labels = _get_sustainability_info(parsed_page.beautiful_soup)
 
     certificate_strings = other_labels + energy_labels
 
@@ -306,5 +303,5 @@ def _get_sustainability(
         return [CertificateType.UNAVAILABLE]
 
     return sustainability_labels_to_certificates(
-        certificate_strings, _LABEL_MAPPING, product_category
+        certificate_strings, _LABEL_MAPPING, parsed_page.scraped_page.source, parsed_page.scraped_page.product_category
     )

--- a/extract/extract/extractors/otto_de.py
+++ b/extract/extract/extractors/otto_de.py
@@ -303,5 +303,5 @@ def _get_sustainability(
         return [CertificateType.UNAVAILABLE]
 
     return sustainability_labels_to_certificates(
-        certificate_strings, _LABEL_MAPPING, parsed_page.scraped_page.source, parsed_page.scraped_page.product_category
+        certificate_strings, _LABEL_MAPPING, parsed_page.scraped_page.source, parsed_page.scraped_page.category
     )

--- a/extract/extract/extractors/zalando_de.py
+++ b/extract/extract/extractors/zalando_de.py
@@ -105,7 +105,7 @@ def extract_zalando_de(
 
     sustainability_strings = get_sustainability_strings(parsed_page)
     sustainability_labels = sustainability_labels_to_certificates(
-        sustainability_strings, label_mapping
+        sustainability_strings, label_mapping, parsed_page.scraped_page.source
     )
 
     try:

--- a/extract/extract/utils.py
+++ b/extract/extract/utils.py
@@ -73,6 +73,7 @@ def get_product_from_JSON_LD(json_ld: List[Any], else_return: Any = {}) -> Any:
 def sustainability_labels_to_certificates(
     certificate_strings: Iterable[str],
     certificate_mapping: dict,
+    source: str,
     product_category: str = "",
 ) -> Optional[list[str]]:
     """
@@ -86,6 +87,7 @@ def sustainability_labels_to_certificates(
     Args:
         certificate_strings (list[str]): Certificate strings from the HTML span tags
         certificate_mapping (dict): Mapping of certificate strings to certificates
+        source: source (str) of the product coming from, for logging purposes
         product_category (str): Category of the product, to infer category-specific labels
 
     Returns:
@@ -115,7 +117,7 @@ def sustainability_labels_to_certificates(
                 result.update({certificate_string: certificate_mapping[certificate_string]})
             else:  # if certificate_string can not be mapped, assign UNKNOWN and create log message
                 result.update({certificate_string: CertificateType.UNKNOWN})  # type: ignore[attr-defined] # noqa
-                logger.info(f"unknown sustainability label: {certificate_string}")
+                logger.info(f"unknown sustainability label from {source}: {certificate_string}")
 
     # assign (general) extracted certificates to a product category-specific version, if possible
     if product_category in _certificate_category_names.keys():


### PR DESCRIPTION
With the current logging mechanism, it is not straightforward to trace back the source for which an unknown sustainability label was found. This PR adds the source to the logging message which ensures a correct identification of the source to which an unknown label belongs.

The old message format looked like e.g. this:
`2023-02-19 20:00:08,562 - INFO - extract.utils: unknown sustainability label: TENCEL™ Lyocell (Lenzing)`
which will be replaced by this:
`2023-02-19 20:00:08,562 - INFO - extract.utils: unknown sustainability label from otto: TENCEL™ Lyocell (Lenzing)`