### PR TITLE
Set chart versions and adjust Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DB_EXPORTING_CHART=infrastructure/charts/db-exporting
 START_JOB_CHART=infrastructure/charts/start-job
 
 
-.PHONY: patch-core-version patch-database-version patch-extract-version patch-message-queue-version patch-scraping-version patch-workers-version patch-product-classification-version patch-start-job-version patch-all patch-version
+.PHONY: patch-core-version patch-database-version patch-extract-version patch-message-queue-version patch-scraping-version patch-workers-version patch-product-classification-version patch-start-job-version patch-db-exporting-version patch-all patch-version
 
 patch-core-version:
 	$(MAKE) -C core patch-version
@@ -35,7 +35,10 @@ patch-product-classification-version:
 patch-start-job-version:
 	$(MAKE) -C start-job patch-version
 
-patch-all: patch-core-version patch-database-version patch-extract-version patch-message-queue-version patch-monitoring-version patch-scraping-version patch-workers-version patch-product-classification-version
+patch-db-exporting-version:
+	$(MAKE) -C db-exporting patch-version
+
+patch-all: patch-core-version patch-database-version patch-extract-version patch-message-queue-version patch-monitoring-version patch-scraping-version patch-workers-version patch-product-classification-version patch-db-exporting-version
 
 patch-version: patch-all
 	# get version from core package.

--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ patch-workers-version:
 patch-product-classification-version:
 	$(MAKE) -C product-classification patch-version
 
-patch-start-job-version
-    $(MAKE) -C start-job patch-version
+patch-start-job-version:
+	$(MAKE) -C start-job patch-version
 
-patch-all: patch-core-version patch-database-version patch-extract-version patch-message-queue-version patch-monitoring-version patch-scraping-version patch-workers-version patch-product-classification-version patch-start-job-version
+patch-all: patch-core-version patch-database-version patch-extract-version patch-message-queue-version patch-monitoring-version patch-scraping-version patch-workers-version patch-product-classification-version
 
 patch-version: patch-all
 	# get version from core package.

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,11 @@ SCRAPYD_CHART=infrastructure/charts/scrapyd
 WORKERS_CHART=infrastructure/charts/workers
 MONITORING_CHART=infrastructure/charts/monitoring
 PRODUCT_CLASSIFICATION_CHART=infrastructure/charts/product-classification/helm
+DB_EXPORTING_CHART=infrastructure/charts/db-exporting
+START_JOB_CHART=infrastructure/charts/start-job
 
-.PHONY: patch-core-version patch-database-version patch-extract-version patch-message-queue-version patch-scraping-version patch-workers-version patch-product-classification-version patch-all patch-version
+
+.PHONY: patch-core-version patch-database-version patch-extract-version patch-message-queue-version patch-scraping-version patch-workers-version patch-product-classification-version patch-start-job-version patch-all patch-version
 
 patch-core-version:
 	$(MAKE) -C core patch-version
@@ -29,13 +32,16 @@ patch-workers-version:
 patch-product-classification-version:
 	$(MAKE) -C product-classification patch-version
 
-patch-all: patch-core-version patch-database-version patch-extract-version patch-message-queue-version patch-monitoring-version patch-scraping-version patch-workers-version patch-product-classification-version
+patch-start-job-version
+    $(MAKE) -C start-job patch-version
+
+patch-all: patch-core-version patch-database-version patch-extract-version patch-message-queue-version patch-monitoring-version patch-scraping-version patch-workers-version patch-product-classification-version patch-start-job-version
 
 patch-version: patch-all
 	# get version from core package.
 	$(eval VERSION=$(shell cd core; poetry version -s))
 	
