### PR TITLE
Update otto sustainability extraction according to new html.

### DIFF
--- a/extract/extract/extractors/otto_de.py
+++ b/extract/extract/extractors/otto_de.py
@@ -235,14 +235,16 @@ def _get_sustainability_info(beautiful_soup: BeautifulSoup) -> List[str]:
         list: includes found sustainability strings.
     """
 
-    return_value = []
+    sustainability_classes = [
+        "pdp_sustainability-sheet__label-name",
+        "pdp_sustainability-details-sheet__label-name",
+    ]
 
-    for label_html in beautiful_soup.find_all(
-        "figcaption", attrs={"class": "pdp_sustainability-sheet__label-name"}
-    ):
-        return_value.append(label_html.text.strip())
-
-    return return_value
+    return [
+        label_html.text.strip()
+        for sc in sustainability_classes
+        for label_html in beautiful_soup.find_all("figcaption", attrs={"class": sc})
+    ]
 
 
 def _get_energy_labels(product_data: dict, beautiful_soup: BeautifulSoup) -> List[str]:


### PR DESCRIPTION
For some products on otto the HTML has changed and we cannot extract the sustainability information. This PR adds the new figure class from which we can extract the desired content. The old class is still neccessary, as some products still use the old html (and classes).