-	git add core/pyproject.toml database/pyproject.toml extract/pyproject.toml message-queue/pyproject.toml monitoring/pyproject.toml scraping/pyproject.toml workers/pyproject.toml product-classification/pyproject.toml ${MONITORING_CHART}/Chart.yaml ${WORKERS_CHART}/Chart.yaml ${WORKERS_CHART}/Chart.yaml ${PRODUCT_CLASSIFICATION_CHART}/Chart.yaml
+	git add core/pyproject.toml database/pyproject.toml extract/pyproject.toml message-queue/pyproject.toml monitoring/pyproject.toml scraping/pyproject.toml workers/pyproject.toml product-classification/pyproject.toml ${MONITORING_CHART}/Chart.yaml ${WORKERS_CHART}/Chart.yaml ${SCRAPYD_CHART}/Chart.yaml ${PRODUCT_CLASSIFICATION_CHART}/Chart.yaml ${DB_EXPORTING_CHART}/Chart.yaml ${START_JOB_CHART}/Chart.yaml
 	git commit -m "bump version to '${VERSION}'"
 	git tag ${VERSION}
 
@@ -43,7 +49,7 @@ patch-version-push: patch-all
 	# get version from core package.
 	$(eval VERSION=$(shell cd core; poetry version -s))
 
-	git add core/pyproject.toml database/pyproject.toml extract/pyproject.toml message-queue/pyproject.toml monitoring/pyproject.toml scraping/pyproject.toml workers/pyproject.toml ${MONITORING_CHART}/Chart.yaml ${WORKERS_CHART}/Chart.yaml ${WORKERS_CHART}/Chart.yaml ${PRODUCT_CLASSIFICATION_CHART}/Chart.yaml
+	git add core/pyproject.toml database/pyproject.toml extract/pyproject.toml message-queue/pyproject.toml monitoring/pyproject.toml scraping/pyproject.toml workers/pyproject.toml db-exporting/pyproject.toml {MONITORING_CHART}/Chart.yaml ${WORKERS_CHART}/Chart.yaml ${SCRAPYD_CHART}/Chart.yaml ${PRODUCT_CLASSIFICATION_CHART}/Chart.yaml ${DB_EXPORTING_CHART}/Chart.yaml ${START_JOB_CHART}/Chart.yaml
 	git commit -m "bump version to '${VERSION}'"
 	git tag ${VERSION}
 

--- a/Makefile
+++ b/Makefile
@@ -41,18 +41,11 @@ patch-version: patch-all
 	# get version from core package.
 	$(eval VERSION=$(shell cd core; poetry version -s))
 	
-	git add core/pyproject.toml database/pyproject.toml extract/pyproject.toml message-queue/pyproject.toml monitoring/pyproject.toml scraping/pyproject.toml workers/pyproject.toml product-classification/pyproject.toml ${MONITORING_CHART}/Chart.yaml ${WORKERS_CHART}/Chart.yaml ${SCRAPYD_CHART}/Chart.yaml ${PRODUCT_CLASSIFICATION_CHART}/Chart.yaml ${DB_EXPORTING_CHART}/Chart.yaml ${START_JOB_CHART}/Chart.yaml
+	git add core/pyproject.toml database/pyproject.toml extract/pyproject.toml message-queue/pyproject.toml monitoring/pyproject.toml scraping/pyproject.toml workers/pyproject.toml db-exporting/pyproject.toml product-classification/pyproject.toml ${MONITORING_CHART}/Chart.yaml ${WORKERS_CHART}/Chart.yaml ${SCRAPYD_CHART}/Chart.yaml ${PRODUCT_CLASSIFICATION_CHART}/Chart.yaml ${DB_EXPORTING_CHART}/Chart.yaml ${START_JOB_CHART}/Chart.yaml
 	git commit -m "bump version to '${VERSION}'"
 	git tag ${VERSION}
 
-patch-version-push: patch-all
-	# get version from core package.
-	$(eval VERSION=$(shell cd core; poetry version -s))
-
-	git add core/pyproject.toml database/pyproject.toml extract/pyproject.toml message-queue/pyproject.toml monitoring/pyproject.toml scraping/pyproject.toml workers/pyproject.toml db-exporting/pyproject.toml {MONITORING_CHART}/Chart.yaml ${WORKERS_CHART}/Chart.yaml ${SCRAPYD_CHART}/Chart.yaml ${PRODUCT_CLASSIFICATION_CHART}/Chart.yaml ${DB_EXPORTING_CHART}/Chart.yaml ${START_JOB_CHART}/Chart.yaml
-	git commit -m "bump version to '${VERSION}'"
-	git tag ${VERSION}
-
+patch-version-push: patch-version
 	# push everything
 	git push
 	git push origin ${VERSION}

--- a/db-exporting/Makefile
+++ b/db-exporting/Makefile
@@ -1,12 +1,18 @@
-ifndef DOCKER_IMAGE_NAME
-DOCKER_IMAGE_NAME=registry.datexis.com/trajanovska/db-exporting
-$(info DOCKER_IMAGE_NAME is not set. Using ${DOCKER_IMAGE_NAME})
-endif
-
-
 DB_EXPORTING_CHART=../infrastructure/charts/db-exporting
 
+## Define `sed` command depending on operating system.
+
+ifeq ($(shell uname), Darwin)
+	# macOS
+	SED_INPLACE=sed -i '' -e
+else
+	# otherwise assume GNU sed
+	SED_INPLACE=sed -i -e
+endif
+
 .PHONY: patch-package patch-chart patch-version check-docker-prerequisites build-docker push-docker docker-test docker-tag helm-delete helm-install helm deploy-test set-docker-tag patch-and-deploy
+
+patch-version: patch-package patch-chart
 
 patch-package:
 	# update green-db dependencies
@@ -17,41 +23,33 @@ patch-package:
 
 patch-chart:
 	$(eval NEW_VERSION=$(shell poetry version -s))
-	sed -i '' -e 's/${OLD_VERSION}/${NEW_VERSION}/' ${DB_EXPORTING_CHART}/Chart.yaml
+	${SED_INPLACE} 's/${OLD_VERSION}/${NEW_VERSION}/' ${DB_EXPORTING_CHART}/Chart.yaml
 
-patch-version: patch-package patch-chart
-	# commit and push new version
-	git add pyproject.toml poetry.lock ${DB_EXPORTING_CHART}/Chart.yaml
-	git commit -m "bump version to '${NEW_VERSION}'"
-	#git tag ${NEW_VERSION}
+check-docker-prerequisites:
+ifndef DOCKER_IMAGE_NAME
+	$(error DOCKER_IMAGE_NAME is not set)
+endif
 
-	# push everything
-	git push
-	#git push origin ${NEW_VERSION} #todo this should be done with the greendb version
+build-docker: check-docker-prerequisites
+	docker build -t ${DOCKER_IMAGE_NAME}:test -f Dockerfile ..
 
-set-docker-tag:
-	$(eval DOCKER_IMAGE_TAG=$(shell poetry version -s))
+push-docker: check-docker-prerequisites
+	docker push ${DOCKER_IMAGE_NAME}:test
 
-set-docker-test:
-	$(eval DOCKER_IMAGE_TAG=test)
-
-build-docker:
-	docker build -t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} .
-
-push-docker:
-	docker push ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
-
-docker-test: set-docker-test build-docker push-docker
-docker-tag: set-docker-tag build-docker push-docker
+docker: build-docker push-docker
 
 helm-delete:
 	# ignoring error as long as it does not exist
-	helm -n greendb delete db-exporting
+	-helm delete db-exporting
 
 helm-install:
-	helm -n greendb install db-exporting --set image.tag=${DOCKER_IMAGE_TAG} --set image.pullPolicy=Always ${DB_EXPORTING_CHART}
+	helm install db-exporting ${DB_EXPORTING_CHART}
 
 helm: helm-delete helm-install
 
-deploy-test: docker-test helm
-deploy-tag: docker-tag helm
+deploy-test: docker helm-delete
+	# for private docker registry, we need 'private-registry-auth' imagePullSecrets
+	helm install db-exporting --set image.pullPolicy=Always --set image.repository=${DOCKER_IMAGE_NAME} --set image.tag=test --set imagePullSecrets[0].name=private-registry-auth ${DB_EXPORTING_CHART}
+
+test:
+	poetry run pytest -W ignore::DeprecationWarning

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,7 +15,9 @@ In order to create a new version one should use one fo the `make` commands as fo
 Then to restart the jobs with the new changes, one should run:
 
 ```yaml
-helm delete -n greendb workers scrapyd
-helm install workers -n greendb infrastructure/charts/workers
+helm delete -n greendb workers scrapyd product-classification
 helm install scrapyd -n greendb infrastructure/charts/scrapyd
+helm install workers -n greendb infrastructure/charts/workers
+helm install product-classification -n greendb infrastructure/charts/product-classification/helm
+helm install start-job -n greendb infrastructure/charts/start-job
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,7 +15,7 @@ In order to create a new version one should use one fo the `make` commands as fo
 Then to restart the jobs with the new changes, one should run:
 
 ```yaml
-helm delete -n greendb workers scrapyd product-classification
+helm delete -n greendb workers scrapyd product-classification start-job db-exporting
 helm install scrapyd -n greendb infrastructure/charts/scrapyd
 helm install workers -n greendb infrastructure/charts/workers
 helm install product-classification -n greendb infrastructure/charts/product-classification/helm

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -20,4 +20,5 @@ helm install scrapyd -n greendb infrastructure/charts/scrapyd
 helm install workers -n greendb infrastructure/charts/workers
 helm install product-classification -n greendb infrastructure/charts/product-classification/helm
 helm install start-job -n greendb infrastructure/charts/start-job
+helm install db-exporting -n greendb infrastructure/charts/db-exporting
 ```

--- a/infrastructure/charts/db-exporting/Chart.yaml
+++ b/infrastructure/charts/db-exporting/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: db-exporting
 description: A Helm chart to schedule DB export on Kubernetes
 type: application
-version: 0.2.11
-appVersion: "0.2.11"
+version: 0.2.13
+appVersion: "0.2.13"

--- a/infrastructure/charts/db-exporting/values.yaml
+++ b/infrastructure/charts/db-exporting/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: registry.datexis.com/trajanovska/db-exporting
+  repository: registry.datexis.com/greendb/db-exporting
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag:

--- a/infrastructure/charts/monitoring/Chart.yaml
+++ b/infrastructure/charts/monitoring/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: monitoring
 description: A Helm chart to deploy project dashboard in monitoring on Kubernetes
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.13
+appVersion: "0.2.13"

--- a/infrastructure/charts/product-classification/helm/Chart.yaml
+++ b/infrastructure/charts/product-classification/helm/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "0.2.13"

--- a/infrastructure/charts/scrapyd/Chart.yaml
+++ b/infrastructure/charts/scrapyd/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: scrapyd
 description: A Helm chart to deploy scrapyd on Kubernetes
 type: application
-version: 0.2.1
-appVersion: "0.2.1"
+version: 0.2.13
+appVersion: "0.2.13"

--- a/infrastructure/charts/start-job/Chart.yaml
+++ b/infrastructure/charts/start-job/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: start-job
 description: A Helm chart to schedule start scraping jobs on Kubernetes
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.13
+appVersion: "0.2.13"

--- a/product-classification/pyproject.toml
+++ b/product-classification/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "product-classification"
-version = "0.2.12"
+version = "0.2.13"
 description = ""
 license = "Apache-2.0"
 authors = ["Alex Flick <alex.flick@gmx.de>"]

--- a/start-job/Makefile
+++ b/start-job/Makefile
@@ -5,7 +5,10 @@ ifndef DOCKER_IMAGE_NAME
 	$(error DOCKER_IMAGE_NAME is not set)
 endif
 
+patch-version: patch-chart
+
 patch-chart:
+    # we do not have a poetry env for start-job so we use the workers env to retrieve NEW_VERSION
     $(eval OLD_VERSION=$(shell helm show chart ${START_JOB_CHART} | grep '^appVersion:' | awk '{print $2}'))
 	$(eval NEW_VERSION=$(shell cd ../workers; poetry version -s))
 	${SED_INPLACE} 's/${OLD_VERSION}/${NEW_VERSION}/' ${START_JOB_CHART}/Chart.yaml

--- a/start-job/Makefile
+++ b/start-job/Makefile
@@ -9,9 +9,9 @@ patch-version: patch-chart
 
 patch-chart:
     # we do not have a poetry env for start-job so we use the workers env to retrieve NEW_VERSION
-    $(eval OLD_VERSION=$(shell helm show chart ${START_JOB_CHART} | grep '^appVersion:' | awk '{print $2}'))
-	$(eval NEW_VERSION=$(shell cd ../workers; poetry version -s))
-	${SED_INPLACE} 's/${OLD_VERSION}/${NEW_VERSION}/' ${START_JOB_CHART}/Chart.yaml
+	$(eval OLD_VERSION=$(shell helm show chart ${START_JOB_CHART} | grep '^appVersion:' | awk '{print $$2}'))
+	$(eval NEW_VERSION=$(shell cd ../core; poetry version -s))
+	${SED_INPLACE} "s/${OLD_VERSION}/${NEW_VERSION}/" ${START_JOB_CHART}/Chart.yaml
 
 build-docker: check-docker-prerequisites
 	docker build -t ${DOCKER_IMAGE_NAME}:test -f Dockerfile ..

--- a/start-job/Makefile
+++ b/start-job/Makefile
@@ -5,6 +5,11 @@ ifndef DOCKER_IMAGE_NAME
 	$(error DOCKER_IMAGE_NAME is not set)
 endif
 
+patch-chart:
+    $(eval OLD_VERSION=$(shell helm show chart ${START_JOB_CHART} | grep '^appVersion:' | awk '{print $2}'))
+	$(eval NEW_VERSION=$(shell cd ../workers; poetry version -s))
+	${SED_INPLACE} 's/${OLD_VERSION}/${NEW_VERSION}/' ${START_JOB_CHART}/Chart.yaml
+
 build-docker: check-docker-prerequisites
 	docker build -t ${DOCKER_IMAGE_NAME}:test -f Dockerfile ..
 

--- a/start-job/Makefile
+++ b/start-job/Makefile
@@ -1,5 +1,15 @@
 START_JOB_CHART=../infrastructure/charts/start-job
 
+## Define `sed` command depending on operating system.
+
+ifeq ($(shell uname), Darwin)
+	# macOS
+	SED_INPLACE=sed -i '' -e
+else
+	# otherwise assume GNU sed
+	SED_INPLACE=sed -i -e
+endif
+
 check-docker-prerequisites:
 ifndef DOCKER_IMAGE_NAME
 	$(error DOCKER_IMAGE_NAME is not set)
@@ -8,10 +18,10 @@ endif
 patch-version: patch-chart
 
 patch-chart:
-    # we do not have a poetry env for start-job so we use the workers env to retrieve NEW_VERSION
+    # we do not have a poetry env for start-job so we use the core env to retrieve NEW_VERSION
 	$(eval OLD_VERSION=$(shell helm show chart ${START_JOB_CHART} | grep '^appVersion:' | awk '{print $$2}'))
 	$(eval NEW_VERSION=$(shell cd ../core; poetry version -s))
-	${SED_INPLACE} "s/${OLD_VERSION}/${NEW_VERSION}/" ${START_JOB_CHART}/Chart.yaml
+	${SED_INPLACE} 's/${OLD_VERSION}/${NEW_VERSION}/' ${START_JOB_CHART}/Chart.yaml
 
 build-docker: check-docker-prerequisites
 	docker build -t ${DOCKER_IMAGE_NAME}:test -f Dockerfile ..


### PR DESCRIPTION
The appVersions were not updated accordingly, as they were not initialized correctly when the packages were created. Thus we were using old tags to retrieve the docker images from github, as the image tag uses by default the chart appVersion.

This PR sets all appVersion to our current version (0.2.13) and modifies the global and local Makefiles in order to increment the chart appVersion whenever we increment the poetry version aka bump a new version.

P.S.: I have not yet tested the deployment with all the new versions